### PR TITLE
Allow building ESMPy with setuptoos/pip

### DIFF
--- a/src/addon/ESMPy/setup.py
+++ b/src/addon/ESMPy/setup.py
@@ -109,7 +109,7 @@ class BuildCommand(AbstractESMFCommand, _build):
 
         # Create "esmfmkfile.py" file holding the path to the ESMF "esmf.mk" file
         if not isinstance(self.ESMFMKFILE, type(None)):
-            f = open(os.path.join('src', 'ESMF', 'interface', 'esmfmkfile.py'), 'w')
+            f = open(os.path.join(self.build_lib, 'ESMF', 'interface', 'esmfmkfile.py'), 'w')
             f.write('ESMFMKFILE = "%s"' % self.ESMFMKFILE)
             f.close()
 

--- a/src/addon/ESMPy/setup.py
+++ b/src/addon/ESMPy/setup.py
@@ -4,6 +4,7 @@ import os
 import sys
 from distutils.core import setup, Command
 from distutils.util import get_platform
+from distutils.command.build import build as _build
 import subprocess
 
 
@@ -25,9 +26,11 @@ class AbstractESMFCommand(Command):
     user_options = []
 
     def initialize_options(self):
+        super().initialize_options()
         self.cwd = None
 
     def finalize_options(self):
+        super().finalize_options()
         self.cwd = os.getcwd()
 
     def _validate_(self):
@@ -76,12 +79,13 @@ class AbstractESMFNoseCommand(AbstractESMFCommand):
         return ret
 
 
-class BuildCommand(AbstractESMFCommand):
+class BuildCommand(AbstractESMFCommand, _build):
     description = "build: will build the ESMF package"
     user_options = [('ESMFMKFILE=', 'e',
                      "Location of esmf.mk for the ESMF installation")]
 
     def initialize_options(self):
+        super().initialize_options()
         self.cwd = None
         self.ESMFMKFILE = None
         SITEDIR = os.system('%s -m site --user-site' % sys.executable)
@@ -90,6 +94,7 @@ class BuildCommand(AbstractESMFCommand):
         self.plat_name = None
 
     def finalize_options(self):
+        super().finalize_options()
         self.cwd = os.getcwd()
         if isinstance(self.ESMFMKFILE, type(None)):
             self.ESMFMKFILE = os.getenv('ESMFMKFILE')
@@ -99,6 +104,7 @@ class BuildCommand(AbstractESMFCommand):
             self.plat_name = get_platform()
 
     def run(self):
+        super().run()
         assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
 
         # Create "esmfmkfile.py" file holding the path to the ESMF "esmf.mk" file

--- a/src/addon/ESMPy/setup.py
+++ b/src/addon/ESMPy/setup.py
@@ -2,7 +2,8 @@
 
 import os
 import sys
-from distutils.core import setup, Command
+from setuptools import setup
+from distutils.core import Command
 from distutils.util import get_platform
 from distutils.command.build import build as _build
 import subprocess

--- a/src/addon/ESMPy/setup.py
+++ b/src/addon/ESMPy/setup.py
@@ -107,10 +107,6 @@ class BuildCommand(AbstractESMFCommand):
             f.write('ESMFMKFILE = "%s"' % self.ESMFMKFILE)
             f.close()
 
-        # Attempt to load ESMF.
-        update_system_path()
-        import ESMF.interface.loadESMF
-
 
 class CleanCommand(AbstractESMFCommand):
     description = "clean: will remove all libraries, log and output files"

--- a/src/addon/ESMPy/setup.py
+++ b/src/addon/ESMPy/setup.py
@@ -271,4 +271,8 @@ setup(name="ESMPy",
                 'test_regrid_from_file': TestRegridFromFileCommand,
                 'test_regrid_from_file_dryrun': TestRegridFromFileDryrunCommand,
                 'test_regrid_parallel': TestRegridParallelCommand,
-                'test_regrid_from_file_parallel': TestRegridFromFileParallelCommand})
+                'test_regrid_from_file_parallel': TestRegridFromFileParallelCommand},
+      install_requires=[
+          "numpy",
+      ],
+)


### PR DESCRIPTION
# The issue

As of Python 3.10, upon running `python setup.py install` there is an error printed 

```
DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
```

The usual way to install packages in Python is using `pip` which follows the recommendations of PEP 632 and can use setuptools. However, if I try to install ESMPy with:

```console
$ export ESMFMKFILE=...
$ cd src/addon/ESMPy
$ pip install .
```

then (after having to manually install `numpy` first) you get the error:

```
...
        File "/usr/lib64/python3.10/distutils/cmd.py", line 290, in set_undefined_options
          setattr(self, dst_option, getattr(src_cmd_obj, src_option))
        File "/usr/lib64/python3.10/distutils/cmd.py", line 103, in __getattr__
          raise AttributeError(attr)
      AttributeError: build_scripts
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> ESMPy
```

It seems there's some subtle change with how `distutils` and `setuptools` work which causes this to fail. 

# This PR

This PR tries to make the minimal change to ESMPy to allow it to be installed with `pip` without changing how it behaves. It makes the following changes:

1. Uses the `setuptools.setup` function explicitly to ensure modern behaviour
2. The `BuildCommand` class now also derives from the pre-existing `build` command to get access to the required state.
3. The `esmfmkfile.py` file is created in the build tree, not the source tree
4. It no longer tries to import the library at build time, as there's no guarantee that any dependencies will have been installed at that time.
5. `numpy` is specified as a dependency in `setup.py` so that it's automatically installed.

# Future possible changes

Other potential changes are (you have no issue tracker I can find to suggest/discuss these):

1. In `emsfmkfile.py` it is currently hard-coded at build-time to the value of `ESMFMKFILE`. I would change this to be able to read this env var at run-time with `os.getenv("ESMFMKFILE", "hard/coded/path/from/build")`. And if the `ESMFMKFILE` variable is not set at build-time, then it will just be `os.getenv("ESMFMKFILE")`. This will allow portable builds of ESMPy which can be pointed wherever ESMF is installed.
2. Create a `pyproject.toml` which just has the minimum from https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use. This explicitly flags that you are conforming to the spec.
6. `setup.py` currently does a lot and is being used like a `Makefile`. This is becoming less common and I believe it is deprecated. The test suite should be run directly with some runner (I think you use `nose`)
7. Build a `wheel` of ESMPy since there's nothing but plain Python code in here. It can be easily installed and could then be distributed via PyPI like all other Python packages instead of just `conda`.
8. Remove the option of build-time setting of `ESMFMKFILE` and require that it's set at runtime (the docs imply that this is possible, but it doesn't work). This would allow moving to a static build configuration like specified in PEP 621 (`setuptools`/`flit`/`poetry` are all options)