### PR TITLE
ESMPy: update deprecated NumPy usage in grid module

### DIFF
--- a/src/addon/ESMPy/src/ESMF/api/grid.py
+++ b/src/addon/ESMPy/src/ESMF/api/grid.py
@@ -333,8 +333,8 @@ class Grid(object):
         self._coords = [None]
 
         # mask and area
-        self._mask = np.zeros(None)
-        self._area = np.zeros(None)
+        self._mask = np.zeros(())
+        self._area = np.zeros(())
 
         # create the correct grid
         self._struct = None


### PR DESCRIPTION
Hi, I co-develop a Python library ([cf-python](https://github.com/NCAS-CMS/cf-python)) which wraps `ESMPy` to include regridding capability, and a pair of identical `DeprecationWarning`s emerged in our test suite recently (details provided in our ticket NCAS-CMS/cf-python#266) which emerge from `ESMF` code:


```python
/home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/ESMF/api/grid.py:336: DeprecationWarning: Passing None into shape arguments as an alias for () is deprecated.
  self._mask = np.zeros(None)
/home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/ESMF/api/grid.py:337: DeprecationWarning: Passing None into shape arguments as an alias for () is deprecated.
  self._area = np.zeros(None)
```

Having investigated this to check it was not an issue with our own codebase, I found that it was not, and having cloned the `ESMF` repo I see that the offending lines are as per the traceback, namely use of `np.zeros(None)` twice in succession the `api.grid` module. Running that precise line standalone interactively with NumPy 1.21.0 demonstrates such a statement is deprecated at that version:

```pycon
>>> import numpy as np
>>> np.zeros(None)
<stdin>:1: DeprecationWarning: Passing None into shape arguments as an alias for () is deprecated.
array(0.)
```

and having checked the documentation, it states that such a means to specify `shape` giving `size` of `1` for an array [was indeed deprecated at NumPy version 1.20.0](https://numpy.org/devdocs/release/1.20.0-notes.html#passing-shape-none-to-functions-with-a-non-optional-shape-argument-is-deprecated).

Because the Issue Tracker on this repo seems to be hidden, I couldn't note this small issue, so I thought I'd put in a PR to propose the natural way to address those warnings.

**Note**: because there are no contributor guidelines or developer notes that I can find in your documentation or attached to this repo, I can't work out how to run the test suite for the `ESMPy` library of the overall codebase, so I can't verify in that way whether or not this removes the deprecation warning without changing the behaviour of the module or library as a whole, as desired - I am hoping the CI on this PR will help to show that via passing jobs. Logically, however, the line changes suggested are equivalent to the previous lines, without having deprecated parameters, so this should work as intended.

If there are any changes required, please let me know and I can edit the PR accordingly. Thanks!
