### PR TITLE
Add explicit casts from PIO_offset to int

### DIFF
--- a/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C
@@ -585,7 +585,7 @@ void get_elemConn_info_2Dvar_from_ESMFMesh_file(int pioSystemDesc, int pioFileDe
 
   // Init elementConn decomp
   int ec_iodesc;
-  int gdimlen2D[2]={elementCount,maxNodePElement};
+  int gdimlen2D[2]={(int) elementCount,(int) maxNodePElement};
   piorc = PIOc_InitDecomp(pioSystemDesc, PIO_INT, 2, gdimlen2D, totNumElementConn, ec_offsets, &ec_iodesc, 
                           &rearr, NULL, NULL);
   if (!CHECKPIOERROR(piorc, std::string("Error initializing PIO decomp for file ") + filename,
@@ -715,7 +715,7 @@ void get_nodeCoords_from_ESMFMesh_file(int pioSystemDesc, int pioFileDesc, char 
 
     // Init nodeCoords decomp
     int node_iodesc;
-    int node_gdimlen2D[2]={nodeCount, coordDim};
+    int node_gdimlen2D[2]={(int) nodeCount, (int) coordDim};
     piorc = PIOc_InitDecomp(pioSystemDesc, PIO_DOUBLE, 2, node_gdimlen2D, num_nodes*coordDim, node_offsets, &node_iodesc, 
                     &rearr, NULL, NULL);
     if (!CHECKPIOERROR(piorc, std::string("Error initializing PIO decomp for file ") + filename,
@@ -975,7 +975,7 @@ void get_centerCoords_from_ESMFMesh_file(int pioSystemDesc, int pioFileDesc, cha
     
     // Init elementConn decomp
     int cc_iodesc;
-    int cc_gdimlen2D[2]={elementCount,coordDim};
+    int cc_gdimlen2D[2]={(int) elementCount, (int) coordDim};
     piorc = PIOc_InitDecomp(pioSystemDesc, PIO_DOUBLE, 2, cc_gdimlen2D, num_elems*coordDim, cc_offsets, &cc_iodesc, 
                             &rearr, NULL, NULL);
     if (!CHECKPIOERROR(piorc, std::string("Error initializing PIO decomp for centerCoords ") + filename,

--- a/src/Infrastructure/Mesh/src/ESMCI_UGRID_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_UGRID_Util.C
@@ -353,7 +353,7 @@ void get_elementConn_info_from_UGRID_file(int pioSystemDesc, int pioFileDesc, ch
 
   // Init elementConn decomp
   int ec_iodesc;
-  int gdimlen2D[2]={elementCount,max_num_conns_per_elem};
+  int gdimlen2D[2]={(int) elementCount, (int) max_num_conns_per_elem};
   piorc = PIOc_InitDecomp(pioSystemDesc, PIO_INT, 
                           2, gdimlen2D, totNumRectElementConn,
                           ec_offsets, &ec_iodesc, 


### PR DESCRIPTION
This is needed to avoid compilation errors like this (using clang on my Mac):

/Users/sacks/esmf/esmf0/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C:588:21: error: non-constant-expression cannot be narrowed from type 'MPI_Offset' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]
  int gdimlen2D[2]={elementCount,maxNodePElement};

I'm not positive this change is correct, but I do see similar casts elsewhere - such as:

https://github.com/esmf-org/esmf/blob/de129fc120c40a5e5d3ce85081d5883dce53748e/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C#L269
