### PR TITLE
update xgrid unit test to write out fields after remapping

### DIFF
--- a/src/Infrastructure/XGrid/tests/ESMF_XGridUTest.F90
+++ b/src/Infrastructure/XGrid/tests/ESMF_XGridUTest.F90
@@ -2498,6 +2498,7 @@ end subroutine CreateTestMesh2x2_2
    
   integer :: numOwnedElems
   real(ESMF_KIND_R8), pointer :: ownedElemCoords(:)
+  character(len=255) :: filename
 
   ! result code
   integer :: finalrc
@@ -2740,7 +2741,7 @@ end subroutine CreateTestMesh2x2_2
    if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
-   
+
    ! Field on XGrid
    xField = ESMF_FieldCreate(xgrid, arrayspec, &
         name="xfield", rc=localrc)
@@ -2783,6 +2784,21 @@ end subroutine CreateTestMesh2x2_2
 
   call ESMF_FieldRegrid(xField, dstField, XToDrouteHandle, &
        rc=localrc)
+  if (ESMF_LogFoundError(localrc, &
+       ESMF_ERR_PASSTHRU, &
+       ESMF_CONTEXT, rcToReturn=rc)) return
+
+  ! Write fields
+  write(filename, fmt='(a,i1,a)') 'xField', petCount, '.nc'
+  call ESMF_FieldWrite(xField, trim(filename), &
+       overwrite=.true., rc=localrc)
+  if (ESMF_LogFoundError(localrc, &
+       ESMF_ERR_PASSTHRU, &
+       ESMF_CONTEXT, rcToReturn=rc)) return
+
+  write(filename, fmt='(a,i1,a)') 'dstField', petCount, '.nc'
+  call ESMF_FieldWrite(dstField, trim(filename), &
+       overwrite=.true., rc=localrc)
   if (ESMF_LogFoundError(localrc, &
        ESMF_ERR_PASSTHRU, &
        ESMF_CONTEXT, rcToReturn=rc)) return


### PR DESCRIPTION
This PR extends ESMF_XGridUTest to write out the fields after interpolation. 

- The test can be run as following after building ESMF (you might not be run build again),

```
cd src/Infrastructure/XGrid/tests
make build_unit_tests
make run_unit_tests
make run_unit_tests_uni
```

Note: you could use following command to create interactive session on Cheyenne,

```
qinteractive -l walltime=21600 -l select=1:ncpus=18:mpiprocs=18
```

- Fields are named as `dstField1.nc` and `xField1.nc` for 1 PET and `dstField2.nc` and `xField2.nc` for 2 PET cases.
- Then, files can be compared with `cprnc` as following,

```
cprnc -m xField1.nc xField2.nc
cprnc -m dstField1.nc dstField2.nc
```

Note: cprnc tool can be found in `/glade/p/cesmdata/cseg/tools/cime/tools/cprnc/cprnc`
