### PR TITLE
Feature new NUOPC connector options

### DIFF
--- a/src/Infrastructure/ArrayBundle/include/ESMCI_ArrayBundle.h
+++ b/src/Infrastructure/ArrayBundle/include/ESMCI_ArrayBundle.h
@@ -151,7 +151,7 @@ class ArrayBundle : public ESMC_Base {    // inherits from ESMC_Base class
       InterArray<int> *srcTermProcessing=NULL);
     static int sparseMatMul(ArrayBundle *srcArraybundle,
       ArrayBundle *dstArraybundle, RouteHandle **routehandle,
-      ESMC_Region_Flag zeroflag=ESMC_REGION_TOTAL,
+      ESMC_Region_Flag *zeroregionflag=NULL, int zeroregionflag_len=0,
       ESMC_TermOrder_Flag *termorderflag=NULL, int termorderflag_len=0,
       bool checkflag=false, bool haloFlag=false);  
     static int sparseMatMulRelease(RouteHandle *routehandle);

--- a/src/Infrastructure/ArrayBundle/interface/ESMCI_ArrayBundle_F.C
+++ b/src/Infrastructure/ArrayBundle/interface/ESMCI_ArrayBundle_F.C
@@ -697,8 +697,9 @@ extern "C" {
 
   void FTN_X(c_esmc_arraybundlesmm)(ESMCI::ArrayBundle **srcArraybundle,
     ESMCI::ArrayBundle **dstArraybundle, ESMCI::RouteHandle **routehandle,
-    ESMC_Region_Flag *zeroflag, ESMC_TermOrder_Flag *termorderflag,
-    int *termorderflag_len, ESMC_Logical *checkflag, int *rc){
+    ESMC_Region_Flag *zeroregionflag, int *zeroregionflag_len,
+    ESMC_TermOrder_Flag *termorderflag, int *termorderflag_len,
+    ESMC_Logical *checkflag, int *rc){
 #undef  ESMC_METHOD
 #define ESMC_METHOD "c_esmc_arraybundlesmm()"
     // Initialize return code; assume routine not implemented
@@ -709,8 +710,8 @@ extern "C" {
       if (*checkflag == ESMF_TRUE) checkflagOpt = true;
     // Call into the actual C++ method wrapped inside LogErr handling
     ESMC_LogDefault.MsgFoundError(ESMCI::ArrayBundle::sparseMatMul(
-      *srcArraybundle, *dstArraybundle, routehandle, *zeroflag, 
-      termorderflag, *termorderflag_len, checkflagOpt),
+      *srcArraybundle, *dstArraybundle, routehandle, zeroregionflag,
+      *zeroregionflag_len, termorderflag, *termorderflag_len, checkflagOpt),
       ESMCI_ERR_PASSTHRU, ESMC_CONTEXT,
       ESMC_NOT_PRESENT_FILTER(rc));
   }

--- a/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
+++ b/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
@@ -2616,7 +2616,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     type(ESMF_ArrayBundle)    :: opt_dstArrayBundle ! helper variable
     type(ESMF_Region_Flag)    :: opt_zeroregion     ! helper variable
     type(ESMF_Logical)        :: opt_checkflag      ! helper variable
-    integer                   :: len                ! helper variable
+    integer                   :: zeroRegionFlag_len ! helper variable
+    integer                   :: termOrderFlag_len  ! helper variable
     
     ! initialize return code; assume routine not implemented
     localrc = ESMF_RC_NOT_IMPL
@@ -2647,19 +2648,22 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     opt_checkflag = ESMF_FALSE
     if (present(checkflag)) opt_checkflag = checkflag
     
+    zeroRegionFlag_len = 1
+    
     if (present(termorderflag)) then
-      len = size(termorderflag)
+      termOrderFlag_len = size(termorderflag)
       ! Call into the C++ interface, which will sort out optional arguments
       call c_ESMC_ArrayBundleSMM(opt_srcArrayBundle, opt_dstArrayBundle,&
-        routehandle, opt_zeroregion, termorderflag, len, opt_checkflag, &
-        localrc)
+        routehandle, opt_zeroregion, zeroRegionFlag_len, termorderflag, &
+        termOrderFlag_len, opt_checkflag, localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
     else
-      len = 0
+      termOrderFlag_len = 0
       ! Call into the C++ interface, which will sort out optional arguments
       call c_ESMC_ArrayBundleSMM(opt_srcArrayBundle, opt_dstArrayBundle,&
-        routehandle, opt_zeroregion, len, len, opt_checkflag, localrc)
+        routehandle, opt_zeroregion, zeroRegionFlag_len, termOrderFlag_len, &
+        termOrderFlag_len, opt_checkflag, localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
     endif

--- a/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
+++ b/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
@@ -773,8 +773,9 @@ int ArrayBundle::halo(
   int rc = ESMC_RC_NOT_IMPL;              // final return code
   
   // implemented via sparseMatMul
+  ESMC_Region_Flag zeroregionflag = ESMC_REGION_SELECT;
   localrc = sparseMatMul(arraybundle, arraybundle, routehandle,
-    ESMC_REGION_SELECT, NULL, 0, checkflag, true);
+    &zeroregionflag, 1, NULL, 0, checkflag, true);
   if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU, ESMC_CONTEXT,
     &rc)) return rc;
   
@@ -1059,8 +1060,9 @@ int ArrayBundle::redist(
   int rc = ESMC_RC_NOT_IMPL;              // final return code
   
   // implemented via sparseMatMul
+  ESMC_Region_Flag zeroregionflag = ESMC_REGION_SELECT;
   localrc = sparseMatMul(srcArraybundle, dstArraybundle, routehandle,
-    ESMC_REGION_SELECT, NULL, 0, checkflag);
+    &zeroregionflag, 1, NULL, 0, checkflag);
   if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU, ESMC_CONTEXT,
     &rc)) return rc;
   
@@ -1335,7 +1337,7 @@ int ArrayBundle::sparseMatMulStore(
 }
 //-----------------------------------------------------------------------------
     
-    //-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 #undef  ESMC_METHOD
 #define ESMC_METHOD "ESMCI::ArrayBundle::sparseMatMul()"
 //BOPI
@@ -1352,12 +1354,13 @@ int ArrayBundle::sparseMatMul(
   ArrayBundle *srcArraybundle,          // in    - source ArrayBundle
   ArrayBundle *dstArraybundle,          // inout - destination ArrayBundle
   RouteHandle **routehandle,            // inout - handle to precomputed comm
-  ESMC_Region_Flag zeroflag,            // in    - ESMC_REGION_TOTAL:
+  ESMC_Region_Flag *zeroregionflag,     // in    - ESMC_REGION_TOTAL:
                                         //          -> zero out total region
                                         //         ESMC_REGION_SELECT:
                                         //          -> zero out target points
                                         //         ESMC_REGION_EMPTY:
                                         //          -> don't zero out any points
+  int zeroregionflag_len,               //       - elements in zeroregionflag
   ESMC_TermOrder_Flag *termorderflag,   // in    - ESMC_TERMORDER_FREE
                                         //         -> free partial sum order
                                         //       - ESMC_TERMORDER_SRCPET
@@ -1391,13 +1394,35 @@ int ArrayBundle::sparseMatMul(
     srcArraybundle->getVector(srcArrayVector, ESMC_ITEMORDER_ADDORDER);
     dstArraybundle->getVector(dstArrayVector, ESMC_ITEMORDER_ADDORDER);
     
-    // prepare termOrders vector
+    // prepare zeroRegion and termOrders vector
+    vector<ESMC_Region_Flag> zeroRegion;
     vector<ESMC_TermOrder_Flag> termOrders;
     int count=0;  // reset
     if (srcArraybundle != NULL){
       count = srcArraybundle->getCount();
     }else if (dstArraybundle != NULL){
       count = dstArraybundle->getCount();
+    }
+    if (zeroregionflag_len == 0 || zeroregionflag == NULL){
+      // set the default for all Array pairs
+      for (int i=0; i<count; i++)
+        zeroRegion.push_back(ESMC_REGION_TOTAL);
+    }else{
+      if (zeroregionflag_len == 1){
+        // set the single provided order for all Array pairs
+        for (int i=0; i<count; i++)
+          zeroRegion.push_back(*zeroregionflag);
+      }else if(zeroregionflag_len == count){
+        // copy the provided entries over
+        for (int i=0; i<count; i++)
+          zeroRegion.push_back(zeroregionflag[i]);
+      }else{
+        // inconsistency detected
+        ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_INCOMP,
+          "incorrect number of elements provided in the zeroregionflag.", 
+          ESMC_CONTEXT, &rc);
+        return rc;  // bail out
+      }
     }
     if (termorderflag_len == 0 || termorderflag == NULL){
       // set the default for all Array pairs
@@ -1435,7 +1460,7 @@ int ArrayBundle::sparseMatMul(
           srcArray = srcArrayVector[i];
           dstArray = dstArrayVector[i];
           localrc = Array::sparseMatMul(srcArray, dstArray, routehandle,
-            ESMF_COMM_BLOCKING, NULL, NULL, zeroflag, termOrders[i],
+            ESMF_COMM_BLOCKING, NULL, NULL, zeroRegion[i], termOrders[i],
             checkflag, haloFlag);
           if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU,
             ESMC_CONTEXT, &rc)) return rc;
@@ -1444,7 +1469,7 @@ int ArrayBundle::sparseMatMul(
         for (int i=0; i<srcArraybundle->getCount(); i++){
           srcArray = srcArrayVector[i];
           localrc = Array::sparseMatMul(srcArray, dstArray, routehandle,
-            ESMF_COMM_BLOCKING, NULL, NULL, zeroflag, termOrders[i],
+            ESMF_COMM_BLOCKING, NULL, NULL, zeroRegion[i], termOrders[i],
             checkflag, haloFlag);
           if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU,
             ESMC_CONTEXT, &rc)) return rc;
@@ -1453,7 +1478,7 @@ int ArrayBundle::sparseMatMul(
         for (int i=0; i<dstArraybundle->getCount(); i++){
           dstArray = dstArrayVector[i];
           localrc = Array::sparseMatMul(srcArray, dstArray, routehandle,
-            ESMF_COMM_BLOCKING, NULL, NULL, zeroflag, termOrders[i],
+            ESMF_COMM_BLOCKING, NULL, NULL, zeroRegion[i], termOrders[i],
             checkflag, haloFlag);
           if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU,
             ESMC_CONTEXT, &rc)) return rc;
@@ -1592,9 +1617,9 @@ int ArrayBundle::sparseMatMul(
 #endif
         }
       }
-      if (zeroflag!=ESMC_REGION_TOTAL)
+      if (zeroRegion[0]!=ESMC_REGION_TOTAL)
         filterBitField |= XXE::filterBitRegionTotalZero;  // filter reg. total zero
-      if (zeroflag!=ESMC_REGION_SELECT)
+      if (zeroRegion[0]!=ESMC_REGION_SELECT)
         filterBitField |= XXE::filterBitRegionSelectZero; // filter reg. select zero
       // execute XXE stream
       localrc = xxe->exec(rraCount, &(rraList[0]), &(vectorLength[0]), 

--- a/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
+++ b/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
@@ -5120,17 +5120,20 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !
 ! !INTERFACE:
   subroutine ESMF_FieldBundleSMM(srcFieldBundle, dstFieldBundle, &
-        routehandle, keywordEnforcer, zeroregion, termorderflag, checkflag, rc)
+    routehandle, keywordEnforcer, &
+    zeroregion, & ! DEPRECATED ARGUMENT
+    zeroregionflag, termorderflag, checkflag, rc)
 !
 ! !ARGUMENTS:
-        type(ESMF_FieldBundle), intent(in),    optional  :: srcFieldBundle
-        type(ESMF_FieldBundle), intent(inout), optional  :: dstFieldBundle
-        type(ESMF_RouteHandle), intent(inout)            :: routehandle
+    type(ESMF_FieldBundle),    intent(in),         optional :: srcFieldBundle
+    type(ESMF_FieldBundle),    intent(inout),      optional :: dstFieldBundle
+    type(ESMF_RouteHandle),    intent(inout)                :: routehandle
 type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
-        type(ESMF_Region_Flag), intent(in),    optional  :: zeroregion
-        type(ESMF_TermOrder_Flag), intent(in), optional  :: termorderflag(:)
-        logical,                intent(in),    optional  :: checkflag
-        integer,                intent(out),   optional  :: rc
+    type(ESMF_Region_Flag),    intent(in), optional  :: zeroregion ! DEPRECATED ARGUMENT
+    type(ESMF_Region_Flag),    intent(in), target, optional :: zeroregionflag(:)
+    type(ESMF_TermOrder_Flag), intent(in),         optional :: termorderflag(:)
+    logical,                   intent(in),         optional :: checkflag
+    integer,                   intent(out),        optional :: rc
 !
 ! !STATUS:
 ! \begin{itemize}
@@ -5140,6 +5143,9 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 ! \item[7.0.0] Added argument {\tt termorderflag}.
 !              The new argument gives the user control over the order in which
 !              the src terms are summed up.
+! \item[8.1.0] Added argument {\tt zeroregionflag}, and deprecated
+!              {\tt zeroregion}. The new argument allows greater flexibility
+!              in setting the zero region for individual ArrayBundle members.
 ! \end{description}
 ! \end{itemize}
 !
@@ -5179,18 +5185,32 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !     {\tt ESMF\_FieldBundle} with destination data.
 !   \item [routehandle]
 !     Handle to the precomputed Route.
-!   \item [{[zeroregion]}]
-!     If set to {\tt ESMF\_REGION\_TOTAL} {\em (default)} the total regions of
-!     all DEs in {\tt dstFieldBundle} will be initialized to zero before updating the 
-!     elements with the results of the sparse matrix multiplication. If set to
-!     {\tt ESMF\_REGION\_EMPTY} the elements in {\tt dstFieldBundle} will not be
-!     modified prior to the sparse matrix multiplication and results will be
-!     added to the incoming element values. Setting {\tt zeroregion} to 
-!
-!     {\tt ESMF\_REGION\_SELECT} will only zero out those elements in the 
-!     destination FieldBundle that will be updated by the sparse matrix
-!     multiplication. See section \ref{const:region} for a complete list of
-!     valid settings.
+!   \item [{[zeroregion]}] 
+!     If set to {\tt ESMF\_REGION\_TOTAL} {\em (default)} the total regions of 
+!     all DEs in all Fields in {\tt dstFieldBundle} will be initialized to zero 
+!     before updating the elements with the results of the sparse matrix 
+!     multiplication. If set to {\tt ESMF\_REGION\_EMPTY} the elements in the
+!     Fields in {\tt dstFieldBundle} will not be modified prior to the sparse
+!     matrix multiplication and results will be added to the incoming element
+!     values. Setting {\tt zeroregion} to {\tt ESMF\_REGION\_SELECT} will only
+!     zero out those elements in the destination Fields that will be updated
+!     by the sparse matrix multiplication. See section \ref{const:region}
+!   \item [{[zeroregionflag]}] 
+!     If set to {\tt ESMF\_REGION\_TOTAL} {\em (default)} the total regions of 
+!     all DEs in the destination Field will be initialized to zero 
+!     before updating the elements with the results of the sparse matrix 
+!     multiplication. If set to {\tt ESMF\_REGION\_EMPTY} the elements in the
+!     destination Field will not be modified prior to the sparse
+!     matrix multiplication and results will be added to the incoming element
+!     values. A setting of {\tt ESMF\_REGION\_SELECT} will only
+!     zero out those elements in the destination Field that will be updated
+!     by the sparse matrix multiplication. See section \ref{const:region}
+!     for a complete list of valid settings.
+!     The size of this array argument must either be 1 or equal the number of
+!     Fields in the {\tt srcFieldBundle} and {\tt dstFieldBundle} arguments. In
+!     the latter case, the zero region for each Field SMM operation is
+!     indicated separately. If only one zero region element is specified, it is
+!     used for {\em all} Field pairs.
 !   \item [{[termorderflag]}]
 !     Specifies the order of the source side terms in all of the destination
 !     sums. The {\tt termorderflag} only affects the order of terms during 
@@ -5219,10 +5239,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
         integer                 :: localrc      ! local return code
         
-        ! local variables to buffer optional arguments
-        type(ESMF_Region_Flag)   :: l_zeroregion
-        logical                 :: l_checkflag! helper variable
-
         ! local internal variables
         logical                 :: src_bundle
         logical                 :: dst_bundle
@@ -5237,12 +5253,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
         ! Check init status of arguments, deal with optional FieldBundle args
         ESMF_INIT_CHECK_DEEP_SHORT(ESMF_RouteHandleGetInit, routehandle, rc)
-
-        ! Set default flags
-        l_checkflag = ESMF_FALSE
-        if (present(checkflag)) l_checkflag = checkflag
-        l_zeroregion = ESMF_REGION_TOTAL
-        if (present(zeroregion)) l_zeroregion = zeroregion
 
         src_bundle = .true.
         if (present(srcFieldBundle)) then
@@ -5265,28 +5275,28 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ! perform FieldBundle SMM
         if(src_bundle .and. dst_bundle) then
           call ESMF_ArrayBundleSMM(srcab, dstab, routehandle, &
-            zeroregion=l_zeroregion, termorderflag=termorderflag, &
-            checkflag=l_checkflag, rc=localrc)
+            zeroregion=zeroregion, zeroregionflag=zeroregionflag, &
+            termorderflag=termorderflag, checkflag=checkflag, rc=localrc)
           if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
             ESMF_CONTEXT, rcToReturn=rc)) return
         else if(src_bundle .and. .not. dst_bundle) then
           call ESMF_ArrayBundleSMM(srcArrayBundle=srcab, &
             routehandle=routehandle, &
-            zeroregion=l_zeroregion, termorderflag=termorderflag, &
-            checkflag=l_checkflag, rc=localrc)
+            zeroregion=zeroregion, zeroregionflag=zeroregionflag, &
+            termorderflag=termorderflag, checkflag=checkflag, rc=localrc)
           if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
             ESMF_CONTEXT, rcToReturn=rc)) return
         else if(.not. src_bundle .and. dst_bundle) then
           call ESMF_ArrayBundleSMM(dstArrayBundle=dstab, &
             routehandle=routehandle, &
-            zeroregion=l_zeroregion, termorderflag=termorderflag, &
-            checkflag=l_checkflag, rc=localrc)
+            zeroregion=zeroregion, zeroregionflag=zeroregionflag, &
+            termorderflag=termorderflag, checkflag=checkflag, rc=localrc)
           if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
             ESMF_CONTEXT, rcToReturn=rc)) return
         else if(.not. src_bundle .and. .not. dst_bundle) then
           call ESMF_ArrayBundleSMM(routehandle=routehandle, &
-            zeroregion=l_zeroregion, termorderflag=termorderflag, &
-            checkflag=l_checkflag, rc=localrc)
+            zeroregion=zeroregion, zeroregionflag=zeroregionflag, &
+            termorderflag=termorderflag, checkflag=checkflag, rc=localrc)
           if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
             ESMF_CONTEXT, rcToReturn=rc)) return
         endif

--- a/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
+++ b/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
@@ -29,7 +29,7 @@ OptionName and the value strings are case insensitive. There are single and mult
      {\tt dumpWeights} & Enable or disable dumping of the interpolation weights into a file. & single & {\tt true}, {\tt false}(default)\\ \hline
      {\tt extrapDistExponent} & The exponent to raise the distance to when calculating weights for the nearest\_idavg extrapolation method. & single & real(default 2.0)\\ \hline
      {\tt extrapMethod} & Fill in points not mapped by the regrid method. & single & {\tt none}(default), {\tt nearest\_idavg}, {\tt nearest\_stod}, {\tt creep}\\ \hline
-     {\tt extrapNumLevels} & The number of levels to output for the extrapolation methods that fill levels. & single & integer(default 1)\\ \hline
+     {\tt extrapNumLevels} & The number of levels to output for the extrapolation methods that fill levels. When a method is used that requires this, then an error will be returned, if it is not specified. & single & integer\\ \hline
      {\tt extrapNumSrcPnts} & The number of source points to use for the extrapolation methods that use more than one source point. & single & integer(default 8)\\ \hline
      {\tt ignoreDegenerate} & Ignore degenerate cells when checking the input Grids or Meshes for errors. & single & {\tt true}, {\tt false}(default)\\ \hline
      {\tt pipelineDepth} & Maximum number of outstanding non-blocking communication calls during the parallel interpolation. Only relevant for cases where the automatic tuning procedure fails to find a setting that works well on a given hardware. & single & integer\\ \hline

--- a/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
+++ b/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
@@ -25,15 +25,21 @@ OptionName and the value strings are case insensitive. There are single and mult
      \hline\hline
      {\bf OptionName} & {\bf Definition} & {\bf Type} & {\bf Values}\\
      \hline\hline
-     {\tt srcMaskValues} & List of integer values that defines the mask values. & multi & List of integers.\\ \hline
      {\tt dstMaskValues} & List of integer values that defines the mask values. & multi & List of integers.\\ \hline
-     {\tt remapmethod} & Redistribution or interpolation to compute the regridding weights.& single & {\tt redist}, {\tt bilinear}(default), {\tt patch}, {\tt nearest\_stod}, {\tt nearest\_dtos}, {\tt conserve}\\ \hline
-     {\tt polemethod} & Extrapolation method around the pole(s).& single & {\tt none}(default), {\tt allavg}, {\tt npntavg}={\em "integer indicating number of points"}\\ \hline
-     {\tt unmappedaction} & The action to take when unmapped destination elements are encountered.& single & {\tt ignore}(default), {\tt error}\\ \hline
+     {\tt dumpWeights} & Enable or disable dumping of the interpolation weights into a file. & single & {\tt true}, {\tt false}(default)\\ \hline
+     {\tt extrapDistExponent} & The exponent to raise the distance to when calculating weights for the nearest\_idavg extrapolation method. & single & real(default 2.0)\\ \hline
+     {\tt extrapMethod} & Fill in points not mapped by the regrid method. & single & {\tt none}(default), {\tt nearest\_idavg}, {\tt nearest\_stod}, {\tt creep}\\ \hline
+     {\tt extrapNumLevels} & The number of levels to output for the extrapolation methods that fill levels. & single & integer(default 1)\\ \hline
+     {\tt extrapNumSrcPnts} & The number of source points to use for the extrapolation methods that use more than one source point. & single & integer(default 8)\\ \hline
+     {\tt ignoreDegenerate} & Ignore degenerate cells when checking the input Grids or Meshes for errors. & single & {\tt true}, {\tt false}(default)\\ \hline
+     {\tt pipelineDepth} & Maximum number of outstanding non-blocking communication calls during the parallel interpolation. Only relevant for cases where the automatic tuning procedure fails to find a setting that works well on a given hardware. & single & integer\\ \hline
+     {\tt poleMethod} & Extrapolation method around the pole(s). & single & {\tt none}(default), {\tt allavg}, {\tt npntavg}={\em "integer indicating number of points"}\\ \hline
+     {\tt remapMethod} & Redistribution or interpolation to compute the regridding weights. & single & {\tt redist}, {\tt bilinear}(default), {\tt patch}, {\tt nearest\_stod}, {\tt nearest\_dtos}, {\tt conserve}\\ \hline
+     {\tt srcMaskValues} & List of integer values that defines the mask values. & multi & List of integers.\\ \hline
      {\tt srcTermProcessing} & Number of terms in each partial sum of the interpolation to process on the source side. This setting impacts the bit-for-bit reproducibility of the parallel interpolation results between runs. The strictest bit-for-bit setting is achieved by setting the value to 1. & single & integer\\ \hline
      {\tt termOrder} & Order of the terms in each partial sum of the interpolation. This setting impacts the bit-for-bit reproducibility of the parallel interpolation results between runs. The strictest bit-for-bit setting is achieved by setting the value to {\tt srcseq}. & single & {\tt free}(default), {\tt srcseq}, {\tt srcpet}\\ \hline
-     {\tt pipelineDepth} & Maximum number of outstanding non-blocking communication calls during the parallel interpolation. Only relevant for cases where the automatic tuning procedure fails to find a setting that works well on a given hardware. & single & integer\\ \hline
-     {\tt dumpWeights} & Enable or disable dumping of the interpolation weights into a file. & single & {\tt true}, {\tt false}(default)\\ \hline
+     {\tt unmappedAction} & The action to take when unmapped destination elements are encountered. & single & {\tt ignore}(default), {\tt error}\\ \hline
+     {\tt zeroRegion} & The region of destination elements set to zero before adding the result of the sparse matrix multiplication. The available options support total, selective, or no zeroing of destination elements. & single & {\tt total}(default), {\tt select}, {\tt empty}\\ \hline
      \hline
 \end{tabular}
 

--- a/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
+++ b/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
@@ -21,7 +21,7 @@ OptionName=value1[=spec1][,value2[=spec2][, ...]]
 
 OptionName and the value strings are case insensitive. There are single and multi-valued options as indicated in the table below. For single valued options only {\tt value1} is relevant. If the same option is listed multiple times, only the first occurrence will be used. If an option has a default value, it is indicated in the table. If a value requires additional specification via {\tt =spec} then the specifications are listed in the table.
 
-\begin{tabular}{|p{4cm}|p{5cm}|p{1cm}|p{35mm}|}
+\begin{longtable}{|p{4cm}|p{5cm}|p{1cm}|p{35mm}|}
      \hline\hline
      {\bf OptionName} & {\bf Definition} & {\bf Type} & {\bf Values}\\
      \hline\hline
@@ -41,5 +41,5 @@ OptionName and the value strings are case insensitive. There are single and mult
      {\tt unmappedAction} & The action to take when unmapped destination elements are encountered. & single & {\tt ignore}(default), {\tt error}\\ \hline
      {\tt zeroRegion} & The region of destination elements set to zero before adding the result of the sparse matrix multiplication. The available options support total, selective, or no zeroing of destination elements. & single & {\tt total}(default), {\tt select}, {\tt empty}\\ \hline
      \hline
-\end{tabular}
+\end{longtable}
 

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -6260,6 +6260,7 @@ print *, "found match:"// &
     integer                         :: extrapNumSrcPnts
     real                            :: extrapDistExponent
     integer                         :: extrapNumLevels
+    logical                         :: extrapNumLevelsINC
     logical                         :: ignoreDegenerate
     type(ESMF_PoleMethod_Flag)      :: polemethod
     integer                         :: regridPoleNPnts
@@ -6661,6 +6662,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
         extrapNumSrcPnts = 8 ! default
         extrapDistExponent = 2.0 ! default
         extrapNumLevels = 1 ! default
+        extrapNumLevelsINC = .true. ! user value not found
         do j=2, size(chopStringList)
           if (index(chopStringList(j),"extrapnumsrcpnts=")==1) then
             call NUOPC_ChopString(chopStringList(j), chopChar="=", &
@@ -6703,9 +6705,16 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
                 line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
             endif
             deallocate(chopSubString) ! local garbage collection
+            extrapNumLevelsINC = .false.
             exit ! skip the rest of the loop after first hit
           endif
         enddo
+        if ((extrapMethod.eq.ESMF_EXTRAPMETHOD_CREEP) .and. extrapNumLevelsINC) then
+          call ESMF_LogSetError(ESMF_RC_ARG_INCOMP, &
+            msg="User must set extrapNumLevels when extrapMethod=ESMF_EXTRAPMETHOD_CREEP!", &
+            line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)
+          return  ! bail out
+        endif
       endif
 
       ! determine "ignoreDegenerate"

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -6478,7 +6478,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to TOTAL for: '", &
+                "' is not a valid choice. Defaulting to TOTAL for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif
@@ -6506,7 +6506,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to FREE for: '", &
+                "' is not a valid choice. Defaulting to FREE for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif
@@ -6595,7 +6595,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to BILINEAR for: '", &
+                "' is not a valid choice. Defaulting to BILINEAR for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif
@@ -6621,7 +6621,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
         cycle ! advance to the next field pair, handle Redist further down
       endif
 
-      ! only Regid field pairs will proceed here...
+      ! only Regrid field pairs will proceed here...
       iRegrid = iRegrid+1
       zeroRegions(iRegrid) = zeroRegion ! record in the list used by Run
       termOrders(iRegrid) = termOrder ! record in the list used by Run
@@ -6649,7 +6649,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to NONE for: '", &
+                "' is not a valid choice. Defaulting to NONE for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif
@@ -6741,7 +6741,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to FALSE for: '", &
+                "' is not a valid choice. Defaulting to FALSE for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif
@@ -6783,7 +6783,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to NONE for: '", &
+                "' is not a valid choice. Defaulting to NONE for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif
@@ -6809,7 +6809,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to IGNORE for: '", &
+                "' is not a valid choice. Defaulting to IGNORE for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif
@@ -6875,7 +6875,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
             else
               write (msgString,*) "Specified option '", &
                 trim(chopStringList(j)), &
-                "' is not a vailid choice. Defaulting to OFF for: '", &
+                "' is not a valid choice. Defaulting to OFF for: '", &
                 trim(chopStringList(1)), "'"
               call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
             endif

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -62,6 +62,7 @@ module NUOPC_Connector
     integer                             :: dstFieldCount
     type(ESMF_RouteHandle)              :: rh
     type(ESMF_State)                    :: state
+    type(ESMF_Region_Flag), pointer     :: zeroRegions(:)
     type(ESMF_TermOrder_Flag), pointer  :: termOrders(:)
   end type
 
@@ -74,6 +75,7 @@ module NUOPC_Connector
     integer                             :: dstFieldCount    
     type(ESMF_RouteHandle)              :: rh
     type(ESMF_State)                    :: state
+    type(ESMF_Region_Flag), pointer     :: zeroRegions(:)
     type(ESMF_TermOrder_Flag), pointer  :: termOrders(:)
     type(type_UpdatePacket), pointer    :: updatePackets
     integer                             :: cplSetCount
@@ -1685,6 +1687,7 @@ module NUOPC_Connector
       line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
 
     ! clean starting condition for pointer member inside internal state
+    nullify(is%wrap%zeroRegions)
     nullify(is%wrap%termOrders)
 
     ! re-reconcile the States because they may have changed
@@ -1768,7 +1771,8 @@ module NUOPC_Connector
 
     ! clean starting condition for pointer member inside internal state   
     do i=1, is%wrap%cplSetCount
-      nullify(is%wrap%cplSet(i)%termOrders) 
+      nullify(is%wrap%cplSet(i)%zeroRegions)
+      nullify(is%wrap%cplSet(i)%termOrders)
     enddo
     
     ! prepare chopStringList
@@ -4874,14 +4878,18 @@ call ESMF_PointerLog(meshListE%keyMesh%this, &
             is%wrap%cplSet(i)%dstFields, &
             cplList=cplSetListTemp(i)%cplList(1:cplSetListTemp(i)%j-1), &
             rh=is%wrap%cplSet(i)%rh, &
-            termOrders=is%wrap%cplSet(i)%termOrders, name=name, rc=rc)
+            zeroRegions=is%wrap%cplSet(i)%zeroRegions, &
+            termOrders=is%wrap%cplSet(i)%termOrders, &
+            name=name, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
         enddo
       else
         call FieldBundleCplStore(is%wrap%srcFields, is%wrap%dstFields, &
           cplList=cplListTemp(1:j-1), rh=is%wrap%rh, &
-          termOrders=is%wrap%termOrders, name=name, rc=rc)
+          zeroRegions=is%wrap%zeroRegions, &
+          termOrders=is%wrap%termOrders, &
+          name=name, rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
       endif
@@ -5636,7 +5644,9 @@ call ESMF_PointerLog(meshListE%keyMesh%this, &
             call ESMF_FieldBundleSMM(is%wrap%cplSet(i)%srcFields, &
               is%wrap%cplSet(i)%dstFields, &
               routehandle=is%wrap%cplSet(i)%rh, &
-              termorderflag=is%wrap%cplSet(i)%termOrders, rc=rc)
+              zeroregionflag=is%wrap%cplSet(i)%zeroRegions, &
+              termorderflag=is%wrap%cplSet(i)%termOrders, &
+              rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
               line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
           endif
@@ -5647,7 +5657,8 @@ call ESMF_PointerLog(meshListE%keyMesh%this, &
           line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
         if (routeHandleIsCreated) then
           call ESMF_FieldBundleSMM(is%wrap%srcFields, is%wrap%dstFields, &
-            routehandle=is%wrap%rh, termorderflag=is%wrap%termOrders, rc=rc)
+            routehandle=is%wrap%rh, zeroregionflag=is%wrap%zeroRegions, &
+            termorderflag=is%wrap%termOrders, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
         endif
@@ -5879,6 +5890,13 @@ call ESMF_PointerLog(meshListE%keyMesh%this, &
         noGarbage=.true., rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
+      if (associated(is%wrap%cplSet(i)%zeroRegions)) then
+        deallocate(is%wrap%cplSet(i)%zeroRegions, stat=stat)
+        if (ESMF_LogFoundDeallocError(statusToCheck=stat, &
+          msg="Deallocation of zeroRegions list.", &
+          line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) &
+          return  ! bail out
+      endif
       if (associated(is%wrap%cplSet(i)%termOrders)) then
         deallocate(is%wrap%cplSet(i)%termOrders, stat=stat)
         if (ESMF_LogFoundDeallocError(statusToCheck=stat, &
@@ -5918,6 +5936,13 @@ call ESMF_PointerLog(meshListE%keyMesh%this, &
     call ESMF_StateDestroy(is%wrap%state, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
+    if (associated(is%wrap%zeroRegions)) then
+      deallocate(is%wrap%zeroRegions, stat=stat)
+      if (ESMF_LogFoundDeallocError(statusToCheck=stat, &
+        msg="Deallocation of zeroRegions list.", &
+        line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) &
+        return  ! bail out
+    endif
     if (associated(is%wrap%termOrders)) then
       deallocate(is%wrap%termOrders, stat=stat)
       if (ESMF_LogFoundDeallocError(statusToCheck=stat, &
@@ -6197,8 +6222,8 @@ print *, "found match:"// &
     
   !-----------------------------------------------------------------------------
 
-  subroutine FieldBundleCplStore(srcFB, dstFB, cplList, rh, termOrders, name, &
-    rc)
+  subroutine FieldBundleCplStore(srcFB, dstFB, cplList, rh, zeroRegions, &
+    termOrders, name, rc)
     ! This method will destroy srcFB/dstFB, and replace with newly created FBs.
     ! Order of fields in outgoing srcFB/dstFB may be different from incoming.
     ! Order of elements in termOrders matches those in outgoing srcFB/dstFB.
@@ -6206,6 +6231,7 @@ print *, "found match:"// &
     type(ESMF_FieldBundle),    intent(inout)         :: dstFB
     character(*)                                     :: cplList(:)
     type(ESMF_RouteHandle),    intent(inout)         :: rh
+    type(ESMF_Region_Flag),    pointer               :: zeroRegions(:)
     type(ESMF_TermOrder_Flag), pointer               :: termOrders(:)
     character(*),              intent(in)            :: name
     integer,                   intent(out), optional :: rc
@@ -6224,10 +6250,17 @@ print *, "found match:"// &
     character(ESMF_MAXSTR), pointer :: chopSubString(:), chopSubSubString(:)
     character(len=160)              :: msgString
     character(len=480)              :: tempString
+    type(ESMF_Region_Flag)          :: zeroRegion
+    type(ESMF_Region_Flag), pointer :: zeroRegionsRedist(:)
     type(ESMF_TermOrder_Flag)       :: termOrder
     type(ESMF_TermOrder_Flag), pointer :: termOrdersRedist(:)
     logical                         :: redistflag
     type(ESMF_RegridMethod_Flag)    :: regridmethod
+    type(ESMF_ExtrapMethod_Flag)    :: extrapMethod
+    integer                         :: extrapNumSrcPnts
+    real                            :: extrapDistExponent
+    integer                         :: extrapNumLevels
+    logical                         :: ignoreDegenerate
     type(ESMF_PoleMethod_Flag)      :: polemethod
     integer                         :: regridPoleNPnts
     type(ESMF_UnmappedAction_Flag)  :: unmappedaction
@@ -6262,6 +6295,11 @@ print *, "found match:"// &
       ! remap specific items
       logical                           :: redistflag 
       type(ESMF_RegridMethod_Flag)      :: regridmethod
+      type(ESMF_ExtrapMethod_Flag)      :: extrapMethod
+      integer                           :: extrapNumSrcPnts
+      real                              :: extrapDistExponent
+      integer                           :: extrapNumLevels
+      logical                           :: ignoreDegenerate
       type(ESMF_RouteHandle)            :: rh
       integer(ESMF_KIND_I4), pointer    :: factorIndexList(:,:)
       real(ESMF_KIND_R8), pointer       :: factorList(:)
@@ -6303,7 +6341,27 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
 
     ! if no fields in bundles, bail out
     if (count < 1) return
-    
+
+    ! consistency check the incoming "zeroRegions" argument
+    if (associated(zeroRegions)) then
+      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+        msg="The 'zeroRegions' argument must enter unassociated!", &
+        line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)
+      return  ! bail out
+    endif 
+    ! prepare "zeroRegions" list
+    allocate(zeroRegions(count), stat=stat)
+    if (ESMF_LogFoundAllocError(statusToCheck=stat, &
+      msg="Allocation of zeroRegions.", &
+      line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) &
+      return  ! bail out
+    ! prepare "zeroRegionsRedist" list
+    allocate(zeroRegionsRedist(count), stat=stat)
+    if (ESMF_LogFoundAllocError(statusToCheck=stat, &
+      msg="Allocation of zeroRegionsRedist.", &
+      line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) &
+      return  ! bail out
+
     ! consistency check the incoming "termOrders" argument
     if (associated(termOrders)) then
       call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
@@ -6400,6 +6458,34 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
         chopStringList=chopStringList, rc=localrc)
       if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+
+      ! determine "zeroRegion" which will be used by Run() method
+      zeroRegion = ESMF_REGION_TOTAL ! default
+      do j=2, size(chopStringList)
+        if (index(chopStringList(j),"zeroregion=")==1) then
+          call NUOPC_ChopString(chopStringList(j), chopChar="=", &
+            chopStringList=chopSubString, rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+          if (size(chopSubString)>=2) then
+            if (trim(chopSubString(2))=="total") then
+              zeroRegion = ESMF_REGION_TOTAL
+            else if (trim(chopSubString(2))=="select") then
+              zeroRegion = ESMF_REGION_SELECT
+            else if (trim(chopSubString(2))=="empty") then
+              zeroRegion = ESMF_REGION_EMPTY
+            else
+              write (msgString,*) "Specified option '", &
+                trim(chopStringList(j)), &
+                "' is not a vailid choice. Defaulting to TOTAL for: '", &
+                trim(chopStringList(1)), "'"
+              call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
+            endif
+          endif
+          deallocate(chopSubString) ! local garbage collection
+          exit ! skip the rest of the loop after first hit
+        endif
+      enddo
 
       ! determine "termOrder" which will be used by Run() method
       termOrder = ESMF_TERMORDER_FREE ! default
@@ -6529,13 +6615,132 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
         if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
         iRedist = iRedist+1
+        zeroRegionsRedist(iRedist) = zeroRegion ! record in list to merge below
         termOrdersRedist(iRedist) = termOrder ! record in list to merge below
         cycle ! advance to the next field pair, handle Redist further down
       endif
 
       ! only Regid field pairs will proceed here...
       iRegrid = iRegrid+1
+      zeroRegions(iRegrid) = zeroRegion ! record in the list used by Run
       termOrders(iRegrid) = termOrder ! record in the list used by Run
+
+      ! determine "extrapmethod" and extrapolation settings
+      extrapMethod = ESMF_EXTRAPMETHOD_NONE ! default
+      extrapNumSrcPnts = 0 ! default
+      extrapDistExponent = 0.0 ! default
+      extrapNumLevels = 0 ! default
+      do j=2, size(chopStringList)
+        if (index(chopStringList(j),"extrapmethod=")==1) then
+          call NUOPC_ChopString(chopStringList(j), chopChar="=", &
+            chopStringList=chopSubString, rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+          if (size(chopSubString)>=2) then
+            if (trim(chopSubString(2))=="none") then
+              extrapMethod = ESMF_EXTRAPMETHOD_NONE
+            else if (trim(chopSubString(2))=="nearest_idavg") then
+              extrapMethod = ESMF_EXTRAPMETHOD_NEAREST_IDAVG
+            else if (trim(chopSubString(2))=="nearest_stod") then
+              extrapMethod = ESMF_EXTRAPMETHOD_NEAREST_STOD
+            else if (trim(chopSubString(2))=="creep") then
+              extrapMethod = ESMF_EXTRAPMETHOD_CREEP
+            else
+              write (msgString,*) "Specified option '", &
+                trim(chopStringList(j)), &
+                "' is not a vailid choice. Defaulting to NONE for: '", &
+                trim(chopStringList(1)), "'"
+              call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
+            endif
+          endif
+          deallocate(chopSubString) ! local garbage collection
+          exit ! skip the rest of the loop after first hit
+        endif
+      enddo
+      if (extrapMethod.ne.ESMF_EXTRAPMETHOD_NONE) then
+        extrapNumSrcPnts = 8 ! default
+        extrapDistExponent = 2.0 ! default
+        extrapNumLevels = 1 ! default
+        do j=2, size(chopStringList)
+          if (index(chopStringList(j),"extrapnumsrcpnts=")==1) then
+            call NUOPC_ChopString(chopStringList(j), chopChar="=", &
+              chopStringList=chopSubString, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+            if (size(chopSubString)>=2) then
+              extrapNumSrcPnts = ESMF_UtilString2Int(trim(chopSubString(2)), rc=rc)
+              if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+            endif
+            deallocate(chopSubString) ! local garbage collection
+            exit ! skip the rest of the loop after first hit
+          endif
+        enddo
+        do j=2, size(chopStringList)
+          if (index(chopStringList(j),"extrapdistexponent=")==1) then
+            call NUOPC_ChopString(chopStringList(j), chopChar="=", &
+              chopStringList=chopSubString, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+            if (size(chopSubString)>=2) then
+              extrapDistExponent = ESMF_UtilString2Real(trim(chopSubString(2)), rc=rc)
+              if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+            endif
+            deallocate(chopSubString) ! local garbage collection
+            exit ! skip the rest of the loop after first hit
+          endif
+        enddo
+        do j=2, size(chopStringList)
+          if (index(chopStringList(j),"extrapnumlevels=")==1) then
+            call NUOPC_ChopString(chopStringList(j), chopChar="=", &
+              chopStringList=chopSubString, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+            if (size(chopSubString)>=2) then
+              extrapNumLevels = ESMF_UtilString2Int(trim(chopSubString(2)), rc=rc)
+              if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+            endif
+            deallocate(chopSubString) ! local garbage collection
+            exit ! skip the rest of the loop after first hit
+          endif
+        enddo
+      endif
+
+      ! determine "ignoreDegenerate"
+      ignoreDegenerate = .false. ! default
+      do j=2, size(chopStringList)
+        if (index(chopStringList(j),"ignoredegenerate=")==1) then
+          call NUOPC_ChopString(chopStringList(j), chopChar="=", &
+            chopStringList=chopSubString, rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
+          if (size(chopSubString)>=2) then
+            if (trim(chopSubString(2))=="on") then
+              ignoreDegenerate = .true.
+            else if (trim(chopSubString(2))=="off") then
+              ignoreDegenerate = .false.
+            else if (trim(chopSubString(2))=="yes") then
+              ignoreDegenerate = .true.
+            else if (trim(chopSubString(2))=="no") then
+              ignoreDegenerate = .false.
+            else if (trim(chopSubString(2))=="true") then
+              ignoreDegenerate = .true.
+            else if (trim(chopSubString(2))=="false") then
+              ignoreDegenerate = .false.
+            else
+              write (msgString,*) "Specified option '", &
+                trim(chopStringList(j)), &
+                "' is not a vailid choice. Defaulting to FALSE for: '", &
+                trim(chopStringList(1)), "'"
+              call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_WARNING)
+            endif
+          endif
+          deallocate(chopSubString) ! local garbage collection
+          exit ! skip the rest of the loop after first hit
+        endif
+      enddo
 
       ! add Regrid field pair to the beginning of replacement srcFB and dstFB
       call ESMF_FieldBundleAdd(srcFB, (/srcFields(i)/), multiflag=.true., rc=localrc)
@@ -6812,6 +7017,21 @@ call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
           ! test regridmethod
           rhListMatch = (rhListE%regridmethod==regridmethod)
           if (.not.rhListMatch) goto 123
+          ! test extrapMethod
+          rhListMatch = (rhListE%extrapMethod==extrapMethod)
+          if (.not.rhListMatch) goto 123
+          ! test extrapNumSrcPnts
+          rhListMatch = (rhListE%extrapNumSrcPnts==extrapNumSrcPnts)
+          if (.not.rhListMatch) goto 123
+          ! test extrapDistExponent
+          rhListMatch = (rhListE%extrapDistExponent==extrapDistExponent)
+          if (.not.rhListMatch) goto 123
+          ! test extrapNumLevels
+          rhListMatch = (rhListE%extrapNumLevels==extrapNumLevels)
+          if (.not.rhListMatch) goto 123
+          ! test ignoreDegenerate
+          rhListMatch = (rhListE%ignoreDegenerate.eqv.ignoreDegenerate)
+          if (.not.rhListMatch) goto 123
           ! test srcMaskValues
           rhListMatch = &
             (size(rhListE%srcMaskValues)==size(srcMaskValues))
@@ -6879,7 +7099,10 @@ call ESMF_LogWrite(trim(name)//&
             srcMaskValues=srcMaskValues, dstMaskValues=dstMaskValues, &
             regridmethod=regridmethod, &
             polemethod=polemethod, regridPoleNPnts=regridPoleNPnts, &
-            unmappedaction=unmappedaction, &
+            extrapMethod=extrapMethod, extrapNumSrcPnts=extrapNumSrcPnts, &
+            extrapDistExponent=extrapDistExponent, &
+            extrapNumLevels=extrapNumLevels, &
+            unmappedaction=unmappedaction, ignoreDegenerate=ignoreDegenerate, &
             srcTermProcessing=srcTermProcessing, pipelineDepth=pipelineDepth, &
             routehandle=rhh, &
             factorIndexList=factorIndexList, factorList=factorList, &
@@ -6903,6 +7126,11 @@ call ESMF_LogWrite(trim(name)//&
           rhListE%dstUngriddedUBound=>dstUngriddedUBound
           rhListE%redistflag=redistflag
           rhListE%regridmethod=regridmethod
+          rhListE%extrapMethod=extrapMethod
+          rhListE%extrapNumSrcPnts=extrapNumSrcPnts
+          rhListE%extrapDistExponent=extrapDistExponent
+          rhListE%extrapNumLevels=extrapNumLevels
+          rhListE%ignoreDegenerate=ignoreDegenerate
           rhListE%rh=rhh
           rhListE%factorIndexList=>factorIndexList
           rhListE%factorList=>factorList
@@ -7046,8 +7274,9 @@ call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME, rcToReturn=rc)) return  ! bail out
 
-      ! append termOrdersRedist at the end of termOrders list
+      ! append zeroRegionRedist and termOrdersRedist
       do i=1, count
+        zeroRegions(iRegrid+i) = zeroRegionsRedist(i)
         termOrders(iRegrid+i) = termOrdersRedist(i)
       enddo
 
@@ -7056,6 +7285,7 @@ call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
     endif
 
     ! garbage collection
+    deallocate(zeroRegionsRedist)
     deallocate(termOrdersRedist)
     call ESMF_FieldBundleDestroy(srcFBRedist, noGarbage=.true., rc=localrc)
     if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &


### PR DESCRIPTION
ESMF_FieldBundleSMM now accepts and array of zeroregionflag values. ESMF Reference Doc needs to be updated.

Added new NUOPC connector options, NUOPC Reference Manual Updated
- extrapMethod - defaults to none
- extrapNumSrcPnts - defaults to 8
- extrapDistExponent - defaults to 2.0
- extrapNumLevels - required for ESMF_EXTRAPMETHOD_CREEP
- ignoreDegenerate - default .false.
- zeroRegion - default total

A new NUOPC prototype has been added
[https://sourceforge.net/p/esmfcontrib/svn/HEAD/tree/NUOPC/trunk/AtmOcnConOptsProto/](https://sourceforge.net/p/esmfcontrib/svn/HEAD/tree/NUOPC/trunk/AtmOcnConOptsProto/)