### PR TITLE
Add -DESMF_NO_F2018ASSUMEDTYPE to NAG and PGI on Darwin

### DIFF
--- a/build_config/Darwin.nag.default/build_rules.mk
+++ b/build_config/Darwin.nag.default/build_rules.mk
@@ -116,6 +116,12 @@ ESMF_CLANGSTR := $(findstring clang, $(shell $(ESMF_CXXCOMPILER) --version))
 ESMF_F90COMPILEOPTS += -DESMF_NAG_UNIX_MODULE
 
 ############################################################
+# Currently NAG does not support the Fortran2018 assumed type feature
+#
+ESMF_F90COMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
+ESMF_CXXCOMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
+
+############################################################
 # nag currently does not support OpenMP
 #
 ESMF_OPENMP := OFF

--- a/build_config/Darwin.pgi.default/build_rules.mk
+++ b/build_config/Darwin.pgi.default/build_rules.mk
@@ -135,6 +135,12 @@ ESMF_F90COMPILECPPFLAGS += -DESMF_PGIVERSION_PATCH=$(ESMF_PGIVERSION_PATCH)
 ESMF_CXXCOMPILECPPFLAGS += -DESMF_PGIVERSION_PATCH=$(ESMF_PGIVERSION_PATCH)
 
 ############################################################
+# Currently PGI does not support the Fortran2018 assumed type feature
+#
+ESMF_F90COMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
+ESMF_CXXCOMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
+
+############################################################
 # Construct the ABISTRING
 #
 ifeq ($(ESMF_MACHINE),x86_64)


### PR DESCRIPTION
Testing by @tclune revealed a crash building with `nagfor` on macOS. Eventually, he figured out that the issue was it was trying to build F2018 code, which NAG can't (yet). 

So, until we know *what* versions of NAG can compile the code, I borrowed the:
```make
############################################################
# Currently NAG does not support the Fortran2018 assumed type feature
#
ESMF_F90COMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
ESMF_CXXCOMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
```
code from `Linux.nag` to add to `Darwin.nag`.  (NOTE: Not yet confirmed to work, @tclune is trying it now. So I'm making this a draft until we know.)

I also then added the same bits to the `Darwin.pgi` though I have no way of testing.