### PR TITLE
Fix to propagate ESMF_Info types

### DIFF
--- a/src/Infrastructure/Base/src/ESMCI_Info.C
+++ b/src/Infrastructure/Base/src/ESMCI_Info.C
@@ -861,20 +861,26 @@ void Info::get(ESMCI::Info &info, key_t &key) const {
   json const *ts = nullptr;
   try {
     j = this->get<json>(key);
-    json::json_pointer jpath = this->formatKey(key);
-    update_json_pointer(this->getTypeStorage(), &ts, jpath, true);
+    check_init_from_json(j);    
 
+    const json &type_storage = info.getTypeStorage();    
+    if (!type_storage.is_null() && type_storage.size() > 0) {
+      json::json_pointer jpath = this->formatKey(key);
+      update_json_pointer(this->getTypeStorage(), &ts, jpath, true);
+      check_init_from_json(*ts);
+    }
+      
 #if 0
-    std::string msg2 = std::string(ESMC_METHOD) + ": j dump=" + j.dump();
+    std:string msg2 = std::string(ESMC_METHOD) + ": j dump=" + j.dump();
     ESMC_LogWrite(msg2.c_str(), ESMC_LOGMSG_DEBUG);
 #endif
-    
-    check_init_from_json(j);
-    check_init_from_json(*ts);
+
   }
   ESMF_CATCH_INFO
   info.getStorageRefWritable() = std::move(j);
-  info.getTypeStorageWritable() = std::move(*ts);
+  if (!type_storage.is_null() && type_storage.size() > 0) {
+    info.getTypeStorageWritable() = std::move(*ts);
+  }
 
 #if 0
   std::string msg3 = std::string(ESMC_METHOD) + ": info dump=" + info.dump(0);

--- a/src/Infrastructure/Base/src/ESMCI_Info.C
+++ b/src/Infrastructure/Base/src/ESMCI_Info.C
@@ -871,7 +871,7 @@ void Info::get(ESMCI::Info &info, key_t &key) const {
     }
       
 #if 0
-    std:string msg2 = std::string(ESMC_METHOD) + ": j dump=" + j.dump();
+    std::string msg2 = std::string(ESMC_METHOD) + ": j dump=" + j.dump();
     ESMC_LogWrite(msg2.c_str(), ESMC_LOGMSG_DEBUG);
 #endif
 

--- a/src/Infrastructure/Base/src/ESMCI_Info.C
+++ b/src/Infrastructure/Base/src/ESMCI_Info.C
@@ -863,7 +863,7 @@ void Info::get(ESMCI::Info &info, key_t &key) const {
     j = this->get<json>(key);
     check_init_from_json(j);    
 
-    const json &type_storage = info.getTypeStorage();    
+    const json &type_storage = this->getTypeStorage();    
     if (!type_storage.is_null() && type_storage.size() > 0) {
       json::json_pointer jpath = this->formatKey(key);
       update_json_pointer(this->getTypeStorage(), &ts, jpath, true);

--- a/src/Infrastructure/Field/tests/ESMF_FieldIOUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldIOUTest.F90
@@ -1330,7 +1330,7 @@ program ESMF_FieldIOUTest
 #if !defined (ESMF_PNETCDF)
     case ("_FillValue")
       call ESMF_AttributeSet (field_att,  &
-          attrNames(i), valueList=(/ -1.e+10 /),  &
+          attrNames(i), valueList=(/ -1.e+10_ESMF_KIND_R8 /),  &
           convention=apConv, purpose=apPurp,  &
           rc=rc)
       if (rc /= ESMF_SUCCESS) exit
@@ -1563,7 +1563,7 @@ program ESMF_FieldIOUTest
 #if !defined (ESMF_PNETCDF)
     case ("_FillValue")
       call ESMF_AttributeSet (field_ugd_att,  &
-          attrNames(i), valueList=(/ -1.e+10 /),  &
+          attrNames(i), valueList=(/ -1.e+10_ESMF_KIND_R8 /),  &
           convention=apConv, purpose=apPurp,  &
           rc=rc)
       if (rc /= ESMF_SUCCESS) exit


### PR DESCRIPTION
This is a new PR to supersede [Dushan-NOAA](https://github.com/esmf-org/esmf/pull/51).  This ensures the type information for the Info object is correctly propagated with calling Info::get().