### PR TITLE
Fixes to get Darwin.gfortranclang combination working; add Linux ARM and LLVM compilers

### DIFF
--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -51,8 +51,8 @@ jobs:
 
     - name: Copy docs
       run: | 
-        cd ${{ github.workspace }}/esmf-org.github.io
-        mkdir -p docs/nightly/${{ github.ref_name }}
+        cd ${{ github.workspace }}/esmf-org.github.io        
+        mkdir -p docs/nightly/${{ github.ref_name }}/dev_guide
         cd ${{ github.workspace }}/artifacts
         unzip doc-artifacts.zip
         cd ${{ github.workspace }}/artifacts/artifacts/doc-esmf
@@ -62,7 +62,7 @@ jobs:
         cp -rf NUOPC_refdoc.pdf ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/
         cp -rf NUOPC_howtodoc ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/
         cp -rf NUOPC_howtodoc.pdf ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/
-        cd ${{ github.workspace }}/artifacts/artifacts/doc-dev_guide
+        cd ${{ github.workspace }}/artifacts/artifacts/doc-dev_guide        
         cp -rf ./dev_guide/dev_guide/* ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/dev_guide/
         
     - name: Commit and publish docs

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build Docker image  
       run: | 
         cd ${{ github.workspace }}/esmf-containers/build-esmf-docs/esmpy
-        docker build . --tag esmf/build-esmpy-docs
+        docker build . --tag esmf/build-esmpy-docs --build-arg ESMF_BRANCH="${{ github.ref_name }}" --no-cache
         
     - name: Copy artifacts
       run: |

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build Docker image  
       run: | 
         cd ${{ github.workspace }}/esmf-containers/build-esmf-docs/esmpy
-        docker build . --tag esmf/build-esmpy-docs --build-arg ESMF_BRANCH="${{ github.ref_name }}" --no-cache
+        docker build . --tag esmf/build-esmpy-docs
         
     - name: Copy artifacts
       run: |

--- a/build_config/Darwin.gfortran.default/README
+++ b/build_config/Darwin.gfortran.default/README
@@ -1,11 +1,12 @@
 Settings for Darwin (Mac OS X), using the GNU gfortran compiler 
 and GNU C++ compiler (g++).
 
-On some Darwin systems, the clang compiler is provided as an alias to g++.
-This is detected and properly supported.  On systems where both g++ and clang
-exist, ensure that the PATH environment variable is set correctly such that
-the desired c++ environment is used.  For example, if clang is the desired
-compiler, the path to it should be prior to the path to the gcc bin directory.
+On Mac OS X, the system-level g++ invokes clang++, so unless you ensure
+that you have a true g++ early in your path (or build the MPI compiler
+wrappers to ensure that they wrap the true g++), you will end up using
+clang even if you think you are using the GNU C++ compiler. In that
+case, you should use the gfortranclang configuration instead of this
+gfortran configuration.
 
 Requires the following environment settings:
 

--- a/build_config/Darwin.gfortran.default/README
+++ b/build_config/Darwin.gfortran.default/README
@@ -4,7 +4,7 @@ and GNU C++ compiler (g++).
 On Mac OS X, the system-level g++ invokes clang++, so unless you ensure
 that you have a true g++ early in your path (or build the MPI compiler
 wrappers to ensure that they wrap the true g++), you will end up using
-clang even if you think you are using the GNU C++ compiler. In that
+clang++ even if you think you are using the GNU C++ compiler. In that
 case, you should use the gfortranclang configuration instead of this
 gfortran configuration.
 

--- a/build_config/Darwin.gfortran.default/build_rules.mk
+++ b/build_config/Darwin.gfortran.default/build_rules.mk
@@ -114,14 +114,15 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version
 # See if g++ is really clang
 #
 ESMF_CLANGSTR := $(findstring clang, $(shell $(ESMF_CXXCOMPILER) --version))
+ifeq ($(ESMF_CLANGSTR), clang)
+$(error "The detected C++ compiler is actually clang. Set ESMF_COMPILER=gfortranclang.")
+endif
 
 ############################################################
 # Special debug flags
 #
 ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
-ifneq ($(ESMF_CLANGSTR), clang)
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
-endif
 
 ############################################################
 # Fortran symbol convention
@@ -193,27 +194,19 @@ endif
 ############################################################
 # OpenMP compiler and linker flags
 #
-ifneq ($(ESMF_CLANGSTR), clang)
 ESMF_OPENMP_F90COMPILEOPTS += -fopenmp
 ESMF_OPENMP_CXXCOMPILEOPTS += -fopenmp
 ESMF_OPENMP_F90LINKOPTS    += -fopenmp
 ESMF_OPENMP_CXXLINKOPTS    += -fopenmp
-else
-ESMF_OPENMP=OFF
-endif
 
 ############################################################
 # OpenACC compiler and linker flags
 #
-ifneq ($(ESMF_CLANGSTR), clang)
 ESMF_OPENACCDEFAULT = OFF
 ESMF_OPENACC_F90COMPILEOPTS += -fopenacc
 ESMF_OPENACC_CXXCOMPILEOPTS += -fopenacc
 ESMF_OPENACC_F90LINKOPTS    += -fopenacc
 ESMF_OPENACC_CXXLINKOPTS    += -fopenacc
-else
-ESMF_OPENACC=OFF
-endif
 
 ############################################################
 # Need this until the file convention is fixed (then remove these two lines)
@@ -255,9 +248,6 @@ ESMF_CLINKRPATHS        =
 # Link against libesmf.a using the F90 linker front-end
 #
 ESMF_F90LINKLIBS += -lstdc++
-ifeq ($(ESMF_CLANGSTR), clang)
-ESMF_F90LINKLIBS += -lc++
-endif
 
 ############################################################
 # Link against libesmf.a using the C++ linker front-end

--- a/build_config/Darwin.gfortranclang.default/ESMC_Conf.h
+++ b/build_config/Darwin.gfortranclang.default/ESMC_Conf.h
@@ -30,12 +30,8 @@ Licensed under the University of Illinois-NCSA License.
 #if defined (__cplusplus)
 // Typedef to match the data type of the 'hidden' string length
 // argument that Fortran uses when passing CHARACTER strings.
-#if (__GNUC__ > 7)
 #include <cstddef>
 typedef size_t ESMCI_FortranStrLenArg;
-#else
-typedef int ESMCI_FortranStrLenArg;
-#endif
 #endif
 
 #define ESMC_PRESENT(arg) ( (arg) != 0 )

--- a/build_config/Darwin.gfortranclang.default/README
+++ b/build_config/Darwin.gfortranclang.default/README
@@ -1,8 +1,10 @@
 Settings for Darwin (Mac OS X), using the GNU gfortran compiler and the
 clang C++ compiler (clang++). Note that, on Mac OS X, the system-level
 g++ invokes clang++, so unless you ensure that you have a true g++ early
-in your path, you will end up using clang even if you think you are
-using the GNU C++ compiler, and so you should use this configuration.
+in your path (or build the MPI compiler wrappers to ensure that they
+wrap the true g++), you will end up using clang even if you think you
+are using the GNU C++ compiler, and so you should use this
+configuration.
 
 Requires the following environment settings:
 

--- a/build_config/Darwin.gfortranclang.default/README
+++ b/build_config/Darwin.gfortranclang.default/README
@@ -1,6 +1,18 @@
-Settings for Darwin (Mac OS X), using the GNU gfortran compiler
- and the clang C++ compiler (g++).
+Settings for Darwin (Mac OS X), using the GNU gfortran compiler and the
+clang C++ compiler (clang++). Note that, on Mac OS X, the system-level
+g++ invokes clang++, so unless you ensure that you have a true g++ early
+in your path, you will end up using clang even if you think you are
+using the GNU C++ compiler, and so you should use this configuration.
 
 Requires the following environment settings:
 
 ESMF_COMPILER gfortranclang
+
+CAUTION:
+For ESMF regression testing we set ESMF_F90LINKERDEFAULT to the C++
+compiler in build_rules.mk because this is needed for clean handling of
+exceptions for this compiler combination. For applications with main
+programs in Fortran we have found that this is not always necessary.
+However, if your application aborts with a message like "libc++abi:
+terminating with uncaught exception", that is a sign that you may need
+to link with a C++ compiler rather than a Fortran compiler.

--- a/build_config/Darwin.gfortranclang.default/README
+++ b/build_config/Darwin.gfortranclang.default/README
@@ -2,7 +2,7 @@ Settings for Darwin (Mac OS X), using the GNU gfortran compiler and the
 clang C++ compiler (clang++). Note that, on Mac OS X, the system-level
 g++ invokes clang++, so unless you ensure that you have a true g++ early
 in your path (or build the MPI compiler wrappers to ensure that they
-wrap the true g++), you will end up using clang even if you think you
+wrap the true g++), you will end up using clang++ even if you think you
 are using the GNU C++ compiler, and so you should use this
 configuration.
 

--- a/build_config/Darwin.gfortranclang.default/build_rules.mk
+++ b/build_config/Darwin.gfortranclang.default/build_rules.mk
@@ -1,13 +1,14 @@
 # $Id$
 #
-# Darwin.gfortran.default
+# Darwin.gfortranclang.default
 #
 
 ############################################################
 # Default compiler setting.
 #
 ESMF_F90DEFAULT         = gfortran
-ESMF_CXXDEFAULT         = clang
+ESMF_F90LINKERDEFAULT   = clang++
+ESMF_CXXDEFAULT         = clang++
 ESMF_CDEFAULT           = clang
 ESMF_CPPDEFAULT         = clang -E -P -x c
 
@@ -35,6 +36,7 @@ ifeq ($(ESMF_COMM),mpich1)
 ESMF_F90COMPILECPPFLAGS+= -DESMF_MPICH1
 ESMF_CXXCOMPILECPPFLAGS+= -DESMF_MPICH1
 ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKERDEFAULT   = mpiCC
 ESMF_CXXDEFAULT         = mpiCC
 ESMF_CDEFAULT           = mpicc
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
@@ -44,6 +46,7 @@ else
 ifeq ($(ESMF_COMM),mpich2)
 # Mpich2 ---------------------------------------------------
 ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKERDEFAULT   = mpicxx
 ESMF_CXXDEFAULT         = mpicxx
 ESMF_CDEFAULT           = mpicc
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
@@ -54,15 +57,18 @@ else
 ifeq ($(ESMF_COMM),mpich)
 # Mpich3 and up --------------------------------------------
 ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKERDEFAULT   = mpicxx
 ESMF_CXXDEFAULT         = mpicxx
 ESMF_CDEFAULT           = mpicc
 ESMF_CXXLINKLIBS       += $(shell $(ESMF_DIR)/scripts/libs.mpich3f90)
+ESMF_F90LINKLIBS       += $(shell $(ESMF_DIR)/scripts/libs.mpich3f90)
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
 ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
 else
 ifeq ($(ESMF_COMM),mvapich2)
 # Mvapich2 -------------------------------------------------
 ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKERDEFAULT   = mpicxx
 ESMF_CXXDEFAULT         = mpicxx
 ESMF_CDEFAULT           = mpicc
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
@@ -72,6 +78,7 @@ ifeq ($(ESMF_COMM),lam)
 # LAM (assumed to be built with gfortran) ------------------
 ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
 ESMF_F90DEFAULT         = mpif77
+ESMF_F90LINKERDEFAULT   = mpic++
 ESMF_CXXDEFAULT         = mpic++
 ESMF_CDEFAULT           = mpicc
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
@@ -86,8 +93,10 @@ ESMF_F90DEFAULT         = mpifort
 else
 ESMF_F90DEFAULT         = mpif90
 endif
+ESMF_F90LINKERDEFAULT   = mpicxx
 ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
-ESMF_F90LINKLIBS       += $(shell $(ESMF_DIR)/scripts/libs.openmpif90 $(ESMF_F90DEFAULT))
+# FIXME(wjs, 2022-09-23) Make the following line more dynamic rather than hard-coding libraries
+ESMF_F90LINKLIBS       += -lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh
 ESMF_CXXDEFAULT         = mpicxx
 ESMF_CDEFAULT           = mpicc
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
@@ -116,7 +125,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fimplicit-none -fcheck=all,no-pointer
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################
@@ -208,6 +217,12 @@ ESMF_F90COMPILEFIXCPP    = -cpp -ffixed-form
 ESMF_F90COMPILEOPTS += -ffree-line-length-none
 
 ############################################################
+# Trying to produce a backtrace can lead programs to hang without any useful information
+# rather than aborting cleanly, so disable backtraces.
+#
+ESMF_F90COMPILEOPTS += -fno-backtrace
+
+############################################################
 # Set rpath syntax
 #
 ESMF_F90RPATHPREFIX         = -Wl,-rpath,
@@ -223,31 +238,22 @@ ESMF_LIBGFORTRAN := $(shell $(ESMF_F90COMPILER) -print-file-name=libgfortran.a)
 endif
 ESMF_CXXLINKPATHS += -L$(dir $(ESMF_LIBGFORTRAN))
 ESMF_CXXLINKRPATHS += $(ESMF_CXXRPATHPREFIX)$(dir $(ESMF_LIBGFORTRAN))
-
-############################################################
-# Link against the c++ library
-#
-ESMF_LIBSTDCXX := $(shell $(ESMF_CXXCOMPILER) -print-file-name=libc++.dylib)
-ifeq ($(ESMF_LIBSTDCXX),libc++.dylib)
-ESMF_LIBSTDCXX := $(shell $(ESMF_CXXCOMPILER) -print-file-name=libc++.a)
-endif
-ESMF_F90LINKPATHS += -L$(dir $(ESMF_LIBSTDCXX))
-ESMF_F90LINKLIBS  += -lc++
-
-############################################################
-# Link against libesmf.a using the F90 linker front-end
-#
-ESMF_F90LINKLIBS += -lm
+# With clang, we use a C++ linker for Fortran programs, so use the same link paths as for CXX:
+ESMF_F90LINKPATHS += -L$(dir $(ESMF_LIBGFORTRAN))
+ESMF_F90LINKRPATHS += $(ESMF_CXXRPATHPREFIX)$(dir $(ESMF_LIBGFORTRAN))
 
 ############################################################
 # Link against libesmf.a using the C++ linker front-end
 #
 ESMF_CXXLINKLIBS += -lgfortran -lc++
+# With clang, we use a C++ linker for Fortran programs, so use the same link libs as for CXX:
+ESMF_F90LINKLIBS += -lgfortran -lc++
 
 ############################################################
 # Shared library options
 ESMF_SL_LIBOPTS  += -dynamiclib
-ESMF_SL_LIBLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKLIBS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKLIBS)
+# No need for "$(ESMF_F90LINKPATHS) $(ESMF_F90LINKLIBS)" in the following because they are identical to the CXX versions:
+ESMF_SL_LIBLIBS  += $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKLIBS)
 
 ############################################################
 # Static builds on Darwin do not support trace lib due to missing linker option

--- a/build_config/Darwin.gfortranclang.default/build_rules.mk
+++ b/build_config/Darwin.gfortranclang.default/build_rules.mk
@@ -95,8 +95,7 @@ ESMF_F90DEFAULT         = mpif90
 endif
 ESMF_F90LINKERDEFAULT   = mpicxx
 ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
-# FIXME(wjs, 2022-09-23) Make the following line more dynamic rather than hard-coding libraries
-ESMF_F90LINKLIBS       += -lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh
+ESMF_F90LINKLIBS       += $(shell $(ESMF_DIR)/scripts/libs.openmpif90_forcxx $(ESMF_F90DEFAULT))
 ESMF_CXXDEFAULT         = mpicxx
 ESMF_CDEFAULT           = mpicc
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)

--- a/build_config/Darwin.gfortranclang.default/build_rules.mk
+++ b/build_config/Darwin.gfortranclang.default/build_rules.mk
@@ -244,9 +244,9 @@ ESMF_F90LINKRPATHS += $(ESMF_CXXRPATHPREFIX)$(dir $(ESMF_LIBGFORTRAN))
 ############################################################
 # Link against libesmf.a using the C++ linker front-end
 #
-ESMF_CXXLINKLIBS += -lgfortran -lc++
+ESMF_CXXLINKLIBS += -lgfortran
 # With clang, we use a C++ linker for Fortran programs, so use the same link libs as for CXX:
-ESMF_F90LINKLIBS += -lgfortran -lc++
+ESMF_F90LINKLIBS += -lgfortran
 
 ############################################################
 # Shared library options

--- a/build_config/Linux.arm.default/ESMC_Conf.h
+++ b/build_config/Linux.arm.default/ESMC_Conf.h
@@ -1,0 +1,39 @@
+#ifdef ESMC_RCS_HEADER
+"$Id$"
+"Defines the configuration for this machine"
+#endif
+
+#if 0
+Earth System Modeling Framework
+Copyright 2002-2022, University Corporation for Atmospheric Research,
+Massachusetts Institute of Technology, Geophysical Fluid Dynamics
+Laboratory, University of Michigan, National Centers for Environmental
+Prediction, Los Alamos National Laboratory, Argonne National Laboratory,
+NASA Goddard Space Flight Center.
+Licensed under the University of Illinois-NCSA License.
+#endif
+
+#if !defined(INCLUDED_CONF_H)
+#define INCLUDED_CONF_H
+
+#define PARCH_linux
+
+#ifdef ESMF_LOWERCASE_SINGLEUNDERSCORE 
+#define FTN_X(func) func##_
+#define FTNX(func) func##_
+#endif
+#ifdef ESMF_LOWERCASE_DOUBLEUNDERSCORE 
+#define FTN_X(func) func##__
+#define FTNX(func) func##_
+#endif
+
+#if defined (__cplusplus)
+// Typedef to match the data type of the 'hidden' string length
+// argument that Fortran uses when passing CHARACTER strings.
+#include <cstddef>
+typedef size_t ESMCI_FortranStrLenArg;
+#endif
+
+#define ESMC_PRESENT(arg) ( (arg) != 0 )
+
+#endif

--- a/build_config/Linux.arm.default/ESMF_Conf.inc
+++ b/build_config/Linux.arm.default/ESMF_Conf.inc
@@ -1,0 +1,11 @@
+#if 0
+$Id$
+
+Earth System Modeling Framework
+Copyright 2002-2022, University Corporation for Atmospheric Research,
+Massachusetts Institute of Technology, Geophysical Fluid Dynamics
+Laboratory, University of Michigan, National Centers for Environmental
+Prediction, Los Alamos National Laboratory, Argonne National Laboratory,
+NASA Goddard Space Flight Center.
+Licensed under the University of Illinois-NCSA License.
+#endif

--- a/build_config/Linux.arm.default/README
+++ b/build_config/Linux.arm.default/README
@@ -1,0 +1,5 @@
+Settings for Linux, using the ARM compilers: armclang and armflang.
+
+Requires the following environment settings:
+
+ESMF_COMPILER arm

--- a/build_config/Linux.arm.default/build_rules.mk
+++ b/build_config/Linux.arm.default/build_rules.mk
@@ -1,0 +1,290 @@
+# $Id$
+#
+# Linux.arm.default
+#
+
+############################################################
+# Default compiler setting.
+#
+ESMF_F90DEFAULT         = armflang
+ESMF_CXXDEFAULT         = armclang
+ESMF_CDEFAULT           = armclang
+ESMF_CPPDEFAULT		= armclang -E -P -x c
+
+ESMF_CXXCOMPILECPPFLAGS += -x c++
+
+############################################################
+# Default MPI setting.
+#
+ifeq ($(ESMF_COMM),default)
+export ESMF_COMM := mpiuni
+endif
+
+############################################################
+# MPI dependent settings.
+#
+ifeq ($(ESMF_COMM),mpiuni)
+# MPI stub library -----------------------------------------
+ESMF_F90COMPILECPPFLAGS+= -DESMF_MPIUNI
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_MPIUNI
+ESMF_CXXCOMPILEPATHS   += -I$(ESMF_DIR)/src/Infrastructure/stubs/mpiuni
+ESMF_MPIRUNDEFAULT      = $(ESMF_DIR)/src/Infrastructure/stubs/mpiuni/mpirun
+else
+ifeq ($(ESMF_COMM),mpi)
+# Vendor MPI -----------------------------------------------
+ESMF_F90LINKLIBS       += -lmpi -lmpi++
+ESMF_CXXLINKLIBS       += -lmpi -lmpi++
+ESMF_MPIRUNDEFAULT      = mpiexec_mpt $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec_mpt $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),mpt)
+# MPT with compiler wrappers -------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKLIBS       += -lmpi++
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),mpich1)
+# Mpich1 ---------------------------------------------------
+ESMF_F90COMPILECPPFLAGS+= -DESMF_MPICH1
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_MPICH1
+ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKLIBS       += -lpmpich++ -lmpich
+ESMF_CXXDEFAULT         = mpiCC
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_F90COMPILECPPFLAGS+= -DESMF_NO_MPI3
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_MPI3
+else
+ifeq ($(ESMF_COMM),mpich2)
+# Mpich2 ---------------------------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+ESMF_F90COMPILECPPFLAGS+= -DESMF_NO_MPI3
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_MPI3
+else
+ifeq ($(ESMF_COMM),mpich)
+# Mpich3 and up --------------------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),mvapich2)
+# Mvapich2 ---------------------------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),lam)
+# LAM (assumed to be built with armflang) -----------------------
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
+ESMF_F90DEFAULT         = mpif77
+ESMF_CXXDEFAULT         = mpic++
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+ESMF_F90COMPILECPPFLAGS+= -DESMF_NO_MPI3
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_MPI3
+else
+ifeq ($(ESMF_COMM),openmpi)
+# OpenMPI --------------------------------------------------
+ifeq ($(shell $(ESMF_DIR)/scripts/available mpifort),mpifort)
+ESMF_F90DEFAULT         = mpifort
+else
+ESMF_F90DEFAULT         = mpif90
+endif
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
+ESMF_F90LINKLIBS       += $(shell $(ESMF_DIR)/scripts/libs.openmpif90 $(ESMF_F90DEFAULT))
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),user)
+# User specified flags -------------------------------------
+else
+$(error Invalid ESMF_COMM setting: $(ESMF_COMM))
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+
+############################################################
+# Print compiler version string
+#
+ESMF_F90COMPILER_VERSION    = ${ESMF_F90COMPILER} -v --version
+ESMF_CXXCOMPILER_VERSION    = ${ESMF_CXXCOMPILER} -v --version
+ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
+
+############################################################
+# Special debug flags
+#
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+
+############################################################
+# Fortran symbol convention
+#
+ifeq ($(ESMF_FORTRANSYMBOLS),default)
+ESMF_F90COMPILEOPTS       +=
+ESMF_F90LINKOPTS          +=
+ESMF_CXXCOMPILEOPTS       += -DESMF_LOWERCASE_SINGLEUNDERSCORE
+else
+ifeq ($(ESMF_FORTRANSYMBOLS),lowercase_singleunderscore)
+ESMF_F90COMPILEOPTS       += -fno-second-underscore
+ESMF_F90LINKOPTS          += -fno-second-underscore
+ESMF_CXXCOMPILEOPTS       += -DESMF_LOWERCASE_SINGLEUNDERSCORE
+else
+ifeq ($(ESMF_FORTRANSYMBOLS),lowercase_doubleunderscore)
+ESMF_F90COMPILEOPTS       += -fsecond-underscore
+ESMF_F90LINKOPTS          += -fsecond-underscore
+ESMF_CXXCOMPILEOPTS       += -DESMF_LOWERCASE_DOUBLEUNDERSCORE
+else
+$(error "ESMF_FORTRANSYMBOLS = $(ESMF_FORTRANSYMBOLS)" not supported by ESMF and/or this platform)
+endif
+endif
+endif
+
+############################################################
+# Construct the ABISTRING
+#
+ifeq ($(ESMF_MACHINE),ia64)
+ifeq ($(ESMF_ABI),64)
+ESMF_ABISTRING := $(ESMF_MACHINE)_64
+else
+$(error Invalid ESMF_MACHINE / ESMF_ABI combination: $(ESMF_MACHINE) / $(ESMF_ABI))
+endif
+endif
+ifeq ($(ESMF_MACHINE),x86_64)
+ifeq ($(ESMF_ABI),32)
+ESMF_ABISTRING := $(ESMF_MACHINE)_32
+endif
+ifeq ($(ESMF_ABI),64)
+ESMF_ABISTRING := x86_64_small
+endif
+endif
+
+############################################################
+# Set memory model compiler flags according to ABISTRING
+#
+ifeq ($(ESMF_ABISTRING),x86_64_32)
+ESMF_CXXCOMPILEOPTS       += -m32
+ESMF_CXXLINKOPTS          += -m32
+ESMF_F90COMPILEOPTS       += -m32
+ESMF_F90LINKOPTS          += -m32
+endif
+ifeq ($(ESMF_ABISTRING),x86_64_small)
+ESMF_CXXCOMPILEOPTS       += -m64 -mcmodel=small
+ESMF_CXXLINKOPTS          += -m64 -mcmodel=small
+ESMF_F90COMPILEOPTS       += -m64 -mcmodel=small
+ESMF_F90LINKOPTS          += -m64 -mcmodel=small
+endif
+ifeq ($(ESMF_ABISTRING),x86_64_medium)
+ESMF_CXXCOMPILEOPTS       += -m64 -mcmodel=medium
+ESMF_CXXLINKOPTS          += -m64 -mcmodel=medium
+ESMF_F90COMPILEOPTS       += -m64 -mcmodel=medium
+ESMF_F90LINKOPTS          += -m64 -mcmodel=medium
+endif
+
+############################################################
+# Conditionally add pthread compiler and linker flags
+#
+ifeq ($(ESMF_PTHREADS),ON)
+ESMF_F90COMPILEOPTS += -pthread
+ESMF_CXXCOMPILEOPTS += -pthread
+ESMF_F90LINKOPTS    += -pthread
+ESMF_CXXLINKOPTS    += -pthread
+endif
+
+############################################################
+# OpenMP compiler and linker flags
+#
+ESMF_OPENMP=OFF
+# ESMF_OPENMP_F90COMPILEOPTS += -fopenmp
+# ESMF_OPENMP_CXXCOMPILEOPTS += -fopenmp
+# ESMF_OPENMP_F90LINKOPTS    += -fopenmp
+# ESMF_OPENMP_CXXLINKOPTS    += -fopenmp
+
+############################################################
+# Need this until the file convention is fixed (then remove these two lines)
+#
+ESMF_F90COMPILEFREENOCPP = -ffree-form
+ESMF_F90COMPILEFIXCPP    = -cpp -ffixed-form
+
+############################################################
+# Set unlimited line length limit for free format files
+#
+ESMF_F90COMPILEOPTS += -ffree-line-length-none
+
+############################################################
+# Set rpath syntax
+#
+ESMF_F90RPATHPREFIX         = -Wl,-rpath,
+ESMF_CXXRPATHPREFIX         = -Wl,-rpath,
+ESMF_CRPATHPREFIX           = -Wl,-rpath,
+
+############################################################
+# Determine where gcc's libraries are located
+#
+ESMF_LIBSTDCXX := $(shell $(ESMF_CXXCOMPILER) $(ESMF_CXXCOMPILEOPTS) -print-file-name=libstdc++.so)
+ifeq ($(ESMF_LIBSTDCXX),libstdc++.so)
+ESMF_LIBSTDCXX := $(shell $(ESMF_CXXCOMPILER) $(ESMF_CXXCOMPILEOPTS) -print-file-name=libstdc++.a)
+endif
+ESMF_F90LINKPATHS += -L$(dir $(ESMF_LIBSTDCXX))
+ESMF_F90LINKRPATHS += $(ESMF_F90RPATHPREFIX)$(dir $(ESMF_LIBSTDCXX))
+
+############################################################
+# Determine where armflang's libraries are located
+#
+ESMF_LIBARMFLANG := $(shell $(ESMF_F90COMPILER) $(ESMF_F90COMPILEOPTS) -print-file-name=libarmflang.so)
+ifeq ($(ESMF_LIBARMFLANG),libarmflang.so)
+ESMF_LIBARMFLANG := $(shell $(ESMF_F90COMPILER) $(ESMF_F90COMPILEOPTS) -print-file-name=libarmflang.a)
+endif
+ESMF_CXXLINKPATHS += -L$(dir $(ESMF_LIBARMFLANG))
+ESMF_CXXLINKRPATHS += $(ESMF_CXXRPATHPREFIX)$(dir $(ESMF_LIBARMFLANG))
+
+############################################################
+# Link against libesmf.a using the F90 linker front-end
+#
+ESMF_F90LINKLIBS += -lrt -lstdc++ -ldl
+
+############################################################
+# Link against libesmf.a using the C++ linker front-end
+#
+ESMF_CXXLINKLIBS += -lrt -larmflang -lstdc++ -lm -ldl
+
+############################################################
+# Linker option that ensures that the specified libraries are 
+# used to also resolve symbols needed by other libraries.
+#
+ESMF_F90LINKOPTS          += -Wl,--no-as-needed
+ESMF_CXXLINKOPTS          += -Wl,--no-as-needed
+
+############################################################
+# Shared library options
+#
+ESMF_SL_LIBOPTS  += -shared
+
+############################################################
+# Shared object options
+#
+ESMF_SO_F90COMPILEOPTS  = -fPIC
+ESMF_SO_F90LINKOPTS     = -shared
+ESMF_SO_F90LINKOPTSEXE  = -Wl,-export-dynamic
+ESMF_SO_CXXCOMPILEOPTS  = -fPIC
+ESMF_SO_CXXLINKOPTS     = -shared
+ESMF_SO_CXXLINKOPTSEXE  = -Wl,-export-dynamic

--- a/build_config/Linux.arm.default/build_rules.mk
+++ b/build_config/Linux.arm.default/build_rules.mk
@@ -132,6 +132,12 @@ ESMF_CXXCOMPILER_VERSION    = ${ESMF_CXXCOMPILER} -v --version
 ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 
 ############################################################
+# Currently no support for the Fortran2018 assumed type feature
+#
+ESMF_F90COMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
+ESMF_CXXCOMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
+
+############################################################
 # Special debug flags
 #
 ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer

--- a/build_config/Linux.gfortranclang.default/ESMC_Conf.h
+++ b/build_config/Linux.gfortranclang.default/ESMC_Conf.h
@@ -30,12 +30,8 @@ Licensed under the University of Illinois-NCSA License.
 #if defined (__cplusplus)
 // Typedef to match the data type of the 'hidden' string length
 // argument that Fortran uses when passing CHARACTER strings.
-#if (__GNUC__ > 7)
 #include <cstddef>
 typedef size_t ESMCI_FortranStrLenArg;
-#else
-typedef int ESMCI_FortranStrLenArg;
-#endif
 #endif
 
 #define ESMC_PRESENT(arg) ( (arg) != 0 )

--- a/build_config/Linux.llvm.default/ESMC_Conf.h
+++ b/build_config/Linux.llvm.default/ESMC_Conf.h
@@ -1,0 +1,39 @@
+#ifdef ESMC_RCS_HEADER
+"$Id$"
+"Defines the configuration for this machine"
+#endif
+
+#if 0
+Earth System Modeling Framework
+Copyright 2002-2022, University Corporation for Atmospheric Research,
+Massachusetts Institute of Technology, Geophysical Fluid Dynamics
+Laboratory, University of Michigan, National Centers for Environmental
+Prediction, Los Alamos National Laboratory, Argonne National Laboratory,
+NASA Goddard Space Flight Center.
+Licensed under the University of Illinois-NCSA License.
+#endif
+
+#if !defined(INCLUDED_CONF_H)
+#define INCLUDED_CONF_H
+
+#define PARCH_linux
+
+#ifdef ESMF_LOWERCASE_SINGLEUNDERSCORE 
+#define FTN_X(func) func##_
+#define FTNX(func) func##_
+#endif
+#ifdef ESMF_LOWERCASE_DOUBLEUNDERSCORE 
+#define FTN_X(func) func##__
+#define FTNX(func) func##_
+#endif
+
+#if defined (__cplusplus)
+// Typedef to match the data type of the 'hidden' string length
+// argument that Fortran uses when passing CHARACTER strings.
+#include <cstddef>
+typedef size_t ESMCI_FortranStrLenArg;
+#endif
+
+#define ESMC_PRESENT(arg) ( (arg) != 0 )
+
+#endif

--- a/build_config/Linux.llvm.default/ESMF_Conf.inc
+++ b/build_config/Linux.llvm.default/ESMF_Conf.inc
@@ -1,0 +1,11 @@
+#if 0
+$Id$
+
+Earth System Modeling Framework
+Copyright 2002-2022, University Corporation for Atmospheric Research,
+Massachusetts Institute of Technology, Geophysical Fluid Dynamics
+Laboratory, University of Michigan, National Centers for Environmental
+Prediction, Los Alamos National Laboratory, Argonne National Laboratory,
+NASA Goddard Space Flight Center.
+Licensed under the University of Illinois-NCSA License.
+#endif

--- a/build_config/Linux.llvm.default/README
+++ b/build_config/Linux.llvm.default/README
@@ -1,0 +1,10 @@
+Settings for Linux, using the LLVM compilers: clang and flang-new.
+
+Requires the following environment settings:
+
+ESMF_COMPILER llvm
+
+CAUTION: 
+This configuration, last tested with LLVM 15.0.1 from https://github.com/llvm/llvm-project.git,
+has NOT been able to successfully build the ESMF library. The configuration is included with
+ESMF for future testing with LLVM, and will likely require modifications.

--- a/build_config/Linux.llvm.default/build_rules.mk
+++ b/build_config/Linux.llvm.default/build_rules.mk
@@ -1,0 +1,290 @@
+# $Id$
+#
+# Linux.llvm.default
+#
+
+############################################################
+# Default compiler setting.
+#
+ESMF_F90DEFAULT         = flang-new
+ESMF_CXXDEFAULT         = clang
+ESMF_CDEFAULT           = clang
+ESMF_CPPDEFAULT		= clang -E -P -x c
+
+ESMF_CXXCOMPILECPPFLAGS += -x c++
+
+############################################################
+# Default MPI setting.
+#
+ifeq ($(ESMF_COMM),default)
+export ESMF_COMM := mpiuni
+endif
+
+############################################################
+# MPI dependent settings.
+#
+ifeq ($(ESMF_COMM),mpiuni)
+# MPI stub library -----------------------------------------
+ESMF_F90COMPILECPPFLAGS+= -DESMF_MPIUNI
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_MPIUNI
+ESMF_CXXCOMPILEPATHS   += -I$(ESMF_DIR)/src/Infrastructure/stubs/mpiuni
+ESMF_MPIRUNDEFAULT      = $(ESMF_DIR)/src/Infrastructure/stubs/mpiuni/mpirun
+else
+ifeq ($(ESMF_COMM),mpi)
+# Vendor MPI -----------------------------------------------
+ESMF_F90LINKLIBS       += -lmpi -lmpi++
+ESMF_CXXLINKLIBS       += -lmpi -lmpi++
+ESMF_MPIRUNDEFAULT      = mpiexec_mpt $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec_mpt $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),mpt)
+# MPT with compiler wrappers -------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKLIBS       += -lmpi++
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),mpich1)
+# Mpich1 ---------------------------------------------------
+ESMF_F90COMPILECPPFLAGS+= -DESMF_MPICH1
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_MPICH1
+ESMF_F90DEFAULT         = mpif90
+ESMF_F90LINKLIBS       += -lpmpich++ -lmpich
+ESMF_CXXDEFAULT         = mpiCC
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_F90COMPILECPPFLAGS+= -DESMF_NO_MPI3
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_MPI3
+else
+ifeq ($(ESMF_COMM),mpich2)
+# Mpich2 ---------------------------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+ESMF_F90COMPILECPPFLAGS+= -DESMF_NO_MPI3
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_MPI3
+else
+ifeq ($(ESMF_COMM),mpich)
+# Mpich3 and up --------------------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),mvapich2)
+# Mvapich2 ---------------------------------------------------
+ESMF_F90DEFAULT         = mpif90
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),lam)
+# LAM (assumed to be built with flang-new) -----------------------
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
+ESMF_F90DEFAULT         = mpif77
+ESMF_CXXDEFAULT         = mpic++
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+ESMF_F90COMPILECPPFLAGS+= -DESMF_NO_MPI3
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_MPI3
+else
+ifeq ($(ESMF_COMM),openmpi)
+# OpenMPI --------------------------------------------------
+ifeq ($(shell $(ESMF_DIR)/scripts/available mpifort),mpifort)
+ESMF_F90DEFAULT         = mpifort
+else
+ESMF_F90DEFAULT         = mpif90
+endif
+ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
+ESMF_F90LINKLIBS       += $(shell $(ESMF_DIR)/scripts/libs.openmpif90 $(ESMF_F90DEFAULT))
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_CDEFAULT           = mpicc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
+ifeq ($(ESMF_COMM),user)
+# User specified flags -------------------------------------
+else
+$(error Invalid ESMF_COMM setting: $(ESMF_COMM))
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+
+############################################################
+# Print compiler version string
+#
+ESMF_F90COMPILER_VERSION    = ${ESMF_F90COMPILER} -v --version
+ESMF_CXXCOMPILER_VERSION    = ${ESMF_CXXCOMPILER} -v --version
+ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
+
+############################################################
+# Special debug flags
+#
+ESMF_F90OPTFLAG_G       += 
+
+############################################################
+# Fortran symbol convention
+#
+ifeq ($(ESMF_FORTRANSYMBOLS),default)
+ESMF_F90COMPILEOPTS       +=
+ESMF_F90LINKOPTS          +=
+ESMF_CXXCOMPILEOPTS       += -DESMF_LOWERCASE_SINGLEUNDERSCORE
+else
+ifeq ($(ESMF_FORTRANSYMBOLS),lowercase_singleunderscore)
+ESMF_F90COMPILEOPTS       += -fno-second-underscore
+ESMF_F90LINKOPTS          += -fno-second-underscore
+ESMF_CXXCOMPILEOPTS       += -DESMF_LOWERCASE_SINGLEUNDERSCORE
+else
+ifeq ($(ESMF_FORTRANSYMBOLS),lowercase_doubleunderscore)
+ESMF_F90COMPILEOPTS       += -fsecond-underscore
+ESMF_F90LINKOPTS          += -fsecond-underscore
+ESMF_CXXCOMPILEOPTS       += -DESMF_LOWERCASE_DOUBLEUNDERSCORE
+else
+$(error "ESMF_FORTRANSYMBOLS = $(ESMF_FORTRANSYMBOLS)" not supported by ESMF and/or this platform)
+endif
+endif
+endif
+
+############################################################
+# Construct the ABISTRING
+#
+ifeq ($(ESMF_MACHINE),ia64)
+ifeq ($(ESMF_ABI),64)
+ESMF_ABISTRING := $(ESMF_MACHINE)_64
+else
+$(error Invalid ESMF_MACHINE / ESMF_ABI combination: $(ESMF_MACHINE) / $(ESMF_ABI))
+endif
+endif
+ifeq ($(ESMF_MACHINE),x86_64)
+ifeq ($(ESMF_ABI),32)
+ESMF_ABISTRING := $(ESMF_MACHINE)_32
+endif
+ifeq ($(ESMF_ABI),64)
+ESMF_ABISTRING := x86_64_small
+endif
+endif
+
+############################################################
+# Set memory model compiler flags according to ABISTRING
+#
+ifeq ($(ESMF_ABISTRING),x86_64_32)
+ESMF_CXXCOMPILEOPTS       += -m32
+ESMF_CXXLINKOPTS          += -m32
+ESMF_F90COMPILEOPTS       += -m32
+ESMF_F90LINKOPTS          += -m32
+endif
+ifeq ($(ESMF_ABISTRING),x86_64_small)
+ESMF_CXXCOMPILEOPTS       += -m64 -mcmodel=small
+ESMF_CXXLINKOPTS          += -m64 -mcmodel=small
+ESMF_F90COMPILEOPTS       += -m64 -mcmodel=small
+ESMF_F90LINKOPTS          += -m64 -mcmodel=small
+endif
+ifeq ($(ESMF_ABISTRING),x86_64_medium)
+ESMF_CXXCOMPILEOPTS       += -m64 -mcmodel=medium
+ESMF_CXXLINKOPTS          += -m64 -mcmodel=medium
+ESMF_F90COMPILEOPTS       += -m64 -mcmodel=medium
+ESMF_F90LINKOPTS          += -m64 -mcmodel=medium
+endif
+
+############################################################
+# Conditionally add pthread compiler and linker flags
+#
+ifeq ($(ESMF_PTHREADS),ON)
+ESMF_F90COMPILEOPTS += -pthread
+ESMF_CXXCOMPILEOPTS += -pthread
+ESMF_F90LINKOPTS    += -pthread
+ESMF_CXXLINKOPTS    += -pthread
+endif
+
+############################################################
+# OpenMP compiler and linker flags
+#
+ESMF_OPENMP=OFF
+# ESMF_OPENMP_F90COMPILEOPTS += -fopenmp
+# ESMF_OPENMP_CXXCOMPILEOPTS += -fopenmp
+# ESMF_OPENMP_F90LINKOPTS    += -fopenmp
+# ESMF_OPENMP_CXXLINKOPTS    += -fopenmp
+
+############################################################
+# Need this until the file convention is fixed (then remove these two lines)
+#
+ESMF_F90COMPILEFREENOCPP = -ffree-form
+ESMF_F90COMPILEFIXCPP    = -cpp -ffixed-form
+
+############################################################
+# Set unlimited line length limit for free format files
+#
+ESMF_F90COMPILEOPTS += -ffree-line-length-none
+
+############################################################
+# Set rpath syntax
+#
+ESMF_F90RPATHPREFIX         = -Wl,-rpath,
+ESMF_CXXRPATHPREFIX         = -Wl,-rpath,
+ESMF_CRPATHPREFIX           = -Wl,-rpath,
+
+############################################################
+# Determine where gcc's libraries are located
+#
+ESMF_LIBSTDCXX := $(shell $(ESMF_CXXCOMPILER) $(ESMF_CXXCOMPILEOPTS) -print-file-name=libstdc++.so)
+ifeq ($(ESMF_LIBSTDCXX),libstdc++.so)
+ESMF_LIBSTDCXX := $(shell $(ESMF_CXXCOMPILER) $(ESMF_CXXCOMPILEOPTS) -print-file-name=libstdc++.a)
+endif
+ESMF_F90LINKPATHS += -L$(dir $(ESMF_LIBSTDCXX))
+ESMF_F90LINKRPATHS += $(ESMF_F90RPATHPREFIX)$(dir $(ESMF_LIBSTDCXX))
+
+############################################################
+# Determine where flang-new's libraries are located
+#
+ESMF_LIBFLANG := $(shell $(ESMF_F90COMPILER) $(ESMF_F90COMPILEOPTS) -print-file-name=libflang.so)
+ifeq ($(ESMF_LIBFLANG),libflang.so)
+ESMF_LIBFLANG := $(shell $(ESMF_F90COMPILER) $(ESMF_F90COMPILEOPTS) -print-file-name=libflang.a)
+endif
+ESMF_CXXLINKPATHS += -L$(dir $(ESMF_LIBFLANG))
+ESMF_CXXLINKRPATHS += $(ESMF_CXXRPATHPREFIX)$(dir $(ESMF_LIBFLANG))
+
+############################################################
+# Link against libesmf.a using the F90 linker front-end
+#
+ESMF_F90LINKLIBS += -lrt -lstdc++ -ldl
+
+############################################################
+# Link against libesmf.a using the C++ linker front-end
+#
+ESMF_CXXLINKLIBS += -lrt -lflang -lstdc++ -lm -ldl
+
+############################################################
+# Linker option that ensures that the specified libraries are 
+# used to also resolve symbols needed by other libraries.
+#
+ESMF_F90LINKOPTS          += -Wl,--no-as-needed
+ESMF_CXXLINKOPTS          += -Wl,--no-as-needed
+
+############################################################
+# Shared library options
+#
+ESMF_SL_LIBOPTS  += -shared
+
+############################################################
+# Shared object options
+#
+ESMF_SO_F90COMPILEOPTS  = -fPIC
+ESMF_SO_F90LINKOPTS     = -shared
+ESMF_SO_F90LINKOPTSEXE  = -Wl,-export-dynamic
+ESMF_SO_CXXCOMPILEOPTS  = -fPIC
+ESMF_SO_CXXLINKOPTS     = -shared
+ESMF_SO_CXXLINKOPTSEXE  = -Wl,-export-dynamic

--- a/scripts/libs.openmpif90
+++ b/scripts/libs.openmpif90
@@ -1,5 +1,5 @@
 #!/bin/sh
-# this scripts determines whether libmpi_cxx needs to be included or not.
+# this scripts determines whether libmpi_cxx needs to be included or not when linking with a Fortran linker
 # Prior to OpenMPI 2.0, libmpi_cxx must be added.  Post-2.0, it is optional.
 OPENMPI_MPIF90=`which $1`
 OPENMPI_LIBDIR=`dirname ${OPENMPI_MPIF90}`/../lib*

--- a/scripts/libs.openmpif90_forcxx
+++ b/scripts/libs.openmpif90_forcxx
@@ -1,0 +1,9 @@
+#!/bin/sh
+# This script obtains the Fortran OpenMPI libraries that need to be explicitly added to
+# the link line when linking with a C++ linker. (This adds an extra instance of -lmpi, but
+# that shouldn't be a problem.)
+OPENMPI_MPIF90=`which $1`
+libs=`${OPENMPI_MPIF90} --showme:libs`
+# The above returns the names of the libraries without '-l'. Here we add '-l' to the start
+# of each library name:
+echo $libs | sed -E 's/(^| ) */ -l/g'

--- a/scripts/nfconfigtest
+++ b/scripts/nfconfigtest
@@ -1,8 +1,8 @@
 #!/bin/sh
 # return "working" if nf-config is working, "notworking" otherwise
-firstpart=`$1 --version  | awk '{ print $1 }'`
-if ([ $firstpart = "netCDF-Fortran" ]); then
-echo "working"
+$1 --flibs | grep -i 'not.*implemented' > /dev/null
+if [ $? = 0 ]; then
+    echo "notworking"
 else
-echo "notworking"
+    echo "working"
 fi

--- a/src/Infrastructure/IO/include/ESMCI_IO_Handler.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Handler.h
@@ -78,7 +78,7 @@ namespace ESMCI {
   private:
 //    IO(ESMC_IOFmt_Flag fmtArg, int rank, int *rc);
   protected:
-    ~IO_Handler() { destruct(); }
+    virtual ~IO_Handler() { destruct(); }
     // create() and destroy()
   public:
     static IO_Handler *create(ESMC_IOFmt_Flag iofmt, int ntiles, int *rc = NULL);

--- a/src/Superstructure/InfoAPI/interface/ESMF_InfoDescribe.F90
+++ b/src/Superstructure/InfoAPI/interface/ESMF_InfoDescribe.F90
@@ -249,7 +249,7 @@ end subroutine ESMF_InfoDescribePrint
 
 #undef  ESMF_METHOD
 #define ESMF_METHOD "fillMembersState()"
-subroutine fillMembersState(self, state, root_key, keywordEnforcer, rc)
+recursive subroutine fillMembersState(self, state, root_key, keywordEnforcer, rc)
   class(ESMF_InfoDescribe), intent(inout) :: self
   type(ESMF_State), intent(in) :: state
   character(*), intent(in) :: root_key
@@ -568,7 +568,7 @@ end subroutine updateWithDistGrid
 
 #undef  ESMF_METHOD
 #define ESMF_METHOD "updateWithState()"
-subroutine updateWithState(self, state, root_key, keywordEnforcer, rc)
+recursive subroutine updateWithState(self, state, root_key, keywordEnforcer, rc)
   class(ESMF_InfoDescribe), intent(inout) :: self
   type(ESMF_State), intent(in) :: state
   character(*), intent(in) :: root_key

--- a/src/addon/NUOPC/src/NUOPC_Driver.F90
+++ b/src/addon/NUOPC/src/NUOPC_Driver.F90
@@ -3448,7 +3448,7 @@ module NUOPC_Driver
   
   !-----------------------------------------------------------------------------
   
-  subroutine routine_executeGridComp(is, i, phase, activeClock, name, userrc, rc)
+  recursive subroutine routine_executeGridComp(is, i, phase, activeClock, name, userrc, rc)
     type(type_InternalState)        :: is
     integer,          intent(in)    :: i, phase
     type(ESMF_Clock), intent(inout) :: activeClock
@@ -3493,7 +3493,7 @@ module NUOPC_Driver
 
   !-----------------------------------------------------------------------------
   
-  subroutine routine_executeCplComp(is, i, j, phase, activeClock, name, userrc, rc)
+  recursive subroutine routine_executeCplComp(is, i, j, phase, activeClock, name, userrc, rc)
     type(type_InternalState)        :: is
     integer,          intent(in)    :: i, j, phase
     type(ESMF_Clock), intent(inout) :: activeClock


### PR DESCRIPTION
(1) From myself: fixes to get Darwin.gfortranclang combination working. I have tested this with openmpi on my M1 Mac. I will do some other testing today.

(2) From @theurich : Add Linux ARM and LLVM compilers

Resolves #60 
Resolves #81 