### PR TITLE
Fix doc for ESMF_UtilSort call

### DIFF
--- a/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
@@ -97,8 +97,8 @@ contains
 !       Array of data to be sorted.  The original data is overwritten by the @\
 !       sorted data.  @\
 !     \item [direction] @\
-!       Direction of sorting.  Legal values are {\tt ESMF\_SORT\_ASCENDING} @\
-!       and {\tt ESMF\_SORT\_DESCENDING}. @\
+!       Direction of sorting.  Legal values are {\tt ESMF\_SORTFLAG\_ASCENDING} @\
+!       and {\tt ESMF\_SORTFLAG\_DESCENDING}. @\
 !     \item [{[rc]}] @\
 !       Return code; equals {\tt ESMF\_SUCCESS} if the sorting is successful. @\
 !     \end{description} @\

--- a/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
@@ -132,8 +132,8 @@ contains
 !       Array of data to be sorted.  The sorted data is returned @\
 !       in the list. @\
 !     \item [direction] @\
-!       Direction of sorting.  Legal values are {\tt ESMF_SORT_ASCENDING} @\
-!       and {\tt ESMF_SORT_DESCENDING}. @\
+!       Direction of sorting.  Legal values are {\tt ESMF_SORTFLAG_ASCENDING} @\
+!       and {\tt ESMF_SORTFLAG_DESCENDING}. @\
 !     \item [{[rc]}] @\
 !       Return code; equals {\tt ESMF_SUCCESS} if the sorting is successful. @\
 !     \end{description} @\


### PR DESCRIPTION
This PR aims to fix the documentation for ESMF_UtilSort call. Particularly, its available options for sort direction.