### PR TITLE
Allow to query allocation status of LocalArray, Array and Field

### DIFF
--- a/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
@@ -137,7 +137,7 @@ contains
     tileCount, minIndexPTile, maxIndexPTile, deToTileMap, indexCountPDe, &
     delayout, deCount, localDeCount, ssiLocalDeCount, localDeToDeMap, &
     localDeList, &    ! DEPRECATED ARGUMENT
-    isESMFallocated, &
+    isESMFAllocated, &
     name, vm, rc)
 !
 ! !ARGUMENTS:
@@ -176,7 +176,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer,                       intent(out), optional :: ssiLocalDeCount
     integer,                       intent(out), optional :: localDeToDeMap(:)
     integer,                       intent(out), optional :: localDeList(:)     ! DEPRECATED ARGUMENT
-    logical,                       intent(out), optional :: isESMFallocated
+    logical,                       intent(out), optional :: isESMFAllocated
     character(len=*),              intent(out), optional :: name
     type(ESMF_VM),                 intent(out), optional :: vm
     integer,                       intent(out), optional :: rc  
@@ -195,7 +195,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !              between PETs on the same single system image (SSI).\newline
 !              Added argument {\tt vm} in order to offer information about the
 !              VM on which the Array was created.
-! \item[8.3.0] Added argument {\tt isESMFallocated}.
+! \item[8.3.0] Added argument {\tt isESMFAllocated}.
 ! \end{description}
 ! \end{itemize}
 !         
@@ -347,7 +347,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !     {\tt ssiLocalDeCount}, and will be filled accordingly.
 !   \item[{[localDeList]}]
 !     \apiDeprecatedArgWithReplacement{localDeToDeMap}
-!   \item[{[isESMFallocated]}]
+!   \item[{[isESMFAllocated]}]
 !     If .TRUE., the data associated with the Array allocated internally by ESMF.
 !   \item [{[name]}]
 !     Name of the Array object.
@@ -578,7 +578,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       ESMF_CONTEXT, rcToReturn=rc)) return
 
     ! Obtain dealloc information
-    if (present(isESMFallocated)) then
+    if (present(isESMFAllocated)) then
       do i=1, opt_ssiLocalDeCount
         call c_ESMC_ArrayGetLArray(array, i, localArray, localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
@@ -587,9 +587,9 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
         if (dealloc.eq.ESMF_TRUE) then
-          isESMFallocated = .true.
+          isESMFAllocated = .true.
         else
-          isESMFallocated = .false.
+          isESMFAllocated = .false.
         end if
       end do
     end if

--- a/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
@@ -579,6 +579,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
     ! Obtain dealloc information
     if (present(isESMFAllocated)) then
+      isESMFAllocated = .false.
       do i=1, opt_ssiLocalDeCount
         call c_ESMC_ArrayGetLArray(array, i, localArray, localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
@@ -588,8 +589,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
           ESMF_CONTEXT, rcToReturn=rc)) return
         if (dealloc.eq.ESMF_TRUE) then
           isESMFAllocated = .true.
-        else
-          isESMFAllocated = .false.
         end if
       end do
     end if

--- a/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
@@ -137,6 +137,7 @@ contains
     tileCount, minIndexPTile, maxIndexPTile, deToTileMap, indexCountPDe, &
     delayout, deCount, localDeCount, ssiLocalDeCount, localDeToDeMap, &
     localDeList, &    ! DEPRECATED ARGUMENT
+    isESMFallocated, &
     name, vm, rc)
 !
 ! !ARGUMENTS:
@@ -175,6 +176,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer,                       intent(out), optional :: ssiLocalDeCount
     integer,                       intent(out), optional :: localDeToDeMap(:)
     integer,                       intent(out), optional :: localDeList(:)     ! DEPRECATED ARGUMENT
+    logical,                       intent(out), optional :: isESMFallocated
     character(len=*),              intent(out), optional :: name
     type(ESMF_VM),                 intent(out), optional :: vm
     integer,                       intent(out), optional :: rc  
@@ -193,6 +195,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !              between PETs on the same single system image (SSI).\newline
 !              Added argument {\tt vm} in order to offer information about the
 !              VM on which the Array was created.
+! \item[8.3.0] Added argument {\tt isESMFallocated}.
 ! \end{description}
 ! \end{itemize}
 !         
@@ -344,6 +347,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !     {\tt ssiLocalDeCount}, and will be filled accordingly.
 !   \item[{[localDeList]}]
 !     \apiDeprecatedArgWithReplacement{localDeToDeMap}
+!   \item[{[isESMFallocated]}]
+!     If .TRUE., the data associated with the Array allocated internally by ESMF.
 !   \item [{[name]}]
 !     Name of the Array object.
 !   \item [{[vm}]
@@ -379,6 +384,9 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     type(ESMF_InterArray)           :: localDeToDeMapArg      ! helper variable
     type(ESMF_DistGrid)             :: opt_distgrid           ! helper variable
     type(ESMF_DELayout)             :: opt_delayout           ! helper variable
+    type(ESMF_Logical)              :: dealloc                ! helper variable
+    type(ESMF_LocalArray)           :: localArray             ! helper variable
+
 
     ! Initialize return code
     localrc = ESMF_RC_NOT_IMPL
@@ -386,7 +394,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     
     ! Check init status of arguments
     ESMF_INIT_CHECK_DEEP(ESMF_ArrayGetInit, array, rc)
-    
+
     ! Deal with (optional) array arguments
     if (present(localarrayList)) then
       len_localarrayPtrList = size(localarrayList)
@@ -568,6 +576,23 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       localDeCount=localDeCount, rc=localrc)
     if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
       ESMF_CONTEXT, rcToReturn=rc)) return
+
+    ! Obtain dealloc information
+    if (present(isESMFallocated)) then
+      do i=1, opt_ssiLocalDeCount
+        call c_ESMC_ArrayGetLArray(array, i, localArray, localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        call c_ESMC_LocalArrayGetDealloc(localArray, dealloc, localrc) 
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        if (dealloc.eq.ESMF_TRUE) then
+          isESMFallocated = .true.
+        else
+          isESMFallocated = .false.
+        end if
+      end do
+    end if
       
     ! Deal with optional arguments that were already queried internally
     if (present(typekind)) typekind = opt_typekind

--- a/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
@@ -81,6 +81,7 @@ program ESMF_ArrayCreateGetUTest
   logical:: isCreated
   logical:: dataCorrect
   logical:: ssiSharedMemoryEnabled
+  logical:: isESMFallocated
 
   integer:: count
 
@@ -444,6 +445,14 @@ program ESMF_ArrayCreateGetUTest
   farrayPtr2D     = real(localPet+20, ESMF_KIND_R8)  ! fill with data to check
   arrayCpy = ESMF_ArrayCreate(array, datacopyflag=ESMF_DATACOPY_VALUE, rc=rc)
   call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+
+  !------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "ArrayGet isESMFallocated from Array Copy (VALUE) Test"
+  write(failMsg, *) "Did not return .true."
+  call ESMF_ArrayGet(arrayCpy, isESMFallocated=isESMFallocated, rc=rc)
+  print *, "Array is allocated internally: ", isESMFallocated
+  call ESMF_Test(isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
   
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
@@ -536,6 +545,14 @@ program ESMF_ArrayCreateGetUTest
   farrayPtr2D     = real(localPet+30, ESMF_KIND_R8)  ! fill with data to check
   arrayCpy = ESMF_ArrayCreate(array, datacopyflag=ESMF_DATACOPY_REFERENCE, rc=rc)
   call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+
+  !------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "ArrayGet isESMFallocated from Array Copy (REF) Test"
+  write(failMsg, *) "Did not return .false."
+  call ESMF_ArrayGet(arrayCpy, isESMFallocated=isESMFallocated, rc=rc)
+  print *, "Array is allocated internally: ", isESMFallocated
+  call ESMF_Test(.not.isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
 
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only

--- a/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
@@ -81,7 +81,7 @@ program ESMF_ArrayCreateGetUTest
   logical:: isCreated
   logical:: dataCorrect
   logical:: ssiSharedMemoryEnabled
-  logical:: isESMFallocated
+  logical:: isESMFAllocated
 
   integer:: count
 
@@ -448,11 +448,11 @@ program ESMF_ArrayCreateGetUTest
 
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
-  write(name, *) "ArrayGet isESMFallocated from Array Copy (VALUE) Test"
+  write(name, *) "ArrayGet isESMFAllocated from Array Copy (VALUE) Test"
   write(failMsg, *) "Did not return .true."
-  call ESMF_ArrayGet(arrayCpy, isESMFallocated=isESMFallocated, rc=rc)
-  print *, "Array is allocated internally: ", isESMFallocated
-  call ESMF_Test(isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
+  call ESMF_ArrayGet(arrayCpy, isESMFAllocated=isESMFAllocated, rc=rc)
+  print *, "Array is allocated internally: ", isESMFAllocated
+  call ESMF_Test(isESMFAllocated, name, failMsg, result, ESMF_SRCLINE)
   
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
@@ -548,11 +548,11 @@ program ESMF_ArrayCreateGetUTest
 
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
-  write(name, *) "ArrayGet isESMFallocated from Array Copy (REF) Test"
+  write(name, *) "ArrayGet isESMFAllocated from Array Copy (REF) Test"
   write(failMsg, *) "Did not return .false."
-  call ESMF_ArrayGet(arrayCpy, isESMFallocated=isESMFallocated, rc=rc)
-  print *, "Array is allocated internally: ", isESMFallocated
-  call ESMF_Test(.not.isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
+  call ESMF_ArrayGet(arrayCpy, isESMFAllocated=isESMFAllocated, rc=rc)
+  print *, "Array is allocated internally: ", isESMFAllocated
+  call ESMF_Test(.not.isESMFAllocated, name, failMsg, result, ESMF_SRCLINE)
 
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only

--- a/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
@@ -116,7 +116,8 @@ contains
     gridindex, gridToFieldMap, ungriddedLBound, ungriddedUBound, &
     totalLWidth, totalUWidth, localDeCount, ssiLocalDeCount, &
     localDeToDeMap, minIndex, maxIndex, elementCount, &
-    localMinIndex, localMaxIndex, localElementCount, name, vm, rc)
+    localMinIndex, localMaxIndex, localElementCount, name, vm, &
+    isESMFAllocated, rc)
 !
 ! !ARGUMENTS:
     type(ESMF_Field),           intent(in)            :: field
@@ -153,6 +154,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer,                    intent(out), optional :: localElementCount(:)
     character(len=*),           intent(out), optional :: name
     type(ESMF_VM),              intent(out), optional :: vm
+    logical,                    intent(out), optional :: isESMFAllocated
     integer,                    intent(out), optional :: rc
 !
 ! !STATUS:
@@ -340,12 +342,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 ! \item[{[localElementCount]}]
 !     Upon return this holds the PET local number of items of the field data.
 !     {\tt localElementCount} must be allocated to be of size equal to the field rank.
-! \item [{[name]}]
+! \item[{[name]}]
 !       Name of queried item.
-! \item [{[vm]}]
+! \item[{[vm]}]
 !       The VM on which the Field object was created.
+! \item[{[isESMFAllocated]}]
+!     If .TRUE., the data associated with the Array allocated internally by ESMF.
 ! \item [{[rc]}]
-!       Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
+!     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 ! \end{description}
 !EOP
 !------------------------------------------------------------------------------
@@ -368,6 +372,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     type(ESMF_Grid)             :: l_grid
     type(ESMF_Mesh)             :: l_mesh
     type(ESMF_DistGrid)         :: distgrid
+    type(ESMF_Logical)          :: dealloc
+    type(ESMF_LocalArray)       :: localArray
 
     ! Initialize
     localrc = ESMF_RC_NOT_IMPL
@@ -920,6 +926,20 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
           ESMF_CONTEXT, rcToReturn=rc)) return
         ESMF_INIT_CHECK_DEEP(ESMF_VMGetInit, vm, rc)
     endif
+
+    ! Obtain dealloc information
+    if (present(isESMFAllocated)) then
+      call ESMF_FieldGetLocalArray(field, localArray, localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      call c_ESMC_LocalArrayGetDealloc(localArray, dealloc, localrc) 
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      isESMFAllocated = .false.
+      if (dealloc.eq.ESMF_TRUE) then
+        isESMFAllocated = .true.
+      end if
+    end if
 
     if (present(rc)) rc = ESMF_SUCCESS
 

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
@@ -294,7 +294,7 @@ contains
 ! !INTERFACE:
   ! Private name; call using ESMF_LocalArrayGet()
   subroutine ESMF_LocalArrayGetDefault(localarray, keywordEnforcer, &
-    typekind, rank, totalCount, totalLBound, totalUBound, rc)
+    typekind, rank, totalCount, totalLBound, totalUBound, isESMFallocated, rc)
 !
 ! !ARGUMENTS:
     type(ESMF_LocalArray),      intent(in)            :: localarray
@@ -304,6 +304,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer,                    intent(out), optional :: totalCount(:)
     integer,                    intent(out), optional :: totalLBound(:)
     integer,                    intent(out), optional :: totalUBound(:)
+    logical,                    intent(out), optional :: isESMFallocated
     integer,                    intent(out), optional :: rc             
 !
 ! !STATUS:
@@ -328,6 +329,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !     Lower bound per dimension.
 !   \item[{[totalUBound]}]
 !     Upper bound per dimension.
+!   \item[{[isESMFallocated]}]
+!     If .TRUE., the LocalArray object allocated internally by ESMF.
 !   \item[{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 !   \end{description}
@@ -336,6 +339,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer :: localrc    ! local return code
     integer :: lrank      ! Local use to get rank
+    type(ESMF_Logical) :: dealloc       ! do we need to free space?
 
     ! Initialize return code; assume routine not implemented
     if (present(rc)) rc = ESMF_RC_NOT_IMPL
@@ -398,6 +402,18 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
     endif
+
+    if (present(isESMFallocated)) then
+      call c_esmc_localarraygetdealloc(localarray, dealloc, localrc)
+      if (dealloc.eq.ESMF_TRUE) then
+        isESMFallocated = .true.
+      else
+        isESMFallocated = .false.
+      end if
+      if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    end if
 
     ! Return successfully
     if (present(rc)) rc = ESMF_SUCCESS

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
@@ -294,7 +294,7 @@ contains
 ! !INTERFACE:
   ! Private name; call using ESMF_LocalArrayGet()
   subroutine ESMF_LocalArrayGetDefault(localarray, keywordEnforcer, &
-    typekind, rank, totalCount, totalLBound, totalUBound, isESMFallocated, rc)
+    typekind, rank, totalCount, totalLBound, totalUBound, isESMFAllocated, rc)
 !
 ! !ARGUMENTS:
     type(ESMF_LocalArray),      intent(in)            :: localarray
@@ -304,7 +304,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer,                    intent(out), optional :: totalCount(:)
     integer,                    intent(out), optional :: totalLBound(:)
     integer,                    intent(out), optional :: totalUBound(:)
-    logical,                    intent(out), optional :: isESMFallocated
+    logical,                    intent(out), optional :: isESMFAllocated
     integer,                    intent(out), optional :: rc             
 !
 ! !STATUS:
@@ -329,7 +329,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !     Lower bound per dimension.
 !   \item[{[totalUBound]}]
 !     Upper bound per dimension.
-!   \item[{[isESMFallocated]}]
+!   \item[{[isESMFAllocated]}]
 !     If .TRUE., the LocalArray object allocated internally by ESMF.
 !   \item[{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -403,12 +403,12 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
     endif
 
-    if (present(isESMFallocated)) then
+    if (present(isESMFAllocated)) then
       call c_esmc_localarraygetdealloc(localarray, dealloc, localrc)
       if (dealloc.eq.ESMF_TRUE) then
-        isESMFallocated = .true.
+        isESMFAllocated = .true.
       else
-        isESMFallocated = .false.
+        isESMFAllocated = .false.
       end if
       if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &

--- a/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayUTest.F90
+++ b/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayUTest.F90
@@ -36,7 +36,7 @@
     integer(ESMF_KIND_I4), dimension(:), pointer :: intptr
     logical:: localarrayBool
     logical:: isCreated
-    logical:: isESMFallocated
+    logical:: isESMFAllocated
 
     ! individual test failure message
     character(ESMF_MAXSTR) :: failMsg
@@ -100,9 +100,9 @@
     !NEX_UTest
     write(failMsg, *) "Did not return .false."
     write(name, *) "Testing LocalArray is allocated internally or not for docpy ESMF_DATACOPY_REFERENCE"
-    call ESMF_LocalArrayGet(array1, isESMFallocated=isESMFallocated, rc=rc)
-    print *, "isESMFallocated = ", isESMFallocated
-    call ESMF_Test(.not. isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
+    call ESMF_LocalArrayGet(array1, isESMFAllocated=isESMFAllocated, rc=rc)
+    print *, "isESMFAllocated = ", isESMFAllocated
+    call ESMF_Test(.not. isESMFAllocated, name, failMsg, result, ESMF_SRCLINE)
 
   !------------------------------------------------------------------------
   !NEX_UTest
@@ -699,9 +699,9 @@
     !EX_UTest
     write(failMsg, *) "Did not return .true."
     write(name, *) "Testing LocalArray is allocated internally or not for docpy ESMF_DATACOPY_VALUE"
-    call ESMF_LocalArrayGet(array2, isESMFallocated=isESMFallocated, rc=rc)
-    print *, "isESMFallocated = ", isESMFallocated
-    call ESMF_Test(isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
+    call ESMF_LocalArrayGet(array2, isESMFAllocated=isESMFAllocated, rc=rc)
+    print *, "isESMFAllocated = ", isESMFAllocated
+    call ESMF_Test(isESMFAllocated, name, failMsg, result, ESMF_SRCLINE)
 
     !--------------------------------------------------------------------------
    !EX_UTest

--- a/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayUTest.F90
+++ b/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayUTest.F90
@@ -36,6 +36,7 @@
     integer(ESMF_KIND_I4), dimension(:), pointer :: intptr
     logical:: localarrayBool
     logical:: isCreated
+    logical:: isESMFallocated
 
     ! individual test failure message
     character(ESMF_MAXSTR) :: failMsg
@@ -95,7 +96,13 @@
     array1 = ESMF_LocalArrayCreate(intptr, datacopyflag=ESMF_DATACOPY_REFERENCE, rc=rc)
     call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
    
-
+    !--------------------------------------------------------------------------
+    !NEX_UTest
+    write(failMsg, *) "Did not return .false."
+    write(name, *) "Testing LocalArray is allocated internally or not for docpy ESMF_DATACOPY_REFERENCE"
+    call ESMF_LocalArrayGet(array1, isESMFallocated=isESMFallocated, rc=rc)
+    print *, "isESMFallocated = ", isESMFallocated
+    call ESMF_Test(.not. isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
 
   !------------------------------------------------------------------------
   !NEX_UTest
@@ -205,7 +212,7 @@
     write(failMsg, *) "Did return ESMF_SUCCESS"
     array1 = ESMF_LocalArrayCreate(rank=1, typekind=ESMF_TYPEKIND_I4, rc=rc)
     call ESMF_Test((rc.ne.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
-   
+
     !--------------------------------------------------------------------------
     !NEX_UTest
     write(name, *) "Creating a LocalArray from TKR with counts and without lbounds, ubounds"
@@ -341,7 +348,7 @@
     nullify(real3dptr) ! make sure real3dptr is unassociated
     array1 = ESMF_LocalArrayCreate(real3dptr, datacopyflag=ESMF_DATACOPY_VALUE, rc=rc)
     call ESMF_Test((rc.ne.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
-   
+
 #ifdef ESMF_TESTEXHAUSTIVE
 
     !--------------------------------------------------------------------------
@@ -687,6 +694,14 @@
     call ESMF_LocalArrayGet(array2, realptr2, datacopyflag=ESMF_DATACOPY_REFERENCE, rc=rc)
     print *, "array 2c get returned"
     print *, "realptr2 data = ", realptr2(1:3,1:3)
+
+    !--------------------------------------------------------------------------
+    !EX_UTest
+    write(failMsg, *) "Did not return .true."
+    write(name, *) "Testing LocalArray is allocated internally or not for docpy ESMF_DATACOPY_VALUE"
+    call ESMF_LocalArrayGet(array2, isESMFallocated=isESMFallocated, rc=rc)
+    print *, "isESMFallocated = ", isESMFallocated
+    call ESMF_Test(isESMFallocated, name, failMsg, result, ESMF_SRCLINE)
 
     !--------------------------------------------------------------------------
    !EX_UTest


### PR DESCRIPTION
This PR aims to provide interface to allow users to query allocation status (user vs. ESMF allocated) for ESMF_LocalArrayGet(), ESMF_ArrayGet() and ESMF_FieldGet() calls. It also updates unit tests to test new functionality.