### PR TITLE
Fix Resource File line limit

### DIFF
--- a/src/Infrastructure/Config/doc/Config_usage.tex
+++ b/src/Infrastructure/Config/doc/Config_usage.tex
@@ -3,7 +3,7 @@
  \subsubsection{Resource files}
 
    A {\em Resource File (RF)} is a text file consisting of list of 
-   {\em label}-{\em value} pairs. There is a limit of 250 characters 
+   {\em label}-{\em value} pairs. There is a limit of 1024 characters 
    per line and the Resource File can contain a maximum of 200 records. 
    Each {\em label} should be followed by some data, the {\em value}. 
    An example Resource File follows.  It is the file used in the example 

--- a/src/Infrastructure/Config/src/ESMF_Config.F90
+++ b/src/Infrastructure/Config/src/ESMF_Config.F90
@@ -179,7 +179,6 @@
 !------------------------------------------------------------------------------
 ! Revised parameter table to fit Fortran 90 standard.
 
-!       integer,   parameter :: LSZ = 256  ! Maximum line size
        integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
                                           ! should be at least long enough
                                           ! to read in a file name with full


### PR DESCRIPTION
TYPE: documentation fix

KEYWORDS: documentation, ESMF_ConfigGetLen, Resource File

SOURCE: Daniel Rosen, NCAR

DESCRIPTION OF CHANGES: Updates Resource File line limit in ESMF Reference Manual [46.1.2 Resource files](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node6.html#SECTION06091200000000000000)
* see LSZ parameter in ESMF_Config.F90
* remove commented out LSZ code

ISSUES:
https://github.com/esmf-org/esmf-support/issues/155