### PR TITLE
Remove ESMF_IOFMT_BIN and update PIO documentation

### DIFF
--- a/build/doc/user_arch.tex
+++ b/build/doc/user_arch.tex
@@ -3,98 +3,11 @@
 % List of architectures supported.  This file is 
 % meant to be included in a user doc.
 
-This section provides information about supported and tested 
-combinations of environment variable settings used by the ESMF
-build system. The exact configurations tested for this release
- are available online in the Supported Platform Table:
-\htmladdnormallink{http://earthsystemmodeling.org/release/platforms\_8\_1\_0}
-{http://earthsystemmodeling.org/release/platforms_8_1_0}.
+The platforms that are tested and supported depend on the release
+of ESMF.  To see the specific list of supported platforms,
+click the {\em Supported Platforms} link under one of the releases
+on the \htmladdnormallink{ESMF releases page}{http://earthsystemmodeling.org/static/releases.html}.
 
-All possible combinations of {\tt ESMF\_OS}, {\tt ESMF\_COMPILER}, {\tt ESMF\_COMM},
-and {\tt ESMF\_ABI} build environment variables are listed in the following table.
-Where multiple options exist, and the default is independent
-of {\tt ESMF\_MACHINE}, the default value is in {\bf bold}.
-A {\tt default} value in the compiler column indicates
-the vendor compiler. A {\tt mpi} value in the comm column indicates
-the vendor MPI implementation.
-
-\begin{longtable}{lllll}
-  {\bfseries\footnotesize ESMF\_OS} &{\bfseries\footnotesize ESMF\_COMPILER} & {\bfseries\footnotesize ESMF\_COMM} & {\bfseries\footnotesize ESMF\_ABI} \\
-
-AIX     &\tt default     &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 32, {\bf 64} \\
-Cygwin  &\tt g95         &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,lam,openmpi,user &\tt 32, 64 \\
-Cygwin  &\tt gfortran    &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,lam,msmpi,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt absoft      &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt g95         &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt gfortran    &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt gfortranclang &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt intel       &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,intelmpi,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt intelclang  &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,intelmpi,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt intelgcc    &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,intelmpi,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt nag         &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt pgi         &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Darwin  &\tt xlf         &\footnotesize \tt mpiuni,{\bf mpi},mpich,mpich2,mpich3,lam,openmpi,user &\tt 32 \\
-Darwin  &\tt xlfgcc      &\footnotesize \tt mpiuni,{\bf mpi},mpich,mpich2,mpich3,lam,openmpi,user &\tt 32 \\
-IRIX64  &\tt default     &\footnotesize \tt mpiuni,{\bf mpi},user     &\tt 32, {\bf 64} \\
-Linux   &\tt absoft      &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Linux   &\tt absoftintel &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,lam,openmpi,user &\tt 32, 64  \\
-Linux   &\tt g95         &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64, \\
-        &                &                              &\tt ia64\_64, \\
-        &                &                              &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium \\
-Linux   &\tt gfortran    &\footnotesize \tt {\bf mpiuni},mpi,mpt,mpich,mpich2,mpich3,mvapich2, &\tt 32, 64, \\
-        &                &\footnotesize \tt intelmpi,lam,openmpi,user                          &\tt ia64\_64, \\
-        &                &                              &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium \\
-Linux   &\tt gfortranclang &\footnotesize \tt {\bf mpiuni},mpi,mpt,mpich,mpich2,mpich3,mvapich2, &\tt 32, 64, \\
-        &                & \footnotesize \tt lam,openmpi,user                                    &\tt ia64\_64, \\
-        &                &                              &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium \\
-Linux   &\tt intel       &\footnotesize \tt {\bf mpiuni},mpi,mpt,mpich,mpich2,mpich3,mvapich2, &\tt 32, 64, \\
-        &                &\footnotesize \tt intelmpi,scalimpi,lam,openmpi,user                 &\tt ia64\_64, \\
-        &                &                              &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium, \\
-        &                &                              &\tt mic \\
-Linux   &\tt intelgcc    &\footnotesize \tt {\bf mpiuni},mpi,mpt,mpich,mpich2,mpich3,mvapich2, &\tt 32, 64, \\
-        &                &\footnotesize \tt intelmpi,lam,openmpi,user                          &\tt ia64\_64, \\
-        &                &                              &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium \\
-Linux   &\tt lahey       &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Linux   &\tt nag         &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,mvapich2,lam,openmpi,user &\tt 32, 64 \\
-Linux   &\tt nagintel    &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,lam,openmpi,user &\tt 32, 64 \\
-Linux   &\tt nvhpc       &\footnotesize \tt {\bf mpiuni},mpi,mpt,mpich,mpich2,mpich3,mvapich,mvapich2 &\tt 32, 64, \\
-        &                &\footnotesize \tt intelmpi,openmpi,user &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium \\
-Linux   &\tt pathscale   &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,lam,openmpi,user &\tt 32, 64, \\
-        &                &                              &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium \\
-Linux   &\tt pgi         &\footnotesize \tt {\bf mpiuni},mpi,mpt,mpich,mpich2,mpich3,mvapich,mvapich2 &\tt 32, 64, \\
-        &                &\footnotesize \tt intelmpi,scalimpi,lam,openmpi,user &\tt x86\_64\_32, \\
-        &                &                              &\tt x86\_64\_small, \\
-        &                &                              &\tt x86\_64\_medium \\
-Linux   &\tt pgigcc      &\footnotesize \tt {\bf mpiuni},mpich,mpich2,mpich3,lam,openmpi,user &\tt 32 \\
-Linux   &\tt sxcross     &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 32  \\
-Linux   &\tt xlf         &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 32  \\
-MinGW   &\tt gfortran    &\footnotesize \tt {\bf mpiuni},msmpi,user    &\tt 32, 64 \\
-MinGW   &\tt intel       &\footnotesize \tt {\bf mpiuni},msmpi,user    &\tt 32, 64 \\
-MinGW   &\tt intelcl     &\footnotesize \tt {\bf mpiuni},msmpi,user    &\tt 32, 64 \\
-OSF1    &\tt default     &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 64  \\
-SunOS   &\tt default     &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 32, {\bf 64} \\
-Unicos  &\tt default     &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 64  \\
-Unicos  &\tt cce         &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 64  \\
-Unicos  &\tt gfortran    &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 64  \\
-Unicos  &\tt intel       &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 64  \\
-Unicos  &\tt pathscale   &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 64  \\
-Unicos  &\tt pgi         &\footnotesize \tt mpiuni,{\bf mpi},user      &\tt 64
-
-\end{longtable}
 
 \vspace{1ex}
 

--- a/src/Infrastructure/Array/interface/ESMF_Array.F90
+++ b/src/Infrastructure/Array/interface/ESMF_Array.F90
@@ -3882,18 +3882,12 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[overwrite]}]
 !    \begin{sloppypar}
 !      A logical flag, the default is .false., i.e., existing Array data may
-!      {\em not} be overwritten. If .true., the overwrite behavior depends
-!      on the value of {\tt iofmt} as shown below:
-!    \begin{description}
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_BIN}:]\ All data in the file will
-!      be overwritten with each Array's data.
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_NETCDF, ESMF\_IOFMT\_NETCDF\_64BIT\_OFFSET}:]\ Only the
-!      data corresponding to each Array's name will be
+!      {\em not} be overwritten. If .true., only the
+!      data corresponding to the Array's name will be
 !      be overwritten. If the {\tt timeslice} option is given, only data for
 !      the given timeslice may be overwritten.
 !      Note that it is always an error to attempt to overwrite a NetCDF
 !      variable with data which has a different shape.
-!    \end{description}
 !    \end{sloppypar}
 !   \item[{[status]}]
 !    \begin{sloppypar}
@@ -3922,10 +3916,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[iofmt]}]
 !    \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !    \end{sloppypar}
 !   \item[{[rc]}]
 !    Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -3962,19 +3953,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF
     end if
 
     ! Attributes

--- a/src/Infrastructure/Array/interface/ESMF_ArrayHa.F90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayHa.F90
@@ -664,10 +664,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[iofmt]}]
 !    \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !    \end{sloppypar}
 !   \item[{[rc]}]
 !    Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -694,19 +691,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF
     end if
 
     ! Get string length

--- a/src/Infrastructure/Array/src/ESMCI_Array.C
+++ b/src/Infrastructure/Array/src/ESMCI_Array.C
@@ -4000,36 +4000,6 @@ int Array::write(
     localstatus = *status;
   }
 
-  // It is an error to supply a variable name in binary mode
-  if (ESMF_IOFMT_BIN == localiofmt) {
-    if (variableName.size() > 0) {
-      ESMC_LogDefault.MsgFoundError(ESMF_RC_ARG_BAD,
-          "NetCDF variable name not allowed in binary mode",
-          ESMC_CONTEXT, &rc);
-      return rc;
-    }
-  }
-
-  // It is an error to supply Attribute convention in binary mode
-  if (ESMF_IOFMT_BIN == localiofmt) {
-    if (convention.size() > 0) {
-      ESMC_LogDefault.MsgFoundError(ESMF_RC_ARG_BAD,
-          "NetCDF Attribute convention not allowed in binary mode",
-          ESMC_CONTEXT, &rc);
-      return rc;
-    }
-  }
-
-  // It is an error to supply Attribute purpose in binary mode
-  if (ESMF_IOFMT_BIN == localiofmt) {
-    if (purpose.size() > 0) {
-      ESMC_LogDefault.MsgFoundError(ESMF_RC_ARG_BAD,
-          "NetCDF Attribute convention not allowed in binary mode",
-          ESMC_CONTEXT, &rc);
-      return rc;
-    }
-  }
-
   DistGrid *dg = getDistGrid();
   ESMCI::Info *info_this = this->ESMC_BaseGetInfo();
   ESMCI::Info *info_dg = dg->ESMC_BaseGetInfo();

--- a/src/Infrastructure/Array/tests/ESMF_ArrayIOUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayIOUTest.F90
@@ -255,16 +255,6 @@ program ESMF_ArrayIOUTest
 
 !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
-! ! Given an ESMF array, write the binary file. Currently not supported by PIO
-  write(name, *) "Write ESMF_Array with Halo to binary Test"
-  write(failMsg, *) "Did not return ESMF_SUCCESS"
-  call ESMF_ArrayWrite(array_withhalo, fileName='file3D_withhalo.bin', &
-       status=ESMF_FILESTATUS_REPLACE, iofmt=ESMF_IOFMT_BIN, rc=rc)
-  write(failMsg, *) "Did not return ESMF_RC_LIB_NOT_PRESENT"
-  call ESMF_Test(rc /= ESMF_SUCCESS, name, failMsg, result, ESMF_SRCLINE)
-
-!------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
 ! ! Given an ESMF array, write the netCDF file.
   write(name, *) "Write ESMF_Array without Halo to NetCDF Test"
   write(failMsg, *) "Did not return ESMF_SUCCESS"
@@ -385,16 +375,6 @@ program ESMF_ArrayIOUTest
 
 !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
-! ! Read in a binary file to an ESMF array. Currently not supported by PIO
-  write(name, *) "Read ESMF_Array with Halo from binary Test"
-  write(failMsg, *) "Did not return ESMF_SUCCESS"
-  call ESMF_ArrayRead(array_withhalo3, fileName='file3D_withhalo.bin', &
-       iofmt=ESMF_IOFMT_BIN, rc=rc)
-  write(failMsg, *) "Did not return ESMF_RC_LIB_NOT_PRESENT"
-  call ESMF_Test(rc /= ESMF_SUCCESS, name, failMsg, result, ESMF_SRCLINE)
-
-!------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
 ! ! Compare read in and the existing file
   write(name, *) "Compare read in data to the existing NetCDF data - 3D with halo"
   Maxvalue(1) = 0
@@ -419,15 +399,6 @@ program ESMF_ArrayIOUTest
   deallocate (totalLWidth, totalUWidth)
   deallocate (exclusiveLBound, exclusiveUBound)
 
-!------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
-! ! Read in a binary file to an ESMF array specifying a variable.
-  write(name, *) "Read ESMF_Array variable with Halo from binary Test"
-  write(failMsg, *) "Did not return ESMF_SUCCESS"
-  call ESMF_ArrayRead(array_withhalo3, fileName='file3D_withhalo.bin', &
-       iofmt=ESMF_IOFMT_BIN, variableName='dummyname', rc=rc)
- ! Should fail since varname not supported in binary mode
-  call ESMF_Test(rc /= ESMF_SUCCESS, name, failMsg, result, ESMF_SRCLINE)
 
 !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only

--- a/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
+++ b/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
@@ -1693,10 +1693,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[iofmt]}]
 !     \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !     \end{sloppypar}
 !   \item[{[rc]}] 
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -1729,19 +1726,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF
     end if
 
     ! Call into the C++ interface, which will call IO object
@@ -3866,18 +3851,12 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[overwrite]}]
 !    \begin{sloppypar}
 !      A logical flag, the default is .false., i.e., existing Array data may
-!      {\em not} be overwritten. If .true., the overwrite behavior depends
-!      on the value of {\tt iofmt} as shown below:
-!    \begin{description}
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_BIN}:]\ All data in the file will
-!      be overwritten with each Arrays's data.
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_NETCDF, ESMF\_IOFMT\_NETCDF\_64BIT\_OFFSET}:]\ Only the
+!      {\em not} be overwritten. If .true., only the
 !      data corresponding to each Array's name will be
 !      be overwritten. If the {\tt timeslice} option is given, only data for
 !      the given timeslice may be overwritten.
 !      Note that it is always an error to attempt to overwrite a NetCDF
 !      variable with data which has a different shape.
-!    \end{description}
 !    \end{sloppypar}
 !   \item[{[status]}]
 !    \begin{sloppypar}
@@ -3904,10 +3883,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[iofmt]}]
 !     \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !     \end{sloppypar}
 !   \item[{[rc]}] 
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -3952,19 +3928,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF
     end if
 
     ! Call into the C++ interface, which will call IO object

--- a/src/Infrastructure/Field/include/ESMC_Field.h
+++ b/src/Infrastructure/Field/include/ESMC_Field.h
@@ -1216,18 +1216,10 @@ int ESMC_FieldSMMStore(
 //  \item[{[overwrite]}]
 //   \begin{sloppypar}
 //     A logical flag, the default is .false., i.e., existing field data may
-//     {\em not} be overwritten. If .true., the overwrite behavior depends
-//     on the value of {\tt iofmt} as shown below:
-//   \begin{description}
-//   \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_BIN}:]\ All data in the file will
-//     be overwritten with each field's data.
-//   \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_NETCDF}:]\ Only the
-//     data corresponding to each field's name will be
-//     be overwritten. If the {\tt timeslice} option is given, only data for
-//     the given timeslice may be overwritten.
+//     {\em not} be overwritten. If .true., the only the data corresponding to the
+//     field's name will be overwritten.
 //     Note that it is always an error to attempt to overwrite a NetCDF
 //     variable with data which has a different shape.
-//   \end{description}
 //   \end{sloppypar}
 //  \item[{[status]}]
 //   \begin{sloppypar}

--- a/src/Infrastructure/Field/interface/ESMC_Field.C
+++ b/src/Infrastructure/Field/interface/ESMC_Field.C
@@ -355,17 +355,7 @@ int ESMC_FieldGetBounds(ESMC_Field field,
     if (iofmt)
       opt_iofmt = iofmt;
     else {
-      const char *file_ext_p = strrchr (file, '.');
-      if (file_ext_p) {
-        std::string file_ext = std::string(file_ext_p);
-        if (file_ext == ".nc")
-          opt_iofmt = ESMF_IOFMT_NETCDF;
-        else if (file_ext == ".bin")
-          opt_iofmt = ESMF_IOFMT_BIN;
-        else
-          opt_iofmt = ESMF_IOFMT_NETCDF;
-      } else
-        opt_iofmt = ESMF_IOFMT_NETCDF;
+      opt_iofmt = ESMF_IOFMT_NETCDF;
     }
  
     // typecase into ESMCI type
@@ -680,17 +670,7 @@ int ESMC_FieldGetBounds(ESMC_Field field,
     if (iofmt)
       opt_iofmt = iofmt;
     else {
-      const char *file_ext_p = strrchr (file, '.');
-      if (file_ext_p) {
-        std::string file_ext = std::string(file_ext_p);
-        if (file_ext == ".nc")
-          opt_iofmt = ESMF_IOFMT_NETCDF;
-        else if (file_ext == ".bin")
-          opt_iofmt = ESMF_IOFMT_BIN;
-        else
-          opt_iofmt = ESMF_IOFMT_NETCDF;
-      } else
-        opt_iofmt = ESMF_IOFMT_NETCDF;
+      opt_iofmt = ESMF_IOFMT_NETCDF;
     }
 
     // typecase into ESMCI type

--- a/src/Infrastructure/Field/src/ESMF_FieldPr.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldPr.F90
@@ -261,10 +261,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[iofmt]}]
 !     \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !     \end{sloppypar}
 !   \item [{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -297,19 +294,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF
     end if
 
     if (present(variableName)) then

--- a/src/Infrastructure/Field/src/ESMF_FieldPr.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldPr.F90
@@ -256,7 +256,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !    Use this argument only in the I/O format (such as NetCDF) that
 !    supports variable name. If the I/O format does not support this
 !    (such as binary format), ESMF will return an error code.
-!   \item[timeslice]
+!   \item[{[timeslice]}]
 !     Number of slices to be read from file, starting from the 1st slice
 !   \item[{[iofmt]}]
 !     \begin{sloppypar}

--- a/src/Infrastructure/Field/src/ESMF_FieldWr.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldWr.F90
@@ -148,18 +148,10 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[overwrite]}]
 !    \begin{sloppypar}
 !      A logical flag, the default is .false., i.e., existing field data may
-!      {\em not} be overwritten. If .true., the overwrite behavior depends
-!      on the value of {\tt iofmt} as shown below:
-!    \begin{description}
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_BIN}:]\ All data in the file will
-!      be overwritten with each field's data.
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_NETCDF, ESMF\_IOFMT\_NETCDF\_64BIT\_OFFSET}:]\ Only the
-!      data corresponding to each field's name will be
-!      be overwritten. If the {\tt timeslice} option is given, only data for
-!      the given timeslice may be overwritten.
+!      {\em not} be overwritten. If .true., only the data corresponding to the field's name
+!      will be overwritten.    
 !      Note that it is always an error to attempt to overwrite a NetCDF
 !      variable with data which has a different shape.
-!    \end{description}
 !    \end{sloppypar}
 !   \item[{[status]}]
 !    \begin{sloppypar}
@@ -188,10 +180,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[iofmt]}]
 !     \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !     \end{sloppypar}
 !   \item [{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -233,19 +222,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF
     end if
 
     ! Attributes

--- a/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
+++ b/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
@@ -6282,7 +6282,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords for t
 !      the given timeslice will be overwritten.
 !      Note that it is always an error to attempt to overwrite a NetCDF
 !      variable with data which has a different shape.
-!    \end{description}
 !    \end{sloppypar}
 !   \item[{[status]}]
 !    \begin{sloppypar}

--- a/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
+++ b/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
@@ -2787,10 +2787,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords for t
 !   \item[{[iofmt]}]
 !     \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !     \end{sloppypar}
 !   \item[{[rc]}] 
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -2829,19 +2826,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords for t
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF     
     end if
 
     time = 0
@@ -6291,15 +6276,10 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords for t
 !   \item[{[overwrite]}]
 !    \begin{sloppypar}
 !      A logical flag, the default is .false., i.e., existing field data may
-!      {\em not} be overwritten.  If .true., the overwrite behavior depends
-!      on the value of {\tt iofmt} as shown below:
-!    \begin{description}
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_BIN}:]\ All data in the file will
-!      be overwritten with each fields data.
-!    \item[{\tt iofmt} = {\tt ESMF\_IOFMT\_NETCDF, ESMF\_IOFMT\_NETCDF\_64BIT\_OFFSET}:]\ Only the
-!      data corresponding to each fields name will be
+!      {\em not} be overwritten.  If .true., only the
+!      data corresponding to the field's name will be
 !      be overwritten. If the {\tt timeslice} option is given, only data for
-!      the given timeslice may be overwritten.
+!      the given timeslice will be overwritten.
 !      Note that it is always an error to attempt to overwrite a NetCDF
 !      variable with data which has a different shape.
 !    \end{description}
@@ -6329,10 +6309,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords for t
 !   \item[{[iofmt]}]
 !     \begin{sloppypar}
 !    The I/O format.  Please see Section~\ref{opt:iofmtflag} for the list
-!    of options. If not present, file names with a {\tt .bin} extension will
-!    use {\tt ESMF\_IOFMT\_BIN}, and file names with a {\tt .nc} extension
-!    will use {\tt ESMF\_IOFMT\_NETCDF}.  Other files default to
-!    {\tt ESMF\_IOFMT\_NETCDF}.
+!    of options. If not present, defaults to {\tt ESMF\_IOFMT\_NETCDF}.
 !     \end{sloppypar}
 !   \item[{[rc]}] 
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
@@ -6380,19 +6357,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords for t
     if (present (iofmt)) then
       opt_iofmt = iofmt
     else
-      if (index (fileName, '.') > 0) then
-        file_ext_p = index (fileName, '.', back=.true.)
-        select case (fileName(file_ext_p:))
-        case ('.nc')
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        case ('.bin')
-          opt_iofmt = ESMF_IOFMT_BIN
-        case default
-          opt_iofmt = ESMF_IOFMT_NETCDF
-        end select
-      else
-        opt_iofmt = ESMF_IOFMT_NETCDF
-      end if
+      opt_iofmt = ESMF_IOFMT_NETCDF
     end if
 
     if (present (convention) .neqv. present (purpose)) then

--- a/src/Infrastructure/IO/src/ESMCI_PIO_Handler.C
+++ b/src/Infrastructure/IO/src/ESMCI_PIO_Handler.C
@@ -618,7 +618,6 @@ void PIO_Handler::arrayRead(
       arrlen *= counts[i]; 
 
 #if defined(ESMF_NETCDF) || defined(ESMF_PNETCDF)
-  if (getFormat() != ESMF_IOFMT_BIN) {
     int nDims;
     if (((char *)NULL != name) && (strlen(name) > 0)) {
       varname = name;
@@ -633,16 +632,15 @@ void PIO_Handler::arrayRead(
     if (!CHECKPIOERROR(piorc, "File is not in NetCDF format", ESMF_RC_FILE_READ, (*rc))) {
       return;
     }
-  }
-  if (getFormat() != ESMF_IOFMT_BIN) {
+
+
     piorc = PIOc_inq_varid(pioFileDesc, varname.c_str(), &vardesc);
     // An error here means the variable is not in the file
     const std::string errmsg = "variable " + varname + " not found in file";
     if (!CHECKPIOERROR(piorc, errmsg, ESMF_RC_FILE_READ, (*rc))) {
       return;
     }
-  }
-  if (getFormat() != ESMF_IOFMT_BIN) {
+
     int frame;
     if (((int *)NULL != timeslice) && (*timeslice > 0)) {
       int dimid_time;
@@ -686,7 +684,7 @@ void PIO_Handler::arrayRead(
         PRINTMSG("calling setframe for read_darray, frame = " << frame);
         PIOc_setframe(pioFileDesc, vardesc, frame-1);
     }
-  }
+
 #endif // defined(ESMF_NETCDF) || defined(ESMF_PNETCDF)
 #ifdef ESMFIO_DEBUG
   PIOc_set_log_level(0);
@@ -802,7 +800,6 @@ void PIO_Handler::arrayWrite(
   PRINTMSG("arrlen = " << arrlen);
 
 #if defined(ESMF_NETCDF) || defined(ESMF_PNETCDF)
-  if (getFormat() != ESMF_IOFMT_BIN) {
     // Define the variable name and check the file
     if (((char *)NULL != name) && (strlen(name) > 0)) {
       varname = name;
@@ -844,11 +841,10 @@ void PIO_Handler::arrayWrite(
       // This should succeed if the variable exists
       varExists = (PIO_NOERR == piorc);
     }
-  }
 
   // Check consistency of time dimension with timeslice
   bool hasTimeDim;
-  if (getFormat() != ESMF_IOFMT_BIN) {
+
     int dimidTime;
     PIO_Offset timeLen;
     PRINTMSG("Checking time dimension");
@@ -900,9 +896,9 @@ void PIO_Handler::arrayWrite(
         PRINTMSG("timeslice not passed but set to " << timeFrame);
       }
     }
-  }
+
   PRINTMSG("ready to check var compat., timeFrame = " << timeFrame);
-  if ((getFormat() != ESMF_IOFMT_BIN) && varExists) {
+  if (varExists) {
     int nDims;
     int nArrdims = nioDims + ((timeFrame > 0) ? 1 : 0);
 
@@ -979,7 +975,7 @@ void PIO_Handler::arrayWrite(
     }
   }
 
-  if ((getFormat() != ESMF_IOFMT_BIN) && !varExists) {
+  if (!varExists) {
     // Ensure we are in define mode
     PRINTMSG("Going into NetCDF define mode (redef)");
     piorc = PIOc_redef(pioFileDesc);
@@ -995,7 +991,7 @@ void PIO_Handler::arrayWrite(
     }
   }
 
-  if ((getFormat() != ESMF_IOFMT_BIN) && !varExists) {
+  if (!varExists) {
     // Create the variable
     for (int i = 0; i < nioDims; i++) {
       std::string axis;
@@ -1059,7 +1055,7 @@ void PIO_Handler::arrayWrite(
     }
   }
   PRINTMSG("varExists = " << varExists);
-  if ((getFormat() != ESMF_IOFMT_BIN) && !varExists) {
+  if (!varExists) {
     PRINTMSG("niodims = " << nioDims);
     PRINTMSG("basepiotype = " << basepiotype);
      
@@ -1070,7 +1066,7 @@ void PIO_Handler::arrayWrite(
       return;
     }
   }
-  if ((getFormat() != ESMF_IOFMT_BIN) && (timeFrame >= 0)) {
+  if (timeFrame >= 0) {
 #ifdef ESMFIO_DEBUG
     int nvdims;
     PIOc_inq_varndims(pioFileDesc, vardesc, &nvdims);
@@ -1083,20 +1079,17 @@ void PIO_Handler::arrayWrite(
     }
   }
 #ifdef ESMFIO_DEBUG
-  else if (getFormat() != ESMF_IOFMT_BIN) {
+  else {
     PRINTMSG("NOT calling setframe, timeFrame = " << timeFrame);
   }
-  if (getFormat() != ESMF_IOFMT_BIN) {
     if (varExists) {
       int varid;
       int lrc;
       lrc = PIOc_inq_varid(pioFileDesc, varname.c_str(), &varid);
       PRINTMSG("varid = " << varid);
     }
-  }
 #endif // ESMFIO_DEBUG
 
-  if (getFormat() != ESMF_IOFMT_BIN) {
     // ESMF Attribute Package -> NetCDF variable and global attributes
     if (varAttPack) {
       attPackPut (vardesc, varAttPack, &localrc);
@@ -1112,16 +1105,16 @@ void PIO_Handler::arrayWrite(
         return;
       }
     }
-  }
+
 
   PRINTMSG("calling enddef, status = " << rc);
-  if ((getFormat() != ESMF_IOFMT_BIN)) {
+
     piorc = PIOc_enddef(pioFileDesc);
     if (!CHECKPIOERROR(piorc,  "Attempting to end definition of variable: " + varname,
         ESMF_RC_FILE_WRITE, (*rc))) {
       return;
     }
-  }
+
 #endif // defined(ESMF_NETCDF) || defined(ESMF_PNETCDF)
   PRINTMSG("calling write_darray, pio type = " << basepiotype << ", address = " << baseAddress);
 #ifdef ESMFIO_DEBUG

--- a/src/Infrastructure/Util/include/ESMC_Util.h
+++ b/src/Infrastructure/Util/include/ESMC_Util.h
@@ -94,8 +94,8 @@ enum ESMC_IndexFlag { ESMC_INDEX_DELOCAL=0,
                       ESMC_INDEX_USER};
 
 // io format type
-typedef enum ESMC_IOFmt_Flag { ESMF_IOFMT_BIN=0,
-                       ESMF_IOFMT_NETCDF,
+typedef enum ESMC_IOFmt_Flag { //ESMF_IOFMT_BIN=0,
+                       ESMF_IOFMT_NETCDF=1,
                        ESMF_IOFMT_NETCDF_64BIT_DATA,
                        ESMF_IOFMT_NETCDF_64BIT_OFFSET,
                        ESMF_IOFMT_NETCDF4,

--- a/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
@@ -558,7 +558,7 @@
       end type
 
       type(ESMF_IOFmt_Flag), parameter ::  &
-                           ESMF_IOFMT_BIN                 = ESMF_IOFmt_Flag(0), &
+!                           ESMF_IOFMT_BIN                 = ESMF_IOFmt_Flag(0), &
                            ESMF_IOFMT_NETCDF              = ESMF_IOFmt_Flag(1), &
                            ESMF_IOFMT_NETCDF_64BIT_DATA   = ESMF_IOFmt_Flag(2), &
                            ESMF_IOFMT_NETCDF_64BIT_OFFSET = ESMF_IOFmt_Flag(3), &
@@ -1060,7 +1060,7 @@
       public ESMF_Direction_Flag, ESMF_DIRECTION_FORWARD, ESMF_DIRECTION_REVERSE
 
       public ESMF_IOFmt_Flag, &
-             ESMF_IOFMT_BIN,  &
+!             ESMF_IOFMT_BIN,  &
              ESMF_IOFMT_NETCDF, &
              ESMF_IOFMT_NETCDF_64BIT_DATA, &
              ESMF_IOFMT_NETCDF_64BIT_OFFSET, &

--- a/src/doc/ESMF_install.tex
+++ b/src/doc/ESMF_install.tex
@@ -21,18 +21,34 @@ guarantees of the stability of development snapshots. New APIs available
 in development snapshots may change before the next release.
 
 Users aware of these risks may check out development snapshots
-using the appropriate git tag.  The standard naming convention
-for development tags is:
+using the appropriate git tag.
+
+Starting with ESMF 8.3.0 beta snapshot 07, the naming convention for development tags has the form:
+
+\begin{verbatim}
+v<VERSION>b<NUMBER>
+\end{verbatim}
+
+For example:
+\begin{verbatim}
+v8.3.0b07
+\end{verbatim}
+
+Prior to this version, the tag naming convention for development tags is:
 
 \begin{verbatim}
 ESMF_<VERSION>_beta_snapshot_<NUMBER>
 \end{verbatim}
 
-For example, to check out ESMF version 8.2.0 beta snapshot 01, use the
-following command:
+For example:
+\begin{verbatim}
+ESMF_8_2_0_beta_snapshot_23
+\end{verbatim}
+
+Use the following example command as a guide to check out a specific development tag:
 
 \begin{verbatim}
-  git clone https://github.com/esmf-org/esmf.git --branch ESMF_8_2_0_beta_snapshot_01 --depth 1
+  git clone https://github.com/esmf-org/esmf.git --branch v8.3.0b13 --depth 1
 \end{verbatim}
 
 Once downloaded, development snapshots are built in the same way as releases.
@@ -254,8 +270,8 @@ application.
 ESMF provides the ability to read and write data in
 NetCDF format through \htmladdnormallink{ParallelIO (PIO)}
 {https://github.com/NCAR/ParallelIO}, a third-party I/O software
-library that is integrated in the ESMF library. The following environment
-variable enables PIO functionalities inside of ESMF.
+library that is integrated into the ESMF library. The following environment
+variable enables PIO functionality inside of ESMF.
 
 The PIO code depends on MPI I/O support by the underlying MPI
 implementation for parallel I/O. Almost all current MPI
@@ -273,7 +289,7 @@ being enabled.
 platforms, as determined by the ESMF build configuration.
 
 \item[{\tt "internal"}] PIO-dependent features will be enabled and will use the
-PIO library that is included and built with ESMF. Internal builds of PIO2 require
+PIO library that is included and built with ESMF. Internal builds of PIO require
 CMake version 2.8.12 or newer be available in the path.
 
 \item[{\tt "external"}] PIO-dependent features will be enabled and will use an
@@ -285,6 +301,15 @@ this option is 2.5.7.
 \item[{\tt "OFF"}] Disables PIO-dependent code.
 
 \end{description}
+
+
+\item[ESMF\_PIO\_INCLUDE] (no default)
+
+Specifies the path where the PIO header files are located.
+
+\item[ESMF\_PIO\_LIBPATH] (no default)
+
+Specifies the path where the PIO library is located.
 
 \end{description}
 

--- a/src/doc/ESMF_install.tex
+++ b/src/doc/ESMF_install.tex
@@ -196,7 +196,7 @@ desired setting.  E.g. {\tt "-lnetcdff -lnetcdf -lhdf5\_hl -lhdf5"}
 
 \subsubsection{Parallel-NetCDF}
 \label{sec:pnetcdf}
-ESMF provides the ability to write Mesh weights using
+ESMF provides the ability to write data using
 \htmladdnormallink{Parallel-NetCDF}{http://trac.mcs.anl.gov/projects/parallel-netcdf}.
 
 Some file systems, for example \htmladdnormallink{Lustre}{http://wiki.lustre.org}, may need
@@ -251,17 +251,17 @@ application.
 
 \subsubsection{PIO}
 \label{sec:pio}
-ESMF provides the ability to read and write data in both binary and
-NetCDF formats through \htmladdnormallink{ParallelIO (PIO)}
+ESMF provides the ability to read and write data in
+NetCDF format through \htmladdnormallink{ParallelIO (PIO)}
 {https://github.com/NCAR/ParallelIO}, a third-party I/O software
 library that is integrated in the ESMF library. The following environment
 variable enables PIO functionalities inside of ESMF.
 
 The PIO code depends on MPI I/O support by the underlying MPI
-implementation to provide the binary format. Almost all current MPI
+implementation for parallel I/O. Almost all current MPI
 implementations support MPI I/O to the required degree. For NetCDF format
-support the integrated PIO code depends on {\tt ESMF\_PNETCDF}
-(see \ref{sec:pnetcdf}) and/or {\tt ESMF\_NETCDF} (see \ref{sec:netcdf})
+support the integrated PIO code depends on {\tt ESMF\_NETCDF} (see \ref{sec:netcdf})
+being enabled and optionally {\tt ESMF\_PNETCDF} (see \ref{sec:pnetcdf})
 being enabled.
 
 \begin{description}
@@ -269,18 +269,18 @@ being enabled.
 {\tt "external"}, {\tt "OFF"}.
 
 \begin{description}
-\item[{\it not set} (default)] PIO-dependent features will be enabled on platforms where
-certain Fortran-2003 C Interoperability features are available.  Most currently supported
-compilers support these features.
+\item[{\it not set} (default)] PIO-dependent features will be enabled on supported
+platforms, as determined by the ESMF build configuration.
 
 \item[{\tt "internal"}] PIO-dependent features will be enabled and will use the
-PIO library that is included and built with ESMF.
+PIO library that is included and built with ESMF. Internal builds of PIO2 require
+CMake version 2.8.12 or newer be available in the path.
 
 \item[{\tt "external"}] PIO-dependent features will be enabled and will use an
 external PIO library.  The additional parameters {\tt ESMF\_PIO\_INCLUDE} 
 (path to PIO include files) and {\tt ESMF\_PIO\_LIBPATH} (path to PIO library files)
 should also be set when using this option. The minimum version of PIO for
-this option is 2.5.5. 
+this option is 2.5.7. 
 
 \item[{\tt "OFF"}] Disables PIO-dependent code.
 

--- a/src/doc/ESMF_options.tex
+++ b/src/doc/ESMF_options.tex
@@ -389,12 +389,26 @@ The type of this flag is:
 
 The valid values are:
 \begin{description}
-\item [ESMF\_IOFMT\_BIN]
-      Binary format.
 \item [ESMF\_IOFMT\_NETCDF]
-      NETCDF and PNETCDF format.
+      NETCDF and PNETCDF (cdf1) format in NETCDF-3 ``classic'' format. Use
+      of PNETCDF is prioritized if available.
 \item [ESMF\_IOFMT\_NETCDF\_64BIT\_OFFSET]
-      NETCDF and PNETCDF 64-bit format.
+      NETCDF and PNETCDF (cdf2) format.  This format allows files greater
+      than 4GiB in NETCDF-3 ``classic'' format.  Use of PNETCDF is prioritized
+      if available.
+\item [ESMF\_IOFMT\_NETCDF\_64BIT\_DATA]
+      NETCDF and PNETCDF (cdf5) format.  This allows individual records greater
+      than 4GiB in NETCDF-3 ``classic'' format.  Use of PNETCDF is prioritized
+      if available.
+\item [ESMF\_IOFMT\_NETCDF4P]
+      NETCDF-4 (HDF-5) format.  If a NETCDF parallel library is available,
+      writes will be in parallel. Writes will use one I/O PET per
+      SSI (node) of the ESMF VM that calls the I/O operation. Otherwise writes
+      will be serial.
+\item [ESMF\_IOFMT\_NETCDF4C]
+      NETCDF-4 (HDF-5) format with lossless compression from HDF-5 applied.
+      This is only available as a serial option, even if a parallel NETCDF
+      library is available.  
 \end{description}
 
 \subsection{ESMF\_IO\_NETCDF\_PRESENT}
@@ -428,7 +442,7 @@ The type of this flag is:
 The valid values are:
 \begin{description}
  \item [.true.]
-      PIO features are enabled..
+      PIO features are enabled.
 \item [.false.]
       PIO  features are not enabled.
 \end{description}
@@ -446,9 +460,9 @@ The type of this flag is:
 The valid values are:
 \begin{description}
 \item [.true.]
-      Parallel netcdf features are enabled.
+      Parallel NETCDF features are enabled.
 \item [.false.]
-      Parallel netcdf features are not enabled.
+      Parallel NETCDF features are not enabled.
 \end{description}
 
 

--- a/src/doc/ESMF_systemreq.tex
+++ b/src/doc/ESMF_systemreq.tex
@@ -14,18 +14,23 @@ for a standard cpp preprocessor implementation;
 test scripts.
 \end{itemize} 
 
-The following packages are optional, and only used for selected capabilities:
+Internal packages that can optionally reference external libraries:
 \begin{itemize}
 \item LAPACK - version 3.x or newer
-\item NetCDF - version 3.6.x or newer
-\item parallel-NetCDF - version 1.2.0 or newer 
-\item Xerces - version 3.1.0 or newer
+\item ParallelIO (PIO) - version 2.5.7 or newer
 \item yaml-cpp - tag yaml-cpp-0.6.2 or newer
 \end{itemize}
 
-Alternatively ESMF can be built using a single-processor MPI-bypass library
-that comes with ESMF. It allows ESMF applications to be linked and run in
-single-process mode.
+Optional external packages that must be specified for certain functions:
+\begin{itemize}
+\item NetCDF - version 3.6.x or newer (version 4.4 or newer required by PIO)
+\item parallel-NetCDF - version 1.2.0 or newer (version 1.12 or newer required by PIO)
+\item Xerces - version 3.1.0 or newer
+\end{itemize}  
+
+ESMF can be built using a single-processor MPI-bypass library
+that comes with ESMF by setting {\tt ESMF\_COMM=mpiuni}. This allows ESMF applications
+to be linked and run in single-process mode.
 
 In order to build html and pdf versions of the ESMF documentation, 
 \htmladdnormallink{\LaTeX}{http://www.latex-project.org},


### PR DESCRIPTION
Updated user guide:
https://earthsystemmodeling.org/docs/nightly/feature/pio_docs/ESMF_usrdoc/
- Third party libraries section updated for PIO

Updated ref manual:
https://earthsystemmodeling.org/docs/nightly/feature/pio_docs/ESMF_refdoc/
- Updated ArrayRead/Write, ArrayBundleRead/Write, FieldRead/Write, FieldBundleRead/Write

Removed all references to ESMF_IOFMT_BIN throughout.  All local tests pass.
