### PR TITLE
Fix bug with alarms after clock direction change.

### DIFF
--- a/src/Infrastructure/TimeMgr/src/ESMCI_Clock.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Clock.C
@@ -566,6 +566,7 @@ int Clock::count=0;
  #define ESMC_METHOD "ESMCI::Clock::advance()"
 
     int rc = ESMF_SUCCESS;
+    bool userChangedDirLocal;
 
     if (this == ESMC_NULL_POINTER) {
       ESMC_LogDefault.MsgFoundError(ESMC_RC_PTR_NULL,
@@ -638,11 +639,21 @@ int Clock::count=0;
                                     ringingAlarmList1stElementPtr);
     }
 
+    // Each alarm sets userChangedDirection to false in checkRingTime,
+    // so only the first alarm knows if the user changed direction.
+    // To remedy this, we'll save userChangedDirection and reset
+    // the clock's userChangedDirection before each alarm. After
+    // the last alarm::checkRingTime, this->userChangedDirection
+    // will be false. This is not the most efficient fix, but
+    // requires the least code changing to achieve it.
+    userChangedDirLocal = this->userChangedDirection;
+
     // traverse alarm list (i) for ringing alarms (j)
     for(int i=0, j=0; i<alarmCount; i++) {
       int rc;
       bool ringing;
 
+      this->userChangedDirection = userChangedDirLocal;
       // check each alarm to see if it's time to ring
       ringing = alarmList[i]->Alarm::checkRingTime(&rc);
 


### PR DESCRIPTION
I have been working on adjoint development for GCHP and found a problem with the history alarms after running the clock forward and then reversing it. It appears to be a problem with the `checkRingTime` command which is called in a for loop but changes a variable in the clock, `userChangedDirection`,  which is then read in subsequent loop iterations but the original value has been overwritten. This small change saves the value and resets it before each call to `checkRingTime` so that the correct branch is taken in there, and then the last one sets `clock->userChangedDirection` to false, which should be the value after the loop has completed. This is probably not the most efficient fix, but it's the one that requires the smallest code change.