### PR TITLE
Potential link options to address Trace failures under Darwin

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -1848,9 +1848,9 @@ ESMF_TRACE_WRAPPERS_MPI += mpi_wait_ mpi_wait__ mpi_waitall_ mpi_waitall__
 ESMF_TRACE_WRAPPERS_MPI += mpi_waitany_ mpi_waitany__
 
 COMMA := ,
-ESMF_TRACE_STATICLINKOPTS := -static -Wl,--wrap=c_esmftrace_notify_wrappers -Wl,--wrap=c_esmftrace_isinitialized
-ESMF_TRACE_STATICLINKOPTS += $(addprefix -Wl$(COMMA)--wrap=, $(ESMF_TRACE_WRAPPERS_IO))
-ESMF_TRACE_STATICLINKOPTS += $(addprefix -Wl$(COMMA)--wrap=, $(ESMF_TRACE_WRAPPERS_MPI))
+ESMF_TRACE_STATICLINKOPTS += $(foreach fun,c_esmftrace_notify_wrappers c_esmftrace_isinitialized,-Wl$(COMMA)-alias$(COMMA)_$(fun)$(COMMA)__wrap_$(fun))
+ESMF_TRACE_STATICLINKOPTS += $(foreach fun,$(ESMF_TRACE_WRAPPERS_IO),-Wl$(COMMA)-alias$(COMMA)_$(fun)$(COMMA)__wrap_$(fun))
+ESMF_TRACE_STATICLINKOPTS += $(foreach fun,$(ESMF_TRACE_WRAPPERS_MPI),-Wl$(COMMA)-alias$(COMMA)_$(fun)$(COMMA)__wrap_$(fun))
 
 #-------------------------------------------------------------------------------
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Raffaele provided modified link options on a branch 3 years ago. This was his commit message:
Add Trace link options for ld (LLVM 10.0.0, clang-1000.11.45.5) on Mac OSX (10.13.6).

If this addresses the Trace failures under Darwin, we should consider how this can be integrated into the build system, not adversely affecting other platforms.