### PR TITLE
Fix git detection in case of submodule

### DIFF
--- a/makefile
+++ b/makefile
@@ -75,7 +75,7 @@ script_info: test_esmfmkfile
 	-@echo "--------------------------------------------------------------"
 	-@echo "ESMF_VERSION_STRING:    $(ESMF_VERSION_STRING)"
 ifeq ($(shell $(ESMF_DIR)/scripts/available git),git)
-	@if [ -d $(ESMF_DIR)/.git ] ; then \
+	@if [ -d $(ESMF_DIR)/.git ] || [ -s $(ESMF_DIR)/.git ]] ; then \
 	echo $(ESMF_VERSION_STRING_GIT);\
 	echo "--------------------------------------------------------------" ;\
 	git status ;\

--- a/makefile
+++ b/makefile
@@ -73,10 +73,10 @@ test_esmfmkfile:
 script_info: test_esmfmkfile
 	-@echo " "
 	-@echo "--------------------------------------------------------------"
-	-@echo "ESMF_VERSION_STRING:    $(ESMF_VERSION_STRING)"
+	-@echo "ESMF_VERSION_STRING:      $(ESMF_VERSION_STRING)"
 ifeq ($(shell $(ESMF_DIR)/scripts/available git),git)
-	@if [ -d $(ESMF_DIR)/.git ] || [ -s $(ESMF_DIR)/.git ]] ; then \
-	echo $(ESMF_VERSION_STRING_GIT);\
+	@if [ "$(ESMF_VERSION_STRING_GIT)" != "" ] ; then \
+	echo "ESMF_VERSION_STRING_GIT: $(ESMF_VERSION_STRING_GIT)";\
 	echo "--------------------------------------------------------------" ;\
 	git status ;\
 	else \
@@ -426,7 +426,7 @@ info_mk: chkdir_lib
 	-@echo "#----------------------------------------------" >> $(MKINFO)
 	-@echo "ESMF_VERSION_STRING=$(ESMF_VERSION_STRING)"     >> $(MKINFO)
 ifeq ($(shell $(ESMF_DIR)/scripts/available git),git)
-	@if [ -d $(ESMF_DIR)/.git ] ; then \
+	@if [ "$(ESMF_VERSION_STRING_GIT)" != "" ] ; then \
 	echo "ESMF_VERSION_STRING_GIT=$(ESMF_VERSION_STRING_GIT)" >> $(MKINFO) ; \
 	else \
 	echo "# Not a Git repository" >> $(MKINFO) ; \

--- a/scripts/esmfversiongit
+++ b/scripts/esmfversiongit
@@ -1,5 +1,6 @@
 #!/bin/sh
 # return the ESMF version from Git if available, or empty string otherwise
-if [ -d $ESMF_DIR/.git ] ; then \
+# test looks for .git directory or .git file (when esmf is a submodule)
+if [ -d $ESMF_DIR/.git ] || [ -s $ESMF_DIR/.git ]; then \
 git describe --tags 2>&1 | grep -v fatal
 fi

--- a/scripts/esmfversiongit
+++ b/scripts/esmfversiongit
@@ -1,6 +1,6 @@
 #!/bin/sh
 # return the ESMF version from Git if available, or empty string otherwise
 # test looks for .git directory or .git file (when esmf is a submodule)
-if [ -d $ESMF_DIR/.git ] || [ -s $ESMF_DIR/.git ]; then \
+if [ -d $ESMF_DIR/.git ] || [ -s $ESMF_DIR/.git ] ; then \
 git describe --tags 2>&1 | grep -v fatal
 fi


### PR DESCRIPTION
This PR changes the git detection bits of ESMF's make system to support the case when ESMF is a git submodule (as in ESMA-Baselibs):
```
--------------------------------------------------------------
ESMF_VERSION_STRING:    8.3.0
Not a Git repository
--------------------------------------------------------------
```
It is a git repo but when a submodule, `.git` is not a directory but a file, a la:

```shell
❯ cat esmf/.git
gitdir: ../.git/modules/esmf
```

So, we add an "or" test for a non-zero file as well as a directory.

This seems to fix the issue for my submodule case:
```
--------------------------------------------------------------
ESMF_VERSION_STRING:    8.4.0 beta snapshot
v8.4.0b07-5-g2f295f71be
--------------------------------------------------------------
On branch develop
Your branch is up to date with 'origin/develop'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   makefile
        modified:   scripts/esmfversiongit

no changes added to commit (use "git add" and/or "git commit -a")
--------------------------------------------------------------

--------------------------------------------------------------
```
Well, mine has a lot of `git status` output since I just made the changes locally for testing.