### PR TITLE
Fix documentation for NUOPC_CompAttributeIngest

### DIFF
--- a/src/addon/NUOPC/src/NUOPC_Comp.F90
+++ b/src/addon/NUOPC/src/NUOPC_Comp.F90
@@ -545,7 +545,11 @@ module NUOPC_Comp
 !   convention {\tt NUOPC} and purpose {\tt Instance}.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_GridCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -634,7 +638,11 @@ module NUOPC_Comp
 !   convention {\tt NUOPC} and purpose {\tt Instance}.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_CplCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -723,7 +731,11 @@ module NUOPC_Comp
 !   convention {\tt NUOPC} and purpose {\tt Instance}.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_GridCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -811,7 +823,11 @@ module NUOPC_Comp
 !   convention {\tt NUOPC} and purpose {\tt Instance}.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_CplCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -903,7 +919,11 @@ module NUOPC_Comp
 !   the attribute is not present or not set.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_GridCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -1042,7 +1062,11 @@ module NUOPC_Comp
 !   the attribute is not present or not set.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_CplCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -1181,7 +1205,11 @@ module NUOPC_Comp
 !   the attribute is not present or not set.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_GridCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -1318,7 +1346,11 @@ module NUOPC_Comp
 !   the attribute is not present or not set.
 !
 !   Unless {\tt isPresent} and {\tt isSet} are provided, return with error if 
-!   the Attribute is not present or not set, respectively.
+!   the attribute is not present or not set, respectively.
+!
+!   Note that attributes ingested by {\tt NUOPC\_CompAttributeIngest()} are
+!   stored and returned as type character string.
+!   See \ref{NUOPC_CplCompAttributeIng} for details.
 !
 !   The arguments are:
 !   \begin{description}
@@ -1445,10 +1477,16 @@ module NUOPC_Comp
     logical,                intent(in),  optional :: addFlag
     integer,                intent(out), optional :: rc
 ! !DESCRIPTION:
+!   \label{NUOPC_GridCompAttributeIng}
 !   Ingest the Attributes from a FreeFormat object onto the highest level
 !   of the standard NUOPC AttPack hierarchy (convention="NUOPC", 
 !   purpose="Instance").
-! 
+!
+!   Important: Attributes ingested by this method are stored as type character
+!   strings, and must be accessed accordingly. Conversion from string into a
+!   different data type, e.g. {\tt integer} or {\tt real}, is the user's
+!   responsibility.
+!
 !   If {\tt addFlag} is {\tt .false.} (default), an error will be returned if 
 !   an attribute is to be ingested that was not previously added to the 
 !   {\tt comp} object. If {\tt addFlag} is {\tt .true.}, all missing attributes
@@ -1590,10 +1628,16 @@ module NUOPC_Comp
     logical,                intent(in),  optional :: addFlag
     integer,                intent(out), optional :: rc
 ! !DESCRIPTION:
+!   \label{NUOPC_CplCompAttributeIng}
 !   Ingest the Attributes from a FreeFormat object onto the highest level
 !   of the standard NUOPC AttPack hierarchy (convention="NUOPC", 
 !   purpose="Instance").
-! 
+!
+!   Important: Attributes ingested by this method are stored as type character
+!   strings, and must be accessed accordingly. Conversion from string into a
+!   different data type, e.g. {\tt integer} or {\tt real}, is the user's
+!   responsibility.
+!
 !   If {\tt addFlag} is {\tt .false.} (default), an error will be returned if 
 !   an attribute is to be ingested that was not previously added to the 
 !   {\tt comp} object. If {\tt addFlag} is {\tt .true.}, all missing attributes


### PR DESCRIPTION
TYPE: documentation fix

KEYWORDS: documentation, NUOPC, NUOPC_CompAttributeIngest

SOURCE: Daniel Rosen, NCAR; Jim Edwards, NCAR

DESCRIPTION OF CHANGES: Updates NUOPC_CompAttributeIngest in NUOPC Reference Manual

- NUOPC_CompAttributeIngest creates all attributes as type character string
- Adds information for NUOPC_CompAttributeGet

ISSUES:
https://github.com/esmf-org/esmf-support/issues/140
*partially completes above issue

TESTING

OS X Catalina 10.15.7 with gcc-9.4.0, openmpi-3.0.0, and netcdf-4.7.0

built NUOPC reference manual
