### PR TITLE
Feature/cmake find esmf

### DIFF
--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -1,34 +1,34 @@
 # - Try to find ESMF
 #
-# Requires setting ESMFMKFILE to the filepath of esmf.mk. If this is NOT set,
-# then ESMF_FOUND will always be FALSE. If ESMFMKFILE exists, then ESMF_FOUND=TRUE
-# and all ESMF makefile variables will be set in the global scope. Optionally,
-# set ESMF_MKGLOBALS to a string list to filter makefile variables. For example,
-# to globally scope only ESMF_LIBSDIR and ESMF_APPSDIR variables, use this CMake
-# command in CMakeLists.txt:
+# Uses ESMFMKFILE to find the filepath of esmf.mk. If this is NOT set, then this
+# module will attempt to find esmf.mk. If ESMFMKFILE exists, then
+# ESMF_FOUND=TRUE and all ESMF makefile variables will be set in the global
+# scope. Optionally, set ESMF_MKGLOBALS to a string list to filter makefile
+# variables. For example, to globally scope only ESMF_LIBSDIR and ESMF_APPSDIR
+# variables, use this CMake command in CMakeLists.txt:
 #
 #   set(ESMF_MKGLOBALS "LIBSDIR" "APPSDIR")
 
-
-# Add the ESMFMKFILE path to the cache if defined as system env variable
-if(DEFINED ENV{ESMFMKFILE} AND NOT DEFINED ESMFMKFILE)
-  set(ESMFMKFILE $ENV{ESMFMKFILE} CACHE FILEPATH "Path to ESMF mk file")
-endif()
-
-# Found the mk file and ESMF exists on the system
-if(EXISTS ${ESMFMKFILE})
-  set(ESMF_FOUND TRUE CACHE BOOL "ESMF mk file found" FORCE)
-  # Did not find the ESMF mk file
-else()
-  set(ESMF_FOUND FALSE CACHE BOOL "ESMF mk file NOT found" FORCE)
-  # Best to warn users that without the mk file there is no way to find ESMF
-  if(NOT DEFINED ESMFMKFILE)
-    message(WARNING "ESMFMKFILE not defined. This is the path to esmf.mk file. Without this filepath, ESMF_FOUND will always be FALSE.")
+# Set ESMFMKFILE as defined by system env variable. If it's not explicitly set
+# try to find esmf.mk file in default locations (ESMF_ROOT, CMAKE_PREFIX_PATH,
+# etc)
+if(NOT DEFINED ESMFMKFILE)
+  if(NOT DEFINED ENV{ESMFMKFILE})
+    find_path(ESMFMKFILE_PATH esmf.mk PATH_SUFFIXES lib lib64)
+    if(ESMFMKFILE_PATH)
+      set(ESMFMKFILE ${ESMFMKFILE_PATH}/esmf.mk)
+      message(STATUS "Found esmf.mk file ${ESMFMKFILE}")
+    endif()
+  else()
+    set(ESMFMKFILE $ENV{ESMFMKFILE})
   endif()
 endif()
 
 # Only parse the mk file if it is found
-if(ESMF_FOUND)
+if(EXISTS ${ESMFMKFILE})
+  set(ESMFMKFILE ${ESMFMKFILE} CACHE FILEPATH "Path to esmf.mk file")
+  set(ESMF_FOUND TRUE CACHE BOOL "esmf.mk file found" FORCE)
+
   # Read the mk file
   file(STRINGS "${ESMFMKFILE}" esmfmkfile_contents)
   # Parse each line in the mk file
@@ -70,20 +70,69 @@ if(ESMF_FOUND)
       endif()
     endif()
   endforeach()
+
+  # Construct ESMF_VERSION from ESMF_VERSION_STRING_GIT
+  # ESMF_VERSION_MAJOR and ESMF_VERSION_MINOR are defined in ESMFMKFILE
+  set(ESMF_VERSION 0)
+  set(ESMF_VERSION_PATCH ${ESMF_VERSION_REVISION})
+  set(ESMF_BETA_RELEASE FALSE)
+  if(ESMF_VERSION_BETASNAPSHOT MATCHES "^('T')$")
+    set(ESMF_BETA_RELEASE TRUE)
+    if(ESMF_VERSION_STRING_GIT MATCHES "^ESMF.*beta_snapshot_[0-9]")
+      string(REGEX REPLACE "^ESMF.*beta_snapshot_\([0-9]*\).*" "\\1" ESMF_BETA_SNAPSHOT "${ESMF_VERSION_STRING_GIT}")
+    elseif(ESMF_VERSION_STRING_GIT MATCHES "^v.*b[0-9]")
+      string(REGEX REPLACE "^v.*b\([0-9]*\).*" "\\1" ESMF_BETA_SNAPSHOT "${ESMF_VERSION_STRING_GIT}")
+    else()
+      set(ESMF_BETA_SNAPSHOT 0)
+    endif()
+    message(STATUS "Detected ESMF Beta snapshot ${ESMF_BETA_SNAPSHOT}")
+  endif()
+  set(ESMF_VERSION "${ESMF_VERSION_MAJOR}.${ESMF_VERSION_MINOR}.${ESMF_VERSION_PATCH}")
+
+  # Find the ESMF library
+  if(USE_ESMF_STATIC_LIBS)
+    find_library(ESMF_LIBRARY_LOCATION NAMES libesmf.a PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
+    if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
+      message(WARNING "Static ESMF library (libesmf.a) not found in \
+                       ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
+    endif()
+    add_library(ESMF STATIC IMPORTED)
+  else()
+    find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
+    if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
+      message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
+    endif()
+    add_library(ESMF UNKNOWN IMPORTED)
+  endif()
+
+  # Add ESMF include directories
+  set(ESMF_INCLUDE_DIRECTORIES "")
+  separate_arguments(_ESMF_F90COMPILEPATHS NATIVE_COMMAND ${ESMF_F90COMPILEPATHS})
+  foreach(_ITEM ${_ESMF_F90COMPILEPATHS})
+    string(REGEX REPLACE "^-I" "" _ITEM "${_ITEM}")
+    list(APPEND ESMF_INCLUDE_DIRECTORIES ${_ITEM})
+  endforeach()
+
+  # Add ESMF link libraries
+  string(STRIP "${ESMF_F90ESMFLINKRPATHS} ${ESMF_F90ESMFLINKPATHS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKLIBS} ${ESMF_F90LINKOPTS}" ESMF_INTERFACE_LINK_LIBRARIES)
+
+  # Finalize find_package
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(
+        ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS ESMF_LIBRARY_LOCATION
+                      ESMF_INTERFACE_LINK_LIBRARIES
+                      ESMF_F90COMPILEPATHS
+        VERSION_VAR ESMF_VERSION)
+
+  set_target_properties(ESMF PROPERTIES
+        IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
+        INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+
+else()
+  set(ESMF_FOUND FALSE CACHE BOOL "esmf.mk file NOT found" FORCE)
+  message(WARNING "ESMFMKFILE ${ESMFMKFILE} not found. Try setting ESMFMKFILE \
+                   to esmf.mk location.")
 endif()
-
-# Creates a CMake target so that users can use it natively
-add_library(ESMF UNKNOWN IMPORTED)
-
-# Find the ESMF library
-find_library(ESMFLIB NAMES esmf PATHS ${ESMF_LIBSDIR})
-
-# Prepare the compile options list
-string(REPLACE " " ";" COMPILEOPTS "${ESMF_F90COMPILEOPTS} ${ESMF_F90COMPILEPATHS} ${ESMF_F90COMPILEFREECPP} ${ESMF_F90COMPILECPPFLAGS}")
-
-# Set appropriate COMPILE and LINK options
-set_target_properties(ESMF PROPERTIES
-       IMPORTED_LOCATION ${ESMFLIB}
-       INTERFACE_COMPILE_OPTIONS "${COMPILEOPTS}"
-       INTERFACE_LINK_LIBRARIES "${ESMF_F90LINKOPTS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKRPATHS} ${ESMF_F90ESMFLINKLIBS}")
-

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -11,65 +11,65 @@
 
 
 # Add the ESMFMKFILE path to the cache if defined as system env variable
-if (DEFINED ENV{ESMFMKFILE} AND NOT DEFINED ESMFMKFILE)
-    set(ESMFMKFILE $ENV{ESMFMKFILE} CACHE FILEPATH "Path to ESMF mk file")
-endif ()
+if(DEFINED ENV{ESMFMKFILE} AND NOT DEFINED ESMFMKFILE)
+  set(ESMFMKFILE $ENV{ESMFMKFILE} CACHE FILEPATH "Path to ESMF mk file")
+endif()
 
 # Found the mk file and ESMF exists on the system
-if (EXISTS ${ESMFMKFILE})
-    set(ESMF_FOUND TRUE CACHE BOOL "ESMF mk file found" FORCE)
-    # Did not find the ESMF mk file
+if(EXISTS ${ESMFMKFILE})
+  set(ESMF_FOUND TRUE CACHE BOOL "ESMF mk file found" FORCE)
+  # Did not find the ESMF mk file
 else()
-    set(ESMF_FOUND FALSE CACHE BOOL "ESMF mk file NOT found" FORCE)
-    # Best to warn users that without the mk file there is no way to find ESMF
-    if (NOT DEFINED ESMFMKFILE)
-        message(WARNING "ESMFMKFILE not defined. This is the path to esmf.mk file. Without this filepath, ESMF_FOUND will always be FALSE.")
-    endif ()
+  set(ESMF_FOUND FALSE CACHE BOOL "ESMF mk file NOT found" FORCE)
+  # Best to warn users that without the mk file there is no way to find ESMF
+  if(NOT DEFINED ESMFMKFILE)
+    message(WARNING "ESMFMKFILE not defined. This is the path to esmf.mk file. Without this filepath, ESMF_FOUND will always be FALSE.")
+  endif()
 endif()
 
 # Only parse the mk file if it is found
-if (ESMF_FOUND)
-    # Read the mk file
-    file(STRINGS "${ESMFMKFILE}" esmfmkfile_contents)
-    # Parse each line in the mk file
-    foreach(str ${esmfmkfile_contents})
-        # Only consider uncommented lines
-        string(REGEX MATCH "^[^#]" def ${str})
-        # Line is not commented
-        if (def)
-            # Extract the variable name
-            string(REGEX MATCH "^[^=]+" esmf_varname ${str})
-            # Extract the variable's value
-            string(REGEX MATCH "=.+$" esmf_vardef ${str})
-            # Only for variables with a defined value
-            if (esmf_vardef)
-                # Get rid of the assignment string
-                string(SUBSTRING ${esmf_vardef} 1 -1 esmf_vardef)
-                # Remove whitespace
-                string(STRIP ${esmf_vardef} esmf_vardef)
-                # A string or single-valued list
-                if(NOT DEFINED ESMF_MKGLOBALS)
-                    # Set in global scope
-                    set(${esmf_varname} ${esmf_vardef})
-                    # Don't display by default in GUI
-                    mark_as_advanced(esmf_varname)
-                else() # Need to filter global promotion
-                    foreach(m ${ESMF_MKGLOBALS})
-                        string(FIND ${esmf_varname} ${m} match)
-                        # Found the string
-                        if(NOT ${match} EQUAL -1)
-                            # Promote to global scope
-                            set(${esmf_varname} ${esmf_vardef})
-                            # Don't display by default in the GUI
-                            mark_as_advanced (esmf_varname)
-                            # No need to search for the current string filter
-                            break()
-                        endif()
-                    endforeach()
-                endif()
+if(ESMF_FOUND)
+  # Read the mk file
+  file(STRINGS "${ESMFMKFILE}" esmfmkfile_contents)
+  # Parse each line in the mk file
+  foreach(str ${esmfmkfile_contents})
+    # Only consider uncommented lines
+    string(REGEX MATCH "^[^#]" def ${str})
+    # Line is not commented
+    if(def)
+      # Extract the variable name
+      string(REGEX MATCH "^[^=]+" esmf_varname ${str})
+      # Extract the variable's value
+      string(REGEX MATCH "=.+$" esmf_vardef ${str})
+      # Only for variables with a defined value
+      if(esmf_vardef)
+        # Get rid of the assignment string
+        string(SUBSTRING ${esmf_vardef} 1 -1 esmf_vardef)
+        # Remove whitespace
+        string(STRIP ${esmf_vardef} esmf_vardef)
+        # A string or single-valued list
+        if(NOT DEFINED ESMF_MKGLOBALS)
+          # Set in global scope
+          set(${esmf_varname} ${esmf_vardef})
+          # Don't display by default in GUI
+          mark_as_advanced(esmf_varname)
+        else() # Need to filter global promotion
+          foreach(m ${ESMF_MKGLOBALS})
+            string(FIND ${esmf_varname} ${m} match)
+            # Found the string
+            if(NOT ${match} EQUAL -1)
+              # Promote to global scope
+              set(${esmf_varname} ${esmf_vardef})
+              # Don't display by default in the GUI
+              mark_as_advanced(esmf_varname)
+              # No need to search for the current string filter
+              break()
             endif()
+          endforeach()
         endif()
-    endforeach()
+      endif()
+    endif()
+  endforeach()
 endif()
 
 # Creates a CMake target so that users can use it natively


### PR DESCRIPTION
TYPE: feature enhancement

KEYWORDS: build, CMake, FindESMF.cmake

SOURCE: Daniel Rosen, NCAR; Dusan Jovic, EMC

DESCRIPTION OF CHANGES: Enhances FindESMF.cmake module

- Searches for esmf.mk using ESMF_ROOT if ESMFMKFILE is not set
- Constructs version string information including beta version
- Strips -I from ESMF_F90COMPILEPATHS then adds them to INTERFACE_INCLUDE_DIRECTORIES instead of compile options
- Searches for static library if USE_ESMF_STATIC_LIBS=ON
- Fixes bug in find_library by adding NO_DEFAULT_PATH
- Updates CMake requirement to v3.12 and above

ISSUES:
Closes: https://github.com/esmf-org/esmf-support/issues/131

TESTING

OS X Catalina 10.15.7 with gcc-9.4.0, openmpi-3.0.0, and netcdf-4.7.0

built, installed, and executed using CMake prototype
updated and tested with esmf-extended-tests
[https://github.com/esmf-org/esmf-extended-tests/tree/develop/ESMF_HelloWorld_CMake](https://github.com/esmf-org/esmf-extended-tests/tree/develop/ESMF_HelloWorld_CMake)
