### PR TITLE
Feature/tclune/abstract state item

### DIFF
--- a/src/Superstructure/ESMFMod/src/ESMF.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF.F90
@@ -92,6 +92,7 @@ module ESMF
     use ESMF_MeshMod
 
     use ESMF_StateTypesMod
+    use ESMF_AbstractStateItemMod
     use ESMF_StateVaMod
     use ESMF_StateMod
     use ESMF_StateReconcileMod

--- a/src/Superstructure/State/src/ESMF_AbstractStateItem.F90
+++ b/src/Superstructure/State/src/ESMF_AbstractStateItem.F90
@@ -37,17 +37,9 @@ module ESMF_AbstractStateItemMod
    type :: ESMF_AbstractStateItem
       sequence
       character(ESMF_MAXSTR) :: name
-      type(ESMF_AbstractItemWrapper) :: wrapper
+      logical :: isInit = .false.
+      type(ESMF_AbstractItemWrapper), pointer :: wrapper
    end type ESMF_AbstractStateItem
-
-!!$   interface ESMF_StateAdd
-!!$      module procedure ESMF_StateAddAbstractItem_
-!!$   end interface ESMF_StateAdd
-!!$
-!!$   interface ESMF_StateGet
-!!$      module procedure ESMF_StateGetAbstractItem_
-!!$   end interface ESMF_StateGet
-
 
 
 #include "ESMF.h"
@@ -93,12 +85,11 @@ contains
 !
 !EOPI
 
-!!$    if (present(si)) then
-!!$      ESMF_AbstractStateItemGetInit = ESMF_INIT_GET(si)
-!!$    else
-!!$      ESMF_AbstractStateItemGetInit = ESMF_INIT_DEFINED
-!!$    endif
+    if (present(si)) then
+      ESMF_AbstractStateItemGetInit = ESMF_INIT_CREATED ! ESMF_INIT_GET(si)
+    else
       ESMF_AbstractStateItemGetInit = ESMF_INIT_DEFINED
+    endif
 
    end function ESMF_AbstractStateItemGetInit
 !------------------------------------------------------------------------------

--- a/src/Superstructure/State/src/ESMF_AbstractStateItem.F90
+++ b/src/Superstructure/State/src/ESMF_AbstractStateItem.F90
@@ -1,11 +1,13 @@
 module ESMF_AbstractStateItemMod
    use ESMF_UtilTypesMod
+   use ESMF_LogErrMod
    implicit none
    private
 
    public :: ESMF_AbstractItem
 
    public :: ESMF_AbstractStateItem
+   public :: AbstractItemWrapper
    public :: ESMF_AbstractItemWrapper
 
    public :: ESMF_AbstractStateItemGetInit
@@ -14,10 +16,15 @@ module ESMF_AbstractStateItemMod
    type, abstract :: ESMF_AbstractItem
    end type ESMF_AbstractItem
 
+   type :: AbstractItemWrapper
+      class(ESMF_AbstractItem), pointer :: item
+   end type AbstractItemWrapper
+
+   
 
    type :: FakeAbstractItem
       sequence
-      integer :: placeholder(2)
+      integer :: placeholder
    end type FakeAbstractItem
    ! This wrapper is intended to just to be the the same size as user
    ! wrappers containing their own pointers to objects of types that
@@ -32,6 +39,14 @@ module ESMF_AbstractStateItemMod
       character(ESMF_MAXSTR) :: name
       type(ESMF_AbstractItemWrapper) :: wrapper
    end type ESMF_AbstractStateItem
+
+!!$   interface ESMF_StateAdd
+!!$      module procedure ESMF_StateAddAbstractItem_
+!!$   end interface ESMF_StateAdd
+!!$
+!!$   interface ESMF_StateGet
+!!$      module procedure ESMF_StateGetAbstractItem_
+!!$   end interface ESMF_StateGet
 
 
 
@@ -88,4 +103,7 @@ contains
    end function ESMF_AbstractStateItemGetInit
 !------------------------------------------------------------------------------
 
+
+
 end module ESMF_AbstractStateItemMod
+

--- a/src/Superstructure/State/src/ESMF_AbstractStateItem.F90
+++ b/src/Superstructure/State/src/ESMF_AbstractStateItem.F90
@@ -1,0 +1,91 @@
+module ESMF_AbstractStateItemMod
+   use ESMF_UtilTypesMod
+   implicit none
+   private
+
+   public :: ESMF_AbstractItem
+
+   public :: ESMF_AbstractStateItem
+   public :: ESMF_AbstractItemWrapper
+
+   public :: ESMF_AbstractStateItemGetInit
+   public :: ESMF_AbstractStateItemGet
+
+   type, abstract :: ESMF_AbstractItem
+   end type ESMF_AbstractItem
+
+
+   type :: FakeAbstractItem
+      sequence
+      integer :: placeholder(2)
+   end type FakeAbstractItem
+   ! This wrapper is intended to just to be the the same size as user
+   ! wrappers containing their own pointers to objects of types that
+   ! extend AbstractStateItem.
+   type :: ESMF_AbstractItemWrapper
+      sequence
+      type(FakeAbstractItem), pointer :: item
+   end type ESMF_AbstractItemWrapper
+
+   type :: ESMF_AbstractStateItem
+      sequence
+      character(ESMF_MAXSTR) :: name
+      type(ESMF_AbstractItemWrapper) :: wrapper
+   end type ESMF_AbstractStateItem
+
+
+
+#include "ESMF.h"
+
+contains
+
+   subroutine ESMF_AbstractStateItemGet(item, name, keywordEnforcer, rc)
+      type(ESMF_AbstractStateItem), intent(in) :: item
+      character(len=ESMF_MAXSTR), intent(out) :: name
+      type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
+      integer, optional, intent(out) :: rc
+
+      if (present(rc)) rc = ESMF_RC_NOT_IMPL
+      name = item%name
+      ! Return successfully
+      if (present(rc)) rc = ESMF_SUCCESS
+      
+   end subroutine ESMF_AbstractStateItemGet
+
+! -------------------------- ESMF-internal method -----------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_AbstractStateItemWrapperInit"
+!BOPI
+! !IROUTINE: ESMF_AbstractStateItemGetInit - Internal access routine for init code
+!
+! !INTERFACE:
+  function ESMF_AbstractStateItemGetInit(si) 
+!
+! !RETURN VALUE:
+      ESMF_INIT_TYPE :: ESMF_AbstractStateItemGetInit   
+!
+! !ARGUMENTS:
+      type(ESMF_AbstractStateItem), intent(in), optional :: si
+!
+! !DESCRIPTION:
+!      Access deep object init code.
+!
+!     The arguments are:
+!     \begin{description}
+!     \item [si]
+!           StateItem object.
+!     \end{description}
+!
+!EOPI
+
+!!$    if (present(si)) then
+!!$      ESMF_AbstractStateItemGetInit = ESMF_INIT_GET(si)
+!!$    else
+!!$      ESMF_AbstractStateItemGetInit = ESMF_INIT_DEFINED
+!!$    endif
+      ESMF_AbstractStateItemGetInit = ESMF_INIT_DEFINED
+
+   end function ESMF_AbstractStateItemGetInit
+!------------------------------------------------------------------------------
+
+end module ESMF_AbstractStateItemMod

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -58,7 +58,7 @@ module ESMF_StateAPIMod
       use ESMF_IOUtilMod
       use ESMF_UtilMod
       use ESMF_UtilStringMod
-
+      use ESMF_AbstractStateItemMod
       implicit none
 
 !------------------------------------------------------------------------------
@@ -142,6 +142,8 @@ module ESMF_StateAPIMod
     module procedure ESMF_StateAddOneStateX
     module procedure ESMF_StateAddStateList
 
+    module procedure ESMF_StateAddAbstractItemList
+
 
 ! !DESCRIPTION:
 ! This interface provides a single entry point for the various
@@ -166,7 +168,6 @@ module ESMF_StateAPIMod
     module procedure ESMF_StateAddRpRoutehandleList
     module procedure ESMF_StateAddRpStateList
 
-
 ! !DESCRIPTION:
 ! This interface provides a single entry point for the various
 ! types of {\tt ESMF\_StateAdd} functions.
@@ -189,6 +190,7 @@ module ESMF_StateAPIMod
       module procedure ESMF_StateGetFieldBundle
       module procedure ESMF_StateGetRouteHandle
       module procedure ESMF_StateGetState
+      module procedure ESMF_StateGetAbstractItem_
       module procedure ESMF_StateGetInfo
       module procedure ESMF_StateGetItemInfo
 
@@ -2158,5 +2160,96 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (present(rc)) rc = ESMF_RC_NOT_IMPL
 
         end function ESMF_StateReadRestart
+
+
+   subroutine ESMF_StateAddAbstractItemList(state, itemname, item, keywordEnforcer, &
+        proxyflag, addflag, replaceflag, relaxedflag, rc)
+      type(ESMF_State),  intent(inout) :: state
+      character(*), intent(in) :: itemname
+      class(ESMF_AbstractItem), target, intent(in) :: item
+      type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
+      logical, optional, intent(in) :: proxyflag
+      logical, optional, intent(in) :: addflag
+      logical, optional, intent(in) :: replaceflag
+      logical, optional, intent(in) :: relaxedflag
+      type(integer), intent(out), optional :: rc
+
+      integer :: localrc
+      type (AbstractItemWrapper) :: wrapper
+
+      interface
+         subroutine ESMF_StateAddAbstractItem(state, itemname, item, &
+              proxyflag, addflag, replaceflag, relaxedflag, rc) bind(c, name="ESMF_StateAddAbstractItem")
+            use ESMF_UtilTypesMod
+            use ESMF_StateTypesMod
+            use ESMF_AbstractStateItemMod
+            use ESMF_StateItemMod
+            use ESMF_StateInternalsMod
+            use ESMF_InitMacrosMod
+            use ESMF_StateVaMod
+            use ESMF_LogErrMod
+            implicit none
+            type(ESMF_State),  intent(inout) :: state
+            character(*), intent(in) :: itemname
+            type(AbstractItemWrapper), intent(in) :: item
+            logical, optional, intent(in) :: proxyflag
+            logical, optional, intent(in) :: addflag
+            logical, optional, intent(in) :: replaceflag
+            logical, optional, intent(in) :: relaxedflag
+            integer, intent(out), optional :: rc
+         end subroutine ESMF_StateAddAbstractItem
+      end interface
+      
+      if (present(rc)) rc = ESMF_RC_NOT_IMPL
+
+      ! Trick compiler to use implicit interface
+      wrapper%item => item
+      call ESMF_StateAddAbstractItem(state, itemname, wrapper, &
+           proxyflag=proxyflag, addflag=addflag, replaceflag=replaceflag, relaxedflag=relaxedflag, &
+           rc=localrc)
+
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+                    ESMF_CONTEXT, rcToReturn=rc))  return
+
+      if (present(rc)) rc = ESMF_SUCCESS
+   end subroutine ESMF_StateAddAbstractItemList
+
+
+   subroutine ESMF_StateGetAbstractItem_(state, itemname, item, keywordEnforcer, rc)
+      type(ESMF_State),  intent(inout) :: state
+      character(*), intent(in) :: itemname
+      class(ESMF_AbstractItem), target, intent(out) :: item
+      type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
+      integer, intent(out), optional :: rc
+
+      integer :: localrc
+      type (AbstractItemWrapper) :: wrapper
+
+      interface
+         subroutine ESMF_StateGetAbstractItem(state, itemname, item, rc) bind(c, name="ESMF_StateGetAbstractItem")
+            use ESMF_UtilTypesMod
+            use ESMF_StateTypesMod
+            use ESMF_AbstractStateItemMod
+            use ESMF_StateItemMod
+            use ESMF_StateInternalsMod
+            use ESMF_InitMacrosMod
+            use ESMF_StateVaMod
+            use ESMF_LogErrMod
+            implicit none
+            type(ESMF_State),  intent(inout) :: state
+            character(len=*), intent(in) :: itemname
+            type(AbstractItemWrapper), intent(out) :: item
+            type(integer), intent(out), optional :: rc
+         end subroutine ESMF_StateGetAbstractItem
+      end interface
+
+      ! Trick compiler to use implicit interface
+      wrapper%item => item
+      call ESMF_StateGetAbstractItem(state, itemname, wrapper, localrc)
+
+      if (present(rc)) rc = ESMF_SUCCESS
+
+   end subroutine ESMF_StateGetAbstractItem_
+
 
 end module ESMF_StateAPIMod

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -2175,11 +2175,11 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       type(integer), intent(out), optional :: rc
 
       integer :: localrc
-      type (AbstractItemWrapper) :: wrapper
+      type (AbstractItemWrapper), pointer :: wrapper
 
       interface
          subroutine ESMF_StateAddAbstractItem(state, itemname, item, &
-              proxyflag, addflag, replaceflag, relaxedflag, rc) bind(c, name="ESMF_StateAddAbstractItem")
+              relaxedflag, rc) bind(c, name="ESMF_StateAddAbstractItem")
             use ESMF_UtilTypesMod
             use ESMF_StateTypesMod
             use ESMF_AbstractStateItemMod
@@ -2191,10 +2191,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
             implicit none
             type(ESMF_State),  intent(inout) :: state
             character(*), intent(in) :: itemname
-            type(AbstractItemWrapper), intent(in) :: item
-            logical, optional, intent(in) :: proxyflag
-            logical, optional, intent(in) :: addflag
-            logical, optional, intent(in) :: replaceflag
+            type(AbstractItemWrapper), target, intent(in):: item
             logical, optional, intent(in) :: relaxedflag
             integer, intent(out), optional :: rc
          end subroutine ESMF_StateAddAbstractItem
@@ -2202,10 +2199,13 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       
       if (present(rc)) rc = ESMF_RC_NOT_IMPL
 
-      ! Trick compiler to use implicit interface
+      ! memory leak
+      allocate(wrapper)
       wrapper%item => item
+
+      ! Trick compiler to use implicit interface
       call ESMF_StateAddAbstractItem(state, itemname, wrapper, &
-           proxyflag=proxyflag, addflag=addflag, replaceflag=replaceflag, relaxedflag=relaxedflag, &
+           relaxedflag=relaxedflag, &
            rc=localrc)
 
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
@@ -2218,12 +2218,12 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
    subroutine ESMF_StateGetAbstractItem_(state, itemname, item, keywordEnforcer, rc)
       type(ESMF_State),  intent(inout) :: state
       character(*), intent(in) :: itemname
-      class(ESMF_AbstractItem), target, intent(out) :: item
+      class(ESMF_AbstractItem), pointer, intent(out) :: item
       type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
       integer, intent(out), optional :: rc
 
       integer :: localrc
-      type (AbstractItemWrapper) :: wrapper
+      type (AbstractItemWrapper), pointer :: wrapper
 
       interface
          subroutine ESMF_StateGetAbstractItem(state, itemname, item, rc) bind(c, name="ESMF_StateGetAbstractItem")
@@ -2238,14 +2238,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
             implicit none
             type(ESMF_State),  intent(inout) :: state
             character(len=*), intent(in) :: itemname
-            type(AbstractItemWrapper), intent(out) :: item
+            type(AbstractItemWrapper), pointer, intent(out) :: item
             type(integer), intent(out), optional :: rc
          end subroutine ESMF_StateGetAbstractItem
       end interface
 
       ! Trick compiler to use implicit interface
-      wrapper%item => item
       call ESMF_StateGetAbstractItem(state, itemname, wrapper, localrc)
+      item => wrapper%item
 
       if (present(rc)) rc = ESMF_SUCCESS
 

--- a/src/Superstructure/State/src/ESMF_StateAddAbstractItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateAddAbstractItem.F90
@@ -5,7 +5,7 @@
 ! being C interoperable.
 #define ESMF_METHOD "ESMF_StateAddAbstractItem"
 subroutine ESMF_StateAddAbstractItem(state, itemname, item, &
-     proxyflag, addflag, replaceflag, relaxedflag, rc) bind(c, name="ESMF_StateAddAbstractItem")
+     relaxedflag, rc) bind(c, name="ESMF_StateAddAbstractItem")
    use ESMF_UtilTypesMod
    use ESMF_StateTypesMod
    use ESMF_AbstractStateItemMod
@@ -17,10 +17,7 @@ subroutine ESMF_StateAddAbstractItem(state, itemname, item, &
    implicit none
    type(ESMF_State),  intent(inout) :: state
    character(*), intent(in) :: itemname
-   type(ESMF_AbstractItemWrapper), intent(in) :: item
-   logical, optional, intent(in) :: proxyflag
-   logical, optional, intent(in) :: addflag
-   logical, optional, intent(in) :: replaceflag
+   type(ESMF_AbstractItemWrapper), target, intent(in) :: item
    logical, optional, intent(in) :: relaxedflag
    type(integer), intent(out), optional :: rc
 
@@ -48,11 +45,9 @@ subroutine ESMF_StateAddAbstractItem(state, itemname, item, &
         ESMF_CONTEXT, rcToReturn=rc)) return
 
       temp_list(1)%name = itemname
-      temp_list(1)%wrapper = item
-
+      temp_list(1)%wrapper => item
       call ESMF_StateClsAdd (state%statep, temp_list, &
-        addflag=addflag, replaceflag=replaceflag, relaxedflag=relaxedflag,  &
-        proxyflag=proxyflag, rc=localrc)
+        addflag=.true., relaxedflag=relaxedflag, rc=localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
                     ESMF_CONTEXT, rcToReturn=rc))  return
 
@@ -74,7 +69,7 @@ subroutine ESMF_StateGetAbstractItem(state, itemname, item, rc) bind(c, name="ES
    implicit none
    type(ESMF_State),  intent(inout) :: state
    character(len=*), intent(in) :: itemname
-   type(ESMF_AbstractItemWrapper), intent(out) :: item
+   type(ESMF_AbstractItemWrapper), pointer, intent(out) :: item
    type(integer), intent(out), optional :: rc
 
    type(ESMF_StateItem), pointer :: dataitem

--- a/src/Superstructure/State/src/ESMF_StateAddAbstractItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateAddAbstractItem.F90
@@ -1,0 +1,125 @@
+! This file is technically not valid Fortran and should be rewritten
+! as C.  It will still be used to "cheat" the enforcement of
+! interfaces, but as C it will at least be portable.  Intel Fortran
+! just happens to accept this interface despite most arguments not
+! being C interoperable.
+#define ESMF_METHOD "ESMF_StateAddAbstractItem"
+subroutine ESMF_StateAddAbstractItem(state, itemname, item, keywordEnforcer, &
+     proxyflag, addflag, replaceflag, relaxedflag, rc) bind(c, name="ESMF_StateAddAbstractItem")
+   use ESMF_UtilTypesMod
+   use ESMF_StateTypesMod
+   use ESMF_AbstractStateItemMod
+   use ESMF_StateItemMod
+   use ESMF_StateInternalsMod
+   use ESMF_InitMacrosMod
+   use ESMF_StateVaMod
+   use ESMF_LogErrMod
+   implicit none
+   type(ESMF_State),  intent(inout) :: state
+   character(*), intent(in) :: itemname
+   type(ESMF_AbstractItemWrapper), intent(in) :: item
+   type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
+   logical, optional, intent(in) :: proxyflag
+   logical, optional, intent(in) :: addflag
+   logical, optional, intent(in) :: replaceflag
+   logical, optional, intent(in) :: relaxedflag
+   type(integer), intent(out), optional :: rc
+
+#  include "ESMF.h"
+
+
+
+      type(ESMF_AbstractStateItem) :: temp_list(1)
+      character(ESMF_MAXSTR) :: lvalue1, lvalue2
+      character(ESMF_MAXSTR) :: lobject, lname
+
+      integer :: localrc
+
+      ! check input variables
+      ESMF_INIT_CHECK_DEEP(ESMF_StateGetInit,state,rc)
+!      ESMF_INIT_CHECK_DEEP(ESMF_AbstractStateItemGetInit,item,rc)
+
+      ! Initialize return code; assume routine not implemented
+      if (present(rc)) rc = ESMF_RC_NOT_IMPL
+      localrc = ESMF_RC_NOT_IMPL
+
+      call ESMF_StateValidate(state, rc=localrc)
+      if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+
+      temp_list(1)%name = itemname
+      temp_list(1)%wrapper = item
+
+      call ESMF_StateClsAdd (state%statep, temp_list, &
+        addflag=addflag, replaceflag=replaceflag, relaxedflag=relaxedflag,  &
+        proxyflag=proxyflag, rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+                    ESMF_CONTEXT, rcToReturn=rc))  return
+
+      if (present(rc)) rc = ESMF_SUCCESS
+
+end subroutine ESMF_StateAddAbstractItem
+#undef ESMF_METHOD
+
+#define ESMF_METHOD "ESMF_StateGetAbstractItem"
+subroutine ESMF_StateGetAbstractItem(state, itemname, item, keywordEnforcer, rc) bind(c, name="ESMF_StateGetAbstractItem")
+   use ESMF_UtilTypesMod
+   use ESMF_StateTypesMod
+   use ESMF_AbstractStateItemMod
+   use ESMF_StateItemMod
+   use ESMF_StateInternalsMod
+   use ESMF_InitMacrosMod
+   use ESMF_StateVaMod
+   use ESMF_LogErrMod
+   implicit none
+   type(ESMF_State),  intent(inout) :: state
+   character(len=*), intent(in) :: itemname
+   type(ESMF_AbstractItemWrapper), intent(out) :: item
+   type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
+   type(integer), intent(out), optional :: rc
+
+   type(ESMF_StateItem), pointer :: dataitem
+   logical :: exists
+   integer :: localrc
+   character(len=len(itemName)+ESMF_MAXSTR) :: errmsg
+
+   localrc = ESMF_RC_NOT_IMPL
+
+   ! check input variables
+   ESMF_INIT_CHECK_DEEP(ESMF_StateGetInit,state,rc)
+   call ESMF_StateValidate(state, rc=localrc)
+   if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+
+      ! Assume failure until we know we will succeed 
+      if (present(rc)) rc=ESMF_RC_NOT_IMPL
+      ! TODO: do we need an empty (or invalid) item to mark failure?
+
+      exists = ESMF_StateClassFindData(state%statep,   &
+                 dataname=itemName, expected=.true., &
+                 dataitem=dataitem,  &
+                 rc=localrc)
+      if (.not. exists) then
+          write(errmsg, *) "no AbstractItem found named: ", trim(itemName)
+          if (ESMF_LogFoundError(ESMF_RC_NOT_FOUND, msg=errmsg, &
+              ESMF_CONTEXT, rcToReturn=rc)) return
+      endif
+
+      if (dataitem%otype .ne. ESMF_STATEITEM_ABSTRACTITEM) then
+          write(errmsg, *) trim(itemName), " found but not type AbstarctItem"
+          if (ESMF_LogFoundError(ESMF_RC_ARG_INCOMP, msg=errmsg, &
+                ESMF_CONTEXT, rcToReturn=rc)) return 
+      endif
+
+!!$#if !defined (stateversion)
+      item = dataitem%datap%asip%wrapper
+!!$#else
+!!$      item%statep => dataitem%datap%mcomponent
+!!$      ! validate created state
+!!$      ESMF_INIT_SET_CREATED(nestedState)
+!!$#endif
+      if (present(rc)) rc = ESMF_SUCCESS
+end subroutine ESMF_StateGetAbstractItem
+#undef ESMF_METHOD

--- a/src/Superstructure/State/src/ESMF_StateAddAbstractItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateAddAbstractItem.F90
@@ -4,7 +4,7 @@
 ! just happens to accept this interface despite most arguments not
 ! being C interoperable.
 #define ESMF_METHOD "ESMF_StateAddAbstractItem"
-subroutine ESMF_StateAddAbstractItem(state, itemname, item, keywordEnforcer, &
+subroutine ESMF_StateAddAbstractItem(state, itemname, item, &
      proxyflag, addflag, replaceflag, relaxedflag, rc) bind(c, name="ESMF_StateAddAbstractItem")
    use ESMF_UtilTypesMod
    use ESMF_StateTypesMod
@@ -18,7 +18,6 @@ subroutine ESMF_StateAddAbstractItem(state, itemname, item, keywordEnforcer, &
    type(ESMF_State),  intent(inout) :: state
    character(*), intent(in) :: itemname
    type(ESMF_AbstractItemWrapper), intent(in) :: item
-   type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
    logical, optional, intent(in) :: proxyflag
    logical, optional, intent(in) :: addflag
    logical, optional, intent(in) :: replaceflag
@@ -63,7 +62,7 @@ end subroutine ESMF_StateAddAbstractItem
 #undef ESMF_METHOD
 
 #define ESMF_METHOD "ESMF_StateGetAbstractItem"
-subroutine ESMF_StateGetAbstractItem(state, itemname, item, keywordEnforcer, rc) bind(c, name="ESMF_StateGetAbstractItem")
+subroutine ESMF_StateGetAbstractItem(state, itemname, item, rc) bind(c, name="ESMF_StateGetAbstractItem")
    use ESMF_UtilTypesMod
    use ESMF_StateTypesMod
    use ESMF_AbstractStateItemMod
@@ -76,7 +75,6 @@ subroutine ESMF_StateGetAbstractItem(state, itemname, item, keywordEnforcer, rc)
    type(ESMF_State),  intent(inout) :: state
    character(len=*), intent(in) :: itemname
    type(ESMF_AbstractItemWrapper), intent(out) :: item
-   type(ESMF_KeywordEnforcer), optional :: keywordEnforcer
    type(integer), intent(out), optional :: rc
 
    type(ESMF_StateItem), pointer :: dataitem

--- a/src/Superstructure/State/src/ESMF_StateInternals.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateInternals.cppF90
@@ -52,6 +52,7 @@ module ESMF_StateInternalsMod
       use ESMF_StateTypesMod
       use ESMF_StateContainerMod
       use ESMF_StateVaMod
+      use ESMF_AbstractStateItemMod
 
       implicit none
 
@@ -102,6 +103,7 @@ module ESMF_StateInternalsMod
     module procedure ESMF_StateClsAddFieldList
     module procedure ESMF_StateClsAddFieldBundleList
     module procedure ESMF_StateClsAddStateList
+    module procedure ESMF_StateClsAddAbstractStateItemList
 
   end interface
 !------------------------------------------------------------------------------
@@ -126,6 +128,7 @@ contains
                          arrays, arraybundles, &
                          fields, fieldbundles, &
                          routehandles, states, &
+			 abstractitems, &
                          itemCount, vm, rc)
 !
 ! !ARGUMENTS:
@@ -138,6 +141,7 @@ contains
       type(ESMF_FieldBundle), intent(in),  optional :: fieldbundles(:)
       type(ESMF_RouteHandle), intent(in),  optional :: routehandles(:)
       type(ESMF_State),       intent(in),  optional :: states(:)
+      type(ESMF_AbstractStateItem),       intent(in),  optional :: abstractitems(:)
       integer,                intent(in),  optional :: itemCount
       type(ESMF_VM),          intent(in),  optional :: vm
       integer,                intent(out), optional :: rc
@@ -166,6 +170,8 @@ contains
 !    An array of {\tt ESMF\_FieldBundle}s.
 !   \item[{[states]}]
 !    An array of nested {\tt ESMF\_State}s.
+!   \item[{[abstractitems]}]
+!    An array of nested {\tt ESMF\_AbstractStateItem}s.
 !   \item[{[routehandles]}]
 !    An array of {\tt ESMF\_RouteHandle}s.
 !   \item[{[itemCount]}]
@@ -224,6 +230,13 @@ ESMF_INIT_CHECK_DEEP(ESMF_FieldBundleGetInit,fieldbundles(i),rc)
 ESMF_INIT_CHECK_DEEP(ESMF_StateGetInit,states(i),rc)
            enddo
            localitemcount = localitemcount + size (states)
+        endif
+        if (present(abstractitems)) then
+           do i=1,size(abstractitems)
+! TLC I do not nkow what this macro does so commenting it out for now
+!ESMF_INIT_CHECK_DEEP(ESMF_StateGetInit,states(i),rc)
+           enddo
+           localitemcount = localitemcount + size (abstractitems)
         endif
         if (present(routehandles)) then
            do i=1,size(routehandles)
@@ -306,6 +319,16 @@ ESMF_INIT_CHECK_DEEP(ESMF_RouteHandleGetInit,routehandles(i),rc)
           if (size (states) > 0) then
             call ESMF_StateClsAddStateList(stypep,  &
               states, addflag=.true., rc=localrc)
+            if (ESMF_LogFoundError(localrc, &
+            ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+          endif
+        endif
+
+        if (present(abstractitems)) then
+          if (size (abstractitems) > 0) then
+            call ESMF_StateClsAddAbstractStateItemList(stypep,  &
+              abstractitems, addflag=.true., rc=localrc)
             if (ESMF_LogFoundError(localrc, &
             ESMF_ERR_PASSTHRU, &
             ESMF_CONTEXT, rcToReturn=rc)) return
@@ -729,6 +752,7 @@ StateClsAddListMacro(ESMF_FieldBundle, FieldBundle, fieldbundles, fbp, FIELDBUND
 ^define stateversion
 StateClsAddListMacro(ESMF_State, State, states, spp, STATE)
 ^undef  stateversion
+StateClsAddListMacro(ESMF_AbstractStateItem, AbstractStateItem, abstractitems, asip, ABSTRACTITEM)
 
 !------------------------------------------------------------------------------
 ^undef  ESMF_METHOD

--- a/src/Superstructure/State/src/ESMF_StateItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateItem.F90
@@ -38,6 +38,7 @@
       use ESMF_InitMacrosMod
       use ESMF_IOUtilMod
       use ESMF_ContainerMod
+      use ESMF_AbstractStateItemMod, only: ESMF_AbstractStateItem
       implicit none
 
 !------------------------------------------------------------------------------
@@ -65,12 +66,13 @@
                 ESMF_STATEITEM_ARRAYBUNDLE  = ESMF_StateItem_Flag(104), &
                 ESMF_STATEITEM_ROUTEHANDLE  = ESMF_StateItem_Flag(105), &
                 ESMF_STATEITEM_STATE        = ESMF_StateItem_Flag(106), &
+                ESMF_STATEITEM_ABSTRACTITEM = ESMF_StateItem_Flag(107), &
 #if 0
-                ESMF_STATEITEM_NAME         = ESMF_StateItem_Flag(107), &
-                ESMF_STATEITEM_INDIRECT     = ESMF_StateItem_Flag(108), &
+                ESMF_STATEITEM_NAME         = ESMF_StateItem_Flag(108), &
+                ESMF_STATEITEM_INDIRECT     = ESMF_StateItem_Flag(109), &
 #endif
-                ESMF_STATEITEM_UNKNOWN      = ESMF_StateItem_Flag(109), &
-                ESMF_STATEITEM_NOTFOUND     = ESMF_StateItem_Flag(110)
+                ESMF_STATEITEM_UNKNOWN      = ESMF_StateItem_Flag(110), &
+                ESMF_STATEITEM_NOTFOUND     = ESMF_StateItem_Flag(111)
 
 #if 0
 !------------------------------------------------------------------------------
@@ -162,6 +164,7 @@
           type(ESMF_Array)        :: ap
           type(ESMF_ArrayBundle)  :: abp
           type(ESMF_RouteHandle)  :: rp
+          type(ESMF_AbstractStateItem) :: asip
           type(ESMF_StateClass), pointer  :: spp
           ESMF_INIT_DECLARE
       end type
@@ -270,6 +273,7 @@
         ESMF_STATEITEM_FIELD, ESMF_STATEITEM_FIELDBUNDLE, &
         ESMF_STATEITEM_ARRAY, ESMF_STATEITEM_ARRAYBUNDLE, &
         ESMF_STATEITEM_ROUTEHANDLE, ESMF_STATEITEM_STATE, &
+        ESMF_STATEITEM_ABSTRACTITEM, &
 #if 0
         ESMF_STATEITEM_NAME, &
 #endif

--- a/src/Superstructure/State/src/ESMF_StateItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateItem.F90
@@ -182,7 +182,7 @@
 #endif
 #endif
       !private
-        type(ESMF_DataHolder) :: datap
+      type(ESMF_DataHolder) :: datap
         type(ESMF_StateItem_Flag) :: otype
 #if 0
         type(ESMF_NeededFlag) :: needed 

--- a/src/Superstructure/State/src/ESMF_StateItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateItem.F90
@@ -38,7 +38,7 @@
       use ESMF_InitMacrosMod
       use ESMF_IOUtilMod
       use ESMF_ContainerMod
-      use ESMF_AbstractStateItemMod, only: ESMF_AbstractStateItem
+      use ESMF_AbstractStateItemMod, only: ESMF_AbstractStateItem, ESMF_AbstractStateItemGet
       implicit none
 
 !------------------------------------------------------------------------------
@@ -443,6 +443,12 @@ contains
         return
     case (ESMF_STATEITEM_ROUTEHANDLE%ot)
       call ESMF_RouteHandleGet(stateItem%datap%rp, name=name, rc=localrc)
+      if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) &
+        return
+    case (ESMF_STATEITEM_ABSTRACTITEM%ot)
+      call ESMF_AbstractStateItemGet(stateItem%datap%asip, name=name, rc=localrc)
       if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) &

--- a/src/Superstructure/State/src/ESMF_StateTypes.F90
+++ b/src/Superstructure/State/src/ESMF_StateTypes.F90
@@ -46,6 +46,7 @@
       use ESMF_InitMacrosMod
       use ESMF_StateItemMod
       use ESMF_StateContainerMod
+      use ESMF_AbstractStateItemMod
       implicit none
 
 !------------------------------------------------------------------------------
@@ -75,6 +76,7 @@
         ESMF_STATEITEM_FIELD, ESMF_STATEITEM_FIELDBUNDLE, &
         ESMF_STATEITEM_ARRAY, ESMF_STATEITEM_ARRAYBUNDLE, &
         ESMF_STATEITEM_ROUTEHANDLE, ESMF_STATEITEM_STATE, &
+        ESMF_STATEITEM_ABSTRACTITEM, &
 #if 0
         ESMF_STATEITEM_NAME, &
 #endif

--- a/src/Superstructure/State/src/makefile
+++ b/src/Superstructure/State/src/makefile
@@ -9,7 +9,8 @@ AUTOGEN   = ESMF_StateInternals.F90 ESMF_StateRemRep.F90 ESMF_StateAPI.F90
 SOURCEC	  = 
 SOURCEF	  = ESMF_StateItem.F90 ESMF_StateContainer.F90 ESMF_StateTypes.F90 \
 	    ESMF_StateVa.F90 ESMF_State.F90 \
-	    ESMF_StateWr.F90 $(AUTOGEN) ESMF_StateSet.F90
+	    ESMF_StateWr.F90 $(AUTOGEN) ESMF_StateSet.F90 \
+            ESMF_StateAddAbstractItem.F90
 SOURCEH	  = 
 STOREH    = ESMCI_StateItem.h ESMC_State.h
 TEXFILES  = $(addsuffix _fapi.tex, $(basename $(AUTOGEN)))


### PR DESCRIPTION
This request adds a new feature to ESMF that allows users to add objects of CLASS(AbstractStateItem) to an ESMF state.

In particular, users can add objects that are of concrete subclasses of AbstractStateItem and thereby add private state and type bound methods that can be used by other grid comps that are aware of the relevant subclass.    The idea is for sub communities (e.g., atmos. chemistry) to standardize an API and thereby share clean, lightweight interfaces for callbacks between say radiation and chemistry.
