### PR TITLE
Fix finding and updating dylibs for Darwin install

### DIFF
--- a/makefile
+++ b/makefile
@@ -677,11 +677,17 @@ install:
 	cp -f $(ESMF_MODDIR)/*.mod $(ESMF_INSTALL_MODDIR_ABSPATH)
 	mkdir -p $(ESMF_INSTALL_LIBDIR_ABSPATH)
 	cp -f $(ESMF_LIBDIR)/libesmf*.* $(ESMF_INSTALL_LIBDIR_ABSPATH)
-	@for lib in $(wildcard $(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmf*.dylib) foo ; do \
+ifneq (,$(filter $(ESMF_OS),Darwin DARWIN darwin))
+	@for lib in $(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmf*.dylib foo ; do \
 	  if [ $$lib != "foo" ]; then \
 	    install_name_tool -id "$$lib" $$lib ; \
 	  fi ; \
+	  if [ $$lib == "$(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmftrace_preload.dylib" ]; then \
+	    install_name_tool -change "$(ESMF_LIBDIR)/libesmf.dylib" \
+	      "$(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmf.dylib" $$lib; \
+	  fi ; \
 	done
+endif
 ifeq ($(ESMF_TRACE_LIB_BUILD),ON)
 ifeq ($(ESMF_TRACE_BUILD_SHARED),ON)
 	$(MAKE) ESMF_PRELOADDIR=$(ESMF_INSTALL_LIBDIR_ABSPATH) build_preload_script


### PR DESCRIPTION
TYPE: bug

KEYWORDS: DARWIN, INSTALL, DYLIB

SOURCE: Daniel Rosen, NCAR; Matthew Thompson

DESCRIPTION OF CHANGES: Fixes finding dylibs in makefile for Darwin OS in order to fix dynamic library bug on Macs

Included in PR
* Replaces wildcard search, which is expanded before target executes, with find
* Wraps install_name_tool in conditional: ESMF_OS = Darwin or DARWIN or darwin
* Adds libesmf.dylib path change for libesmftrace_preload.dylib

Expands on PR #30  

ISSUES:
Closes: https://github.com/esmf-org/esmf-support/issues/126
Outdates: https://github.com/esmf-org/esmf/pull/30
Issue noted in: https://github.com/esmf-org/esmf-support/issues/19

TESTING

OS X Catalina 10.15.7 with gcc-9.4.0, openmpi-3.0.0, and netcdf-4.7.0 (work laptop)
1. built, installed, and executed
2. checked dylibs using `otool -D <dylib>`
3. checked dylibs using `otool -L <dylib>`
4. moved source directory and executed NUOPC prototype AtmOcnProto

SLES 12.4 with Intel-19.1.1, mpt-2.25, and netcdf-4.3.3.1 (Cheyenne)
1. built, installed, and executed
2. deleted source directory and executed NUOPC prototype AtmOcnProto