### PR TITLE
(Partial) Fix for install_name_tool step

### DIFF
--- a/makefile
+++ b/makefile
@@ -676,7 +676,7 @@ install:
 	cp -f $(ESMF_MODDIR)/*.mod $(ESMF_INSTALL_MODDIR_ABSPATH)
 	mkdir -p $(ESMF_INSTALL_LIBDIR_ABSPATH)
 	cp -f $(ESMF_LIBDIR)/libesmf*.* $(ESMF_INSTALL_LIBDIR_ABSPATH)
-	@for lib in $(wildcard $(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmf*.dylib) foo ; do \
+	@for lib in $(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmf*.dylib foo ; do \
 	  if [ $$lib != "foo" ]; then \
 	    install_name_tool -id "$$lib" $$lib ; \
 	  fi ; \


### PR DESCRIPTION
Okay. This is one for @theurich. I'd have made an issue about this, but no Issues here, so, I'll use this PR as my Issue explanation.

To wit, we've always had issues with ESMF on our macs where the paths inside the dylibs are not correct. For example, first let's make sure no dylibs are installed yet:
```console
❯ ls $HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf*dylib
zsh: no matches found: /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf*dylib
```
Okay, now let us fix the `makefile` to echo out the for loop:
```make
        cp -f $(ESMF_LIBDIR)/libesmf*.* $(ESMF_INSTALL_LIBDIR_ABSPATH)
        for lib in $(wildcard $(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmf*.dylib) foo ; do \
          if [ $$lib != "foo" ]; then \
            install_name_tool -id "$$lib" $$lib ; \
          fi ; \
        done
```
Now, let's run `make install`:
```
❯ make -e install ESMF_COMM=openmpi ESMF_COMPILER=gfortran ESMF_INSTALL_PREFIX=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin ESMF_INSTALL_HEADERDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf ESMF_INSTALL_MODDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf ESMF_INSTALL_LIBDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib ESMF_INSTALL_BINDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/bin

Installing ESMF:

mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/src/include/ESMC.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/src/include/ESMC_*.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/build_config/Darwin.gfortran.default/ESMC_Conf.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/mod/modO/Darwin.gfortran.64.openmpi.default/*.mod /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf
mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/lib/libO/Darwin.gfortran.64.openmpi.default/libesmf*.* /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib
for lib in  foo ; do \
  if [ $lib != "foo" ]; then \
    install_name_tool -id "$lib" $lib ; \
  fi ; \
done
make ESMF_PRELOADDIR=/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib build_preload_script
...
```
Notice that the loop was "empty". If I look at the dylibs made:
```console
❯ otool -L $HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib
/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib:
	/Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/lib/libO/Darwin.gfortran.64.openmpi.default/libesmf.dylib (compatibility version 0.0.0, current version 0.0.0)
...
```
You can see the issue is that it still has the `lib/libO` path. So `install_name_tool` wasn't run. *BUT*, if run `make install` again:
```console
❯ make -e install ESMF_COMM=openmpi ESMF_COMPILER=gfortran ESMF_INSTALL_PREFIX=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin ESMF_INSTALL_HEADERDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf ESMF_INSTALL_MODDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf ESMF_INSTALL_LIBDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib ESMF_INSTALL_BINDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/bin

Installing ESMF:

mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/src/include/ESMC.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/src/include/ESMC_*.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/build_config/Darwin.gfortran.default/ESMC_Conf.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/mod/modO/Darwin.gfortran.64.openmpi.default/*.mod /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf
mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/lib/libO/Darwin.gfortran.64.openmpi.default/libesmf*.* /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib
for lib in /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf_fullylinked.dylib /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmftrace_preload.dylib foo ; do \
  if [ $lib != "foo" ]; then \
    install_name_tool -id "$lib" $lib ; \
  fi ; \
done
make ESMF_PRELOADDIR=/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib build_preload_script
...
```
Ah. It found the dylibs! And now:
```console
❯ otool -L $HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib
/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib:
	/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib (compatibility version 0.0.0, current version 0.0.0)
...
```
I think this is due to "fun" in GNU Make. I believe that the `$(wildcard ...)` does not do what one thinks. I think `$(wildcard)` is evaluated *first* and its values inserted into the shell commands. Since the first time you run `make install` there are no dylibs in the installation directory, it evaluates to nothing. But when you run `make install` a second time, it sees the files!

So, my solution is to just not use a wildcard and use the shell glob. Doing that (after removing the installed dylibs):
```console
❯ ls $HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf*dylib
zsh: no matches found: /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf*dylib
❯ make -e install ESMF_COMM=openmpi ESMF_COMPILER=gfortran ESMF_INSTALL_PREFIX=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin ESMF_INSTALL_HEADERDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf ESMF_INSTALL_MODDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf ESMF_INSTALL_LIBDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib ESMF_INSTALL_BINDIR=$HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/bin

Installing ESMF:

mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/src/include/ESMC.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/src/include/ESMC_*.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/build_config/Darwin.gfortran.default/ESMC_Conf.h /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/include/esmf
mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/mod/modO/Darwin.gfortran.64.openmpi.default/*.mod /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/install/esmf
mkdir -p /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib
cp -f /Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/lib/libO/Darwin.gfortran.64.openmpi.default/libesmf*.* /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib
for lib in /Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf*.dylib foo ; do \
  if [ $lib != "foo" ]; then \
    install_name_tool -id "$lib" $lib ; \
  fi ; \
done
make ESMF_PRELOADDIR=/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib build_preload_script
...
❯ otool -L $HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib
/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib:
	/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmf.dylib (compatibility version 0.0.0, current version 0.0.0)
```
Success!

NOTE: You will see my PR says *partial* fix. The reason is that there is another problem with `install_name_tool`. Even after we get it all working, if we look at `libesmftrace_preload.dylib`, we see we actually need to run it *twice* for that file:
```console
❯ otool -L $HOME/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmftrace_preload.dylib
/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmftrace_preload.dylib:
	/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libesmftrace_preload.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/mathomp4/installed/Compiler/gcc-gfortran-10.3.0/openmpi/4.1.0/lib/libmpi_mpifh.40.dylib (compatibility version 71.0.0, current version 71.0.0)
	/Users/mathomp4/installed/Core/gcc-gfortran/10.3.0/lib/libgfortran.5.dylib (compatibility version 6.0.0, current version 6.0.0)
	/Users/mathomp4/installed/MPI/gcc-gfortran-10.3.0/openmpi-4.1.0/Baselibs/6.2.4-DYLIBTEST/Darwin/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1775.118.101)
	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration (compatibility version 1.0.0, current version 1109.101.1)
	/Users/mathomp4/Baselibs/ESMA-Baselibs-main-fix-esmfdylib/src/esmf/lib/libO/Darwin.gfortran.64.openmpi.default/libesmf.dylib (compatibility version 0.0.0, current version 0.0.0)
...
```
Notice now the `libesmftrace_preload.dylib` library is 'fixed' but the `libesmf.dylib` at the end is not. I can think of a few ways to do this, but I don't know how to test that library, so I'm a bit hesitant to try and propose a fix. 