### PR TITLE
Install FindESMF.cmake to prefix/lib/cmake/esmf

### DIFF
--- a/makefile
+++ b/makefile
@@ -699,6 +699,8 @@ install:
 	cp -f $(ESMF_MODDIR)/*.mod $(ESMF_INSTALL_MODDIR_ABSPATH)
 	mkdir -p $(ESMF_INSTALL_LIBDIR_ABSPATH)
 	cp -f $(ESMF_LIBDIR)/libesmf*.* $(ESMF_INSTALL_LIBDIR_ABSPATH)
+	mkdir -p $(ESMF_INSTALL_LIBDIR_ABSPATH)/cmake/esmf
+	cp -f $(ESMF_DIR)/cmake/* $(ESMF_INSTALL_LIBDIR_ABSPATH)/cmake/esmf
 
 ifeq ($(ESMF_PIO),internal)
 	cp -f $(ESMF_LIBDIR)/libpioc.* $(ESMF_INSTALL_LIBDIR_ABSPATH)


### PR DESCRIPTION
TL;DR: This PR installs the `FindESMF.cmake` file when running `make install`

---

One of my goals with MAPL (and GEOS) is to eventually be able to build using [Spack](https://github.com/spack/spack) as my library provider instead of Baselibs. However, testing today with building the latest MAPL with Spack led to an issue. Namely, recently in GEOS CMake, we've moved to using `find_package(ESMF MODULE REQUIRED)` and then appending to our `CMAKE_MODULE_PATH` where that file is in our installation of ESMF in Baselibs. We used to carry around our own `FindESMF.cmake`, but then I realized @danrosen25 and @theurich do change it every so often, so the "right" thing is to just use what ESMF itself provides.

But, the Spack testing revealed this all works only because in the Baselibs installation, I [*explicitly* copy the file](https://github.com/GEOS-ESM/ESMA-Baselibs/blob/594adb60cbbe86b508f6689e0f6fbf4cb0f9dd1c/esmf_rules.mk#L158) into our install directory:

```make
	@cp -pr $(ESMF_DIR)/cmake/*    $(ESMF_INSTALL_HEADERDIR)
```

because the ESMF `make install` does not do this. 

So, in this PR, I do the "simple" thing and add two lines to the `makefile` so that the `FindESMF.cmake` file is copied into `$(ESMF_INSTALL_LIBDIR_ABSPATH)/cmake/esmf`. 

Note: this is different than how I am currently doing it in Baselibs (see above), but I just sort of winged that long ago, but `lib/cmake/esmf` seems to be a more "canonical" path for a CMake package installations. Now, most packages built with CMake install for Config Mode and, [per this page](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure), the first path CMake looks on Unix for Config mode installs is:
```
<prefix>/(lib/<arch>|lib*|share)/cmake/<name>*/                 (U)
```
So, `lib/cmake/esmf/` seems a good place even for a Module-mode install.

Now, the question for you is: is this how you'd like to do it? Maybe you'd like to make an `ESMF_INSTALL_CMAKEDIR` or some such override variable. I dunno. And maybe you'd also like to copy the file into, say, `lib/libO/Darwin.nag.64.openmpi.default/cmake/esmf` as well? Not sure.

I'd love for this to be in v8.3.0 but I figure that train has left the station. 😄  For now, I have a "hack" in how I'm building MAPL in Spack testing that seems to work where I just grab the file blob from GitHub and shove it into where Spack is building MAPL. But if `make install` installed it, then I think I could work with/bother @climbfuji (who maintains the [esmf Spack package](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/esmf/package.py)) to figure out how to get Spack to add the `prefix/lib/cmake/esmf` to the `CMAKE_MODULE_PATH` Spack can generate.