### PR TITLE
catch a different pio error message

### DIFF
--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
@@ -421,7 +421,7 @@ void ESMCI_mesh_create_from_ESMFMesh_file(int pioSystemDesc,
     int mode = 0;
     piorc = PIOc_openfile(pioSystemDesc, &pioFileDesc, &pio_type, filename, mode);
     // if the file was created with netcdf4, it cannot be opened with pnetcdf
-    if (piorc == PIO_EINVAL || PIO_ENOTBUILT){
+    if (piorc == PIO_EINVAL || piorc == PIO_ENOTBUILT){
         pio_type = PIO_IOTYPE_NETCDF;
         piorc = PIOc_openfile(pioSystemDesc, &pioFileDesc, &pio_type, filename, mode);
     }

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
@@ -421,11 +421,9 @@ void ESMCI_mesh_create_from_ESMFMesh_file(int pioSystemDesc,
     int mode = 0;
     piorc = PIOc_openfile(pioSystemDesc, &pioFileDesc, &pio_type, filename, mode);
     // if the file was created with netcdf4, it cannot be opened with pnetcdf
-    if (piorc != PIO_NOERR) printf("%s %d piorc = %d\n",__FILE__,__LINE__,piorc);
     if (piorc == PIO_EINVAL || PIO_ENOTBUILT){
         pio_type = PIO_IOTYPE_NETCDF;
         piorc = PIOc_openfile(pioSystemDesc, &pioFileDesc, &pio_type, filename, mode);
-	if (piorc != PIO_NOERR) printf("%s %d piorc = %d\n",__FILE__,__LINE__,piorc);
     }
     if (!CHECKPIOERROR(piorc, std::string("Unable to open existing file: ") + filename,
                        ESMF_RC_FILE_OPEN, localrc)) throw localrc;

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
@@ -421,9 +421,11 @@ void ESMCI_mesh_create_from_ESMFMesh_file(int pioSystemDesc,
     int mode = 0;
     piorc = PIOc_openfile(pioSystemDesc, &pioFileDesc, &pio_type, filename, mode);
     // if the file was created with netcdf4, it cannot be opened with pnetcdf
-    if (piorc == PIO_EINVAL){
+    if (piorc != PIO_NOERR) printf("%s %d piorc = %d\n",__FILE__,__LINE__,piorc);
+    if (piorc == PIO_EINVAL || PIO_ENOTBUILT){
         pio_type = PIO_IOTYPE_NETCDF;
         piorc = PIOc_openfile(pioSystemDesc, &pioFileDesc, &pio_type, filename, mode);
+	if (piorc != PIO_NOERR) printf("%s %d piorc = %d\n",__FILE__,__LINE__,piorc);
     }
     if (!CHECKPIOERROR(piorc, std::string("Unable to open existing file: ") + filename,
                        ESMF_RC_FILE_OPEN, localrc)) throw localrc;


### PR DESCRIPTION
In some cases an attempt to open a netcdf-4 file with pnetcdf will generate a PIO_ENOTBUILT error instead of PIO_EINVAL.   This will capture that error and attempt to reopen with netcdf. 