### PR TITLE
Update copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Earth System Modeling Framework
 
-Copyright (c) 2002-2022 University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023 University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory,
 University of Michigan, National Centers for Environmental Prediction,
 Los Alamos National Laboratory, Argonne National Laboratory,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Earth System Modeling Framework (ESMF)
 
->Copyright (c) 2002-2022 University Corporation for Atmospheric Research, Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory, University of Michigan, National Centers for Environmental Prediction, Los Alamos National Laboratory, Argonne National Laboratory, NASA Goddard Space Flight Center. All rights reserved.
+>Copyright (c) 2002-2023 University Corporation for Atmospheric Research, Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory, University of Michigan, National Centers for Environmental Prediction, Los Alamos National Laboratory, Argonne National Laboratory, NASA Goddard Space Flight Center. All rights reserved.
 
 Hello and welcome to ESMF.
 

--- a/build_config/AIX.default.default/ESMC_Conf.h
+++ b/build_config/AIX.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/AIX.default.default/ESMC_Conf.h
+++ b/build_config/AIX.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/AIX.default.default/ESMF_Conf.inc
+++ b/build_config/AIX.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/AIX.default.default/ESMF_Conf.inc
+++ b/build_config/AIX.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.g95.default/ESMC_Conf.h
+++ b/build_config/Cygwin.g95.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.g95.default/ESMC_Conf.h
+++ b/build_config/Cygwin.g95.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.g95.default/ESMF_Conf.inc
+++ b/build_config/Cygwin.g95.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.g95.default/ESMF_Conf.inc
+++ b/build_config/Cygwin.g95.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.gfortran.default/ESMC_Conf.h
+++ b/build_config/Cygwin.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.gfortran.default/ESMC_Conf.h
+++ b/build_config/Cygwin.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Cygwin.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Cygwin.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Cygwin.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.absoft.default/ESMC_Conf.h
+++ b/build_config/Darwin.absoft.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.absoft.default/ESMC_Conf.h
+++ b/build_config/Darwin.absoft.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.absoft.default/ESMF_Conf.inc
+++ b/build_config/Darwin.absoft.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.absoft.default/ESMF_Conf.inc
+++ b/build_config/Darwin.absoft.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.g95.default/ESMC_Conf.h
+++ b/build_config/Darwin.g95.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.g95.default/ESMC_Conf.h
+++ b/build_config/Darwin.g95.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.g95.default/ESMF_Conf.inc
+++ b/build_config/Darwin.g95.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.g95.default/ESMF_Conf.inc
+++ b/build_config/Darwin.g95.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortran.default/ESMC_Conf.h
+++ b/build_config/Darwin.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortran.default/ESMC_Conf.h
+++ b/build_config/Darwin.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Darwin.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Darwin.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortranclang.default/ESMC_Conf.h
+++ b/build_config/Darwin.gfortranclang.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortranclang.default/ESMC_Conf.h
+++ b/build_config/Darwin.gfortranclang.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortranclang.default/ESMF_Conf.inc
+++ b/build_config/Darwin.gfortranclang.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.gfortranclang.default/ESMF_Conf.inc
+++ b/build_config/Darwin.gfortranclang.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intel.default/ESMC_Conf.h
+++ b/build_config/Darwin.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intel.default/ESMC_Conf.h
+++ b/build_config/Darwin.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intel.default/ESMF_Conf.inc
+++ b/build_config/Darwin.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intel.default/ESMF_Conf.inc
+++ b/build_config/Darwin.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelclang.default/ESMC_Conf.h
+++ b/build_config/Darwin.intelclang.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelclang.default/ESMC_Conf.h
+++ b/build_config/Darwin.intelclang.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelclang.default/ESMF_Conf.inc
+++ b/build_config/Darwin.intelclang.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelclang.default/ESMF_Conf.inc
+++ b/build_config/Darwin.intelclang.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelgcc.default/ESMC_Conf.h
+++ b/build_config/Darwin.intelgcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelgcc.default/ESMC_Conf.h
+++ b/build_config/Darwin.intelgcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelgcc.default/ESMF_Conf.inc
+++ b/build_config/Darwin.intelgcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.intelgcc.default/ESMF_Conf.inc
+++ b/build_config/Darwin.intelgcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.nag.default/ESMC_Conf.h
+++ b/build_config/Darwin.nag.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.nag.default/ESMC_Conf.h
+++ b/build_config/Darwin.nag.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.nag.default/ESMF_Conf.inc
+++ b/build_config/Darwin.nag.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.nag.default/ESMF_Conf.inc
+++ b/build_config/Darwin.nag.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.pgi.default/ESMC_Conf.h
+++ b/build_config/Darwin.pgi.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.pgi.default/ESMC_Conf.h
+++ b/build_config/Darwin.pgi.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.pgi.default/ESMF_Conf.inc
+++ b/build_config/Darwin.pgi.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.pgi.default/ESMF_Conf.inc
+++ b/build_config/Darwin.pgi.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlf.default/ESMC_Conf.h
+++ b/build_config/Darwin.xlf.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlf.default/ESMC_Conf.h
+++ b/build_config/Darwin.xlf.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlf.default/ESMF_Conf.inc
+++ b/build_config/Darwin.xlf.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlf.default/ESMF_Conf.inc
+++ b/build_config/Darwin.xlf.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlfgcc.default/ESMC_Conf.h
+++ b/build_config/Darwin.xlfgcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlfgcc.default/ESMC_Conf.h
+++ b/build_config/Darwin.xlfgcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlfgcc.default/ESMF_Conf.inc
+++ b/build_config/Darwin.xlfgcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Darwin.xlfgcc.default/ESMF_Conf.inc
+++ b/build_config/Darwin.xlfgcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/IRIX64.default.default/ESMC_Conf.h
+++ b/build_config/IRIX64.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/IRIX64.default.default/ESMC_Conf.h
+++ b/build_config/IRIX64.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/IRIX64.default.default/ESMF_Conf.inc
+++ b/build_config/IRIX64.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/IRIX64.default.default/ESMF_Conf.inc
+++ b/build_config/IRIX64.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoft.default/ESMC_Conf.h
+++ b/build_config/Linux.absoft.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoft.default/ESMC_Conf.h
+++ b/build_config/Linux.absoft.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoft.default/ESMF_Conf.inc
+++ b/build_config/Linux.absoft.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoft.default/ESMF_Conf.inc
+++ b/build_config/Linux.absoft.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoftintel.default/ESMC_Conf.h
+++ b/build_config/Linux.absoftintel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoftintel.default/ESMC_Conf.h
+++ b/build_config/Linux.absoftintel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoftintel.default/ESMF_Conf.inc
+++ b/build_config/Linux.absoftintel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.absoftintel.default/ESMF_Conf.inc
+++ b/build_config/Linux.absoftintel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.aocc.default/ESMC_Conf.h
+++ b/build_config/Linux.aocc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.aocc.default/ESMC_Conf.h
+++ b/build_config/Linux.aocc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.aocc.default/ESMF_Conf.inc
+++ b/build_config/Linux.aocc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.aocc.default/ESMF_Conf.inc
+++ b/build_config/Linux.aocc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.arm.default/ESMC_Conf.h
+++ b/build_config/Linux.arm.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.arm.default/ESMC_Conf.h
+++ b/build_config/Linux.arm.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.arm.default/ESMF_Conf.inc
+++ b/build_config/Linux.arm.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.arm.default/ESMF_Conf.inc
+++ b/build_config/Linux.arm.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.g95.default/ESMC_Conf.h
+++ b/build_config/Linux.g95.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.g95.default/ESMC_Conf.h
+++ b/build_config/Linux.g95.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.g95.default/ESMF_Conf.inc
+++ b/build_config/Linux.g95.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.g95.default/ESMF_Conf.inc
+++ b/build_config/Linux.g95.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortran.default/ESMC_Conf.h
+++ b/build_config/Linux.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortran.default/ESMC_Conf.h
+++ b/build_config/Linux.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Linux.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Linux.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortranclang.default/ESMC_Conf.h
+++ b/build_config/Linux.gfortranclang.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortranclang.default/ESMC_Conf.h
+++ b/build_config/Linux.gfortranclang.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortranclang.default/ESMF_Conf.inc
+++ b/build_config/Linux.gfortranclang.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.gfortranclang.default/ESMF_Conf.inc
+++ b/build_config/Linux.gfortranclang.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intel.default/ESMC_Conf.h
+++ b/build_config/Linux.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intel.default/ESMC_Conf.h
+++ b/build_config/Linux.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intel.default/ESMF_Conf.inc
+++ b/build_config/Linux.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intel.default/ESMF_Conf.inc
+++ b/build_config/Linux.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intelgcc.default/ESMC_Conf.h
+++ b/build_config/Linux.intelgcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intelgcc.default/ESMC_Conf.h
+++ b/build_config/Linux.intelgcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intelgcc.default/ESMF_Conf.inc
+++ b/build_config/Linux.intelgcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.intelgcc.default/ESMF_Conf.inc
+++ b/build_config/Linux.intelgcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.lahey.default/ESMC_Conf.h
+++ b/build_config/Linux.lahey.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.lahey.default/ESMC_Conf.h
+++ b/build_config/Linux.lahey.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.lahey.default/ESMF_Conf.inc
+++ b/build_config/Linux.lahey.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.lahey.default/ESMF_Conf.inc
+++ b/build_config/Linux.lahey.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.llvm.default/ESMC_Conf.h
+++ b/build_config/Linux.llvm.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.llvm.default/ESMC_Conf.h
+++ b/build_config/Linux.llvm.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.llvm.default/ESMF_Conf.inc
+++ b/build_config/Linux.llvm.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.llvm.default/ESMF_Conf.inc
+++ b/build_config/Linux.llvm.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nag.default/ESMC_Conf.h
+++ b/build_config/Linux.nag.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nag.default/ESMC_Conf.h
+++ b/build_config/Linux.nag.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nag.default/ESMF_Conf.inc
+++ b/build_config/Linux.nag.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nag.default/ESMF_Conf.inc
+++ b/build_config/Linux.nag.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nagintel.default/ESMC_Conf.h
+++ b/build_config/Linux.nagintel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nagintel.default/ESMC_Conf.h
+++ b/build_config/Linux.nagintel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nagintel.default/ESMF_Conf.inc
+++ b/build_config/Linux.nagintel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nagintel.default/ESMF_Conf.inc
+++ b/build_config/Linux.nagintel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nvhpc.default/ESMC_Conf.h
+++ b/build_config/Linux.nvhpc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nvhpc.default/ESMC_Conf.h
+++ b/build_config/Linux.nvhpc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nvhpc.default/ESMF_Conf.inc
+++ b/build_config/Linux.nvhpc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.nvhpc.default/ESMF_Conf.inc
+++ b/build_config/Linux.nvhpc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pathscale.default/ESMC_Conf.h
+++ b/build_config/Linux.pathscale.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pathscale.default/ESMC_Conf.h
+++ b/build_config/Linux.pathscale.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pathscale.default/ESMF_Conf.inc
+++ b/build_config/Linux.pathscale.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pathscale.default/ESMF_Conf.inc
+++ b/build_config/Linux.pathscale.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgi.default/ESMC_Conf.h
+++ b/build_config/Linux.pgi.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgi.default/ESMC_Conf.h
+++ b/build_config/Linux.pgi.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgi.default/ESMF_Conf.inc
+++ b/build_config/Linux.pgi.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgi.default/ESMF_Conf.inc
+++ b/build_config/Linux.pgi.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgigcc.default/ESMC_Conf.h
+++ b/build_config/Linux.pgigcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgigcc.default/ESMC_Conf.h
+++ b/build_config/Linux.pgigcc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgigcc.default/ESMF_Conf.inc
+++ b/build_config/Linux.pgigcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.pgigcc.default/ESMF_Conf.inc
+++ b/build_config/Linux.pgigcc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.sxcross.default/ESMC_Conf.h
+++ b/build_config/Linux.sxcross.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.sxcross.default/ESMC_Conf.h
+++ b/build_config/Linux.sxcross.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.sxcross.default/ESMF_Conf.inc
+++ b/build_config/Linux.sxcross.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.sxcross.default/ESMF_Conf.inc
+++ b/build_config/Linux.sxcross.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.xlf.default/ESMC_Conf.h
+++ b/build_config/Linux.xlf.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.xlf.default/ESMC_Conf.h
+++ b/build_config/Linux.xlf.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.xlf.default/ESMF_Conf.inc
+++ b/build_config/Linux.xlf.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Linux.xlf.default/ESMF_Conf.inc
+++ b/build_config/Linux.xlf.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.gfortran.default/ESMC_Conf.h
+++ b/build_config/MinGW.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.gfortran.default/ESMC_Conf.h
+++ b/build_config/MinGW.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.gfortran.default/ESMF_Conf.inc
+++ b/build_config/MinGW.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.gfortran.default/ESMF_Conf.inc
+++ b/build_config/MinGW.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intel.default/ESMC_Conf.h
+++ b/build_config/MinGW.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intel.default/ESMC_Conf.h
+++ b/build_config/MinGW.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intel.default/ESMF_Conf.inc
+++ b/build_config/MinGW.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intel.default/ESMF_Conf.inc
+++ b/build_config/MinGW.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intelcl.default/ESMC_Conf.h
+++ b/build_config/MinGW.intelcl.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intelcl.default/ESMC_Conf.h
+++ b/build_config/MinGW.intelcl.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intelcl.default/ESMF_Conf.inc
+++ b/build_config/MinGW.intelcl.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/MinGW.intelcl.default/ESMF_Conf.inc
+++ b/build_config/MinGW.intelcl.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/OSF1.default.default/ESMC_Conf.h
+++ b/build_config/OSF1.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/OSF1.default.default/ESMC_Conf.h
+++ b/build_config/OSF1.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/OSF1.default.default/ESMF_Conf.inc
+++ b/build_config/OSF1.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/OSF1.default.default/ESMF_Conf.inc
+++ b/build_config/OSF1.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/README
+++ b/build_config/README
@@ -4,7 +4,7 @@
 
 
  Earth System Modeling Framework
- Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/README
+++ b/build_config/README
@@ -4,7 +4,7 @@
 
 
  Earth System Modeling Framework
- Copyright 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/SunOS.default.default/ESMC_Conf.h
+++ b/build_config/SunOS.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/SunOS.default.default/ESMC_Conf.h
+++ b/build_config/SunOS.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/SunOS.default.default/ESMF_Conf.inc
+++ b/build_config/SunOS.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/SunOS.default.default/ESMF_Conf.inc
+++ b/build_config/SunOS.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.aocc.default/ESMC_Conf.h
+++ b/build_config/Unicos.aocc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.aocc.default/ESMC_Conf.h
+++ b/build_config/Unicos.aocc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.aocc.default/ESMF_Conf.inc
+++ b/build_config/Unicos.aocc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.aocc.default/ESMF_Conf.inc
+++ b/build_config/Unicos.aocc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.cce.default/ESMC_Conf.h
+++ b/build_config/Unicos.cce.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.cce.default/ESMC_Conf.h
+++ b/build_config/Unicos.cce.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.cce.default/ESMF_Conf.inc
+++ b/build_config/Unicos.cce.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.cce.default/ESMF_Conf.inc
+++ b/build_config/Unicos.cce.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.default.default/ESMC_Conf.h
+++ b/build_config/Unicos.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.default.default/ESMC_Conf.h
+++ b/build_config/Unicos.default.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.default.default/ESMF_Conf.inc
+++ b/build_config/Unicos.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.default.default/ESMF_Conf.inc
+++ b/build_config/Unicos.default.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.gfortran.default/ESMC_Conf.h
+++ b/build_config/Unicos.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.gfortran.default/ESMC_Conf.h
+++ b/build_config/Unicos.gfortran.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Unicos.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.gfortran.default/ESMF_Conf.inc
+++ b/build_config/Unicos.gfortran.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.intel.default/ESMC_Conf.h
+++ b/build_config/Unicos.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.intel.default/ESMC_Conf.h
+++ b/build_config/Unicos.intel.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.intel.default/ESMF_Conf.inc
+++ b/build_config/Unicos.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.intel.default/ESMF_Conf.inc
+++ b/build_config/Unicos.intel.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.nvhpc.default/ESMC_Conf.h
+++ b/build_config/Unicos.nvhpc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.nvhpc.default/ESMC_Conf.h
+++ b/build_config/Unicos.nvhpc.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.nvhpc.default/ESMF_Conf.inc
+++ b/build_config/Unicos.nvhpc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.nvhpc.default/ESMF_Conf.inc
+++ b/build_config/Unicos.nvhpc.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pathscale.default/ESMC_Conf.h
+++ b/build_config/Unicos.pathscale.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pathscale.default/ESMC_Conf.h
+++ b/build_config/Unicos.pathscale.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pathscale.default/ESMF_Conf.inc
+++ b/build_config/Unicos.pathscale.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pathscale.default/ESMF_Conf.inc
+++ b/build_config/Unicos.pathscale.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pgi.default/ESMC_Conf.h
+++ b/build_config/Unicos.pgi.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pgi.default/ESMC_Conf.h
+++ b/build_config/Unicos.pgi.default/ESMC_Conf.h
@@ -5,7 +5,7 @@
 
 #if 0
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pgi.default/ESMF_Conf.inc
+++ b/build_config/Unicos.pgi.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/build_config/Unicos.pgi.default/ESMF_Conf.inc
+++ b/build_config/Unicos.pgi.default/ESMF_Conf.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/scripts/doc_templates/templates/scripts/do_ccprotex
+++ b/scripts/doc_templates/templates/scripts/do_ccprotex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_ccprotex
+++ b/scripts/doc_templates/templates/scripts/do_ccprotex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_chprotex
+++ b/scripts/doc_templates/templates/scripts/do_chprotex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_chprotex
+++ b/scripts/doc_templates/templates/scripts/do_chprotex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_fprotex
+++ b/scripts/doc_templates/templates/scripts/do_fprotex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_fprotex
+++ b/scripts/doc_templates/templates/scripts/do_fprotex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_l2h
+++ b/scripts/doc_templates/templates/scripts/do_l2h
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_l2h
+++ b/scripts/doc_templates/templates/scripts/do_l2h
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_latex
+++ b/scripts/doc_templates/templates/scripts/do_latex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_latex
+++ b/scripts/doc_templates/templates/scripts/do_latex
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_newclass
+++ b/scripts/doc_templates/templates/scripts/do_newclass
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_newclass
+++ b/scripts/doc_templates/templates/scripts/do_newclass
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_newcomp
+++ b/scripts/doc_templates/templates/scripts/do_newcomp
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_newcomp
+++ b/scripts/doc_templates/templates/scripts/do_newcomp
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_newdoc
+++ b/scripts/doc_templates/templates/scripts/do_newdoc
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/scripts/do_newdoc
+++ b/scripts/doc_templates/templates/scripts/do_newdoc
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/title_alldoc.tex
+++ b/scripts/doc_templates/templates/title_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/title_alldoc.tex
+++ b/scripts/doc_templates/templates/title_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/verstitle_alldoc.tex
+++ b/scripts/doc_templates/templates/verstitle_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/doc_templates/templates/verstitle_alldoc.tex
+++ b/scripts/doc_templates/templates/verstitle_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/scripts/jinja2_templating/generate_templates.py
+++ b/scripts/jinja2_templating/generate_templates.py
@@ -96,7 +96,7 @@ META['ESMF_FILEHEADER'] = \
 """! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,
@@ -110,7 +110,7 @@ META['ESMC_FILEHEADER'] = \
 """// $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/scripts/jinja2_templating/generate_templates.py
+++ b/scripts/jinja2_templating/generate_templates.py
@@ -96,7 +96,7 @@ META['ESMF_FILEHEADER'] = \
 """! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,
@@ -110,7 +110,7 @@ META['ESMC_FILEHEADER'] = \
 """// $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/doc/Array_cdesc.tex
+++ b/src/Infrastructure/Array/doc/Array_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/doc/Array_cdesc.tex
+++ b/src/Infrastructure/Array/doc/Array_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/doc/Array_crefdoc.ctex
+++ b/src/Infrastructure/Array/doc/Array_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/doc/Array_crefdoc.ctex
+++ b/src/Infrastructure/Array/doc/Array_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/doc/Array_desc.tex
+++ b/src/Infrastructure/Array/doc/Array_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/doc/Array_desc.tex
+++ b/src/Infrastructure/Array/doc/Array_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/doc/Array_refdoc.ctex
+++ b/src/Infrastructure/Array/doc/Array_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/doc/Array_refdoc.ctex
+++ b/src/Infrastructure/Array/doc/Array_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/examples/ESMF_ArrayArbHaloEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayArbHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayArbHaloEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayArbHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayCommNBEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayCommNBEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayCommNBEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayCommNBEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayFarrayEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayFarrayEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayFarrayEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayFarrayEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayFarrayHaloEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayFarrayHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayFarrayHaloEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayFarrayHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayHaloEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayHaloEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayLarrayEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayLarrayEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayLarrayEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayLarrayEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayRedistEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayRedistEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayRedistEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayRedistEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherArbEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherArbEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherArbEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherArbEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArrayScatterGatherEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArraySparseMatMulEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArraySparseMatMulEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/examples/ESMF_ArraySparseMatMulEx.F90
+++ b/src/Infrastructure/Array/examples/ESMF_ArraySparseMatMulEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/include/ESMCI_Array.h
+++ b/src/Infrastructure/Array/include/ESMCI_Array.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/include/ESMCI_Array.h
+++ b/src/Infrastructure/Array/include/ESMCI_Array.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/include/ESMC_Array.h
+++ b/src/Infrastructure/Array/include/ESMC_Array.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/include/ESMC_Array.h
+++ b/src/Infrastructure/Array/include/ESMC_Array.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMCI_Array_F.C
+++ b/src/Infrastructure/Array/interface/ESMCI_Array_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMCI_Array_F.C
+++ b/src/Infrastructure/Array/interface/ESMCI_Array_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMC_Array.C
+++ b/src/Infrastructure/Array/interface/ESMC_Array.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMC_Array.C
+++ b/src/Infrastructure/Array/interface/ESMC_Array.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_Array.F90
+++ b/src/Infrastructure/Array/interface/ESMF_Array.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_Array.F90
+++ b/src/Infrastructure/Array/interface/ESMF_Array.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayCreate.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayCreate.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/interface/ESMF_ArrayCreate.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayCreate.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/interface/ESMF_ArrayGather.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayGather.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayGather.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayGather.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayHa.F90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayHa.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayHa.F90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayHa.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayScatter.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayScatter.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_ArrayScatter.cppF90
+++ b/src/Infrastructure/Array/interface/ESMF_ArrayScatter.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_DynamicMask.F90
+++ b/src/Infrastructure/Array/interface/ESMF_DynamicMask.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/interface/ESMF_DynamicMask.F90
+++ b/src/Infrastructure/Array/interface/ESMF_DynamicMask.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/src/ESMCI_Array.C
+++ b/src/Infrastructure/Array/src/ESMCI_Array.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/src/ESMCI_Array.C
+++ b/src/Infrastructure/Array/src/ESMCI_Array.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMC_ArrayUTest.c
+++ b/src/Infrastructure/Array/tests/ESMC_ArrayUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/tests/ESMC_ArrayUTest.c
+++ b/src/Infrastructure/Array/tests/ESMC_ArrayUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Array/tests/ESMF_ArrayArbIdxSMMUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayArbIdxSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayArbIdxSMMUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayArbIdxSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayDataUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayDataUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayDataUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayDataUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayGatherUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayGatherUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayHaloUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayHaloUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayHaloUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayHaloUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayIOUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayIOUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayRedistPerfUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayRedistPerfUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayRedistPerfUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayRedistPerfUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayRedistUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayRedistUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArraySMMFromFileUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArraySMMFromFileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArraySMMFromFileUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArraySMMFromFileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArraySMMUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArraySMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArraySMMUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArraySMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayScatterUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayScatterUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Array/tests/ESMF_ArrayScatterUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayScatterUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/doc/ArrayBundle_refdoc.ctex
+++ b/src/Infrastructure/ArrayBundle/doc/ArrayBundle_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/doc/ArrayBundle_refdoc.ctex
+++ b/src/Infrastructure/ArrayBundle/doc/ArrayBundle_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleEx.F90
+++ b/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleEx.F90
+++ b/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleHaloEx.F90
+++ b/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleHaloEx.F90
+++ b/src/Infrastructure/ArrayBundle/examples/ESMF_ArrayBundleHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/include/ESMCI_ArrayBundle.h
+++ b/src/Infrastructure/ArrayBundle/include/ESMCI_ArrayBundle.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/include/ESMCI_ArrayBundle.h
+++ b/src/Infrastructure/ArrayBundle/include/ESMCI_ArrayBundle.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/interface/ESMCI_ArrayBundle_F.C
+++ b/src/Infrastructure/ArrayBundle/interface/ESMCI_ArrayBundle_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/interface/ESMCI_ArrayBundle_F.C
+++ b/src/Infrastructure/ArrayBundle/interface/ESMCI_ArrayBundle_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
+++ b/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
+++ b/src/Infrastructure/ArrayBundle/interface/ESMF_ArrayBundle.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
+++ b/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
+++ b/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleCreateUTest.F90
+++ b/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleCreateUTest.F90
+++ b/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleIOUTest.F90
+++ b/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleIOUTest.F90
+++ b/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleRedistUTest.F90
+++ b/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleRedistUTest.F90
+++ b/src/Infrastructure/ArrayBundle/tests/ESMF_ArrayBundleRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/doc/ArraySpec_crefdoc.ctex
+++ b/src/Infrastructure/ArraySpec/doc/ArraySpec_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/doc/ArraySpec_crefdoc.ctex
+++ b/src/Infrastructure/ArraySpec/doc/ArraySpec_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/examples/ESMF_ArraySpecEx.F90
+++ b/src/Infrastructure/ArraySpec/examples/ESMF_ArraySpecEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/examples/ESMF_ArraySpecEx.F90
+++ b/src/Infrastructure/ArraySpec/examples/ESMF_ArraySpecEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/include/ESMCI_ArraySpec.h
+++ b/src/Infrastructure/ArraySpec/include/ESMCI_ArraySpec.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/include/ESMCI_ArraySpec.h
+++ b/src/Infrastructure/ArraySpec/include/ESMCI_ArraySpec.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/include/ESMC_ArraySpec.h
+++ b/src/Infrastructure/ArraySpec/include/ESMC_ArraySpec.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/include/ESMC_ArraySpec.h
+++ b/src/Infrastructure/ArraySpec/include/ESMC_ArraySpec.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/interface/ESMCI_ArraySpec.C
+++ b/src/Infrastructure/ArraySpec/interface/ESMCI_ArraySpec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/interface/ESMCI_ArraySpec.C
+++ b/src/Infrastructure/ArraySpec/interface/ESMCI_ArraySpec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/interface/ESMC_ArraySpec.C
+++ b/src/Infrastructure/ArraySpec/interface/ESMC_ArraySpec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/interface/ESMC_ArraySpec.C
+++ b/src/Infrastructure/ArraySpec/interface/ESMC_ArraySpec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/interface/ESMF_ArraySpec_C.F90
+++ b/src/Infrastructure/ArraySpec/interface/ESMF_ArraySpec_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/interface/ESMF_ArraySpec_C.F90
+++ b/src/Infrastructure/ArraySpec/interface/ESMF_ArraySpec_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/src/ESMF_ArraySpec.F90
+++ b/src/Infrastructure/ArraySpec/src/ESMF_ArraySpec.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/src/ESMF_ArraySpec.F90
+++ b/src/Infrastructure/ArraySpec/src/ESMF_ArraySpec.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/tests/ESMC_ArraySpecUTest.c
+++ b/src/Infrastructure/ArraySpec/tests/ESMC_ArraySpecUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/tests/ESMC_ArraySpecUTest.c
+++ b/src/Infrastructure/ArraySpec/tests/ESMC_ArraySpecUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/ArraySpec/tests/ESMF_ArraySpecUTest.F90
+++ b/src/Infrastructure/ArraySpec/tests/ESMF_ArraySpecUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/ArraySpec/tests/ESMF_ArraySpecUTest.F90
+++ b/src/Infrastructure/ArraySpec/tests/ESMF_ArraySpecUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/doc/Info_refdoc.ctex
+++ b/src/Infrastructure/Base/doc/Info_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/doc/Info_refdoc.ctex
+++ b/src/Infrastructure/Base/doc/Info_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/examples/ESMF_InfoGetFromHostEx.F90
+++ b/src/Infrastructure/Base/examples/ESMF_InfoGetFromHostEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/examples/ESMF_InfoGetFromHostEx.F90
+++ b/src/Infrastructure/Base/examples/ESMF_InfoGetFromHostEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/examples/ESMF_InfoTutorialEx.F90
+++ b/src/Infrastructure/Base/examples/ESMF_InfoTutorialEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/examples/ESMF_InfoTutorialEx.F90
+++ b/src/Infrastructure/Base/examples/ESMF_InfoTutorialEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/include/ESMCI_Base.h
+++ b/src/Infrastructure/Base/include/ESMCI_Base.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/include/ESMCI_Base.h
+++ b/src/Infrastructure/Base/include/ESMCI_Base.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/include/ESMCI_Info.h
+++ b/src/Infrastructure/Base/include/ESMCI_Info.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/include/ESMCI_Info.h
+++ b/src/Infrastructure/Base/include/ESMCI_Info.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMCI_Base_F.C
+++ b/src/Infrastructure/Base/interface/ESMCI_Base_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMCI_Base_F.C
+++ b/src/Infrastructure/Base/interface/ESMCI_Base_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_Base.F90
+++ b/src/Infrastructure/Base/interface/ESMF_Base.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_Base.F90
+++ b/src/Infrastructure/Base/interface/ESMF_Base.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_FactorRead.F90
+++ b/src/Infrastructure/Base/interface/ESMF_FactorRead.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_FactorRead.F90
+++ b/src/Infrastructure/Base/interface/ESMF_FactorRead.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_Info.F90
+++ b/src/Infrastructure/Base/interface/ESMF_Info.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_Info.F90
+++ b/src/Infrastructure/Base/interface/ESMF_Info.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_InfoCDefGeneric.F90
+++ b/src/Infrastructure/Base/interface/ESMF_InfoCDefGeneric.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/interface/ESMF_InfoCDefGeneric.F90
+++ b/src/Infrastructure/Base/interface/ESMF_InfoCDefGeneric.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMCI_Base.C
+++ b/src/Infrastructure/Base/src/ESMCI_Base.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMCI_Base.C
+++ b/src/Infrastructure/Base/src/ESMCI_Base.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMCI_Info.C
+++ b/src/Infrastructure/Base/src/ESMCI_Info.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMCI_Info.C
+++ b/src/Infrastructure/Base/src/ESMCI_Info.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMC_InfoCDef.C
+++ b/src/Infrastructure/Base/src/ESMC_InfoCDef.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMC_InfoCDef.C
+++ b/src/Infrastructure/Base/src/ESMC_InfoCDef.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMC_InfoCDefGeneric.C
+++ b/src/Infrastructure/Base/src/ESMC_InfoCDefGeneric.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/src/ESMC_InfoCDefGeneric.C
+++ b/src/Infrastructure/Base/src/ESMC_InfoCDefGeneric.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMCI_BaseUTest.C
+++ b/src/Infrastructure/Base/tests/ESMCI_BaseUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMCI_BaseUTest.C
+++ b/src/Infrastructure/Base/tests/ESMCI_BaseUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMCI_InfoUTest.C
+++ b/src/Infrastructure/Base/tests/ESMCI_InfoUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMCI_InfoUTest.C
+++ b/src/Infrastructure/Base/tests/ESMCI_InfoUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMCI_NlohmannJSONUTest.C
+++ b/src/Infrastructure/Base/tests/ESMCI_NlohmannJSONUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMCI_NlohmannJSONUTest.C
+++ b/src/Infrastructure/Base/tests/ESMCI_NlohmannJSONUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_BaseUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_BaseUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_BaseUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_BaseUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_InfoArrayUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_InfoArrayUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_InfoArrayUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_InfoArrayUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_InfoProfileUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_InfoProfileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_InfoProfileUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_InfoProfileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_InfoUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_InfoUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Base/tests/ESMF_InfoUTest.F90
+++ b/src/Infrastructure/Base/tests/ESMF_InfoUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Config/doc/Config_crefdoc.ctex
+++ b/src/Infrastructure/Config/doc/Config_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/doc/Config_crefdoc.ctex
+++ b/src/Infrastructure/Config/doc/Config_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/doc/Config_refdoc.ctex
+++ b/src/Infrastructure/Config/doc/Config_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/doc/Config_refdoc.ctex
+++ b/src/Infrastructure/Config/doc/Config_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/examples/ESMC_ConfigOverviewEx.C
+++ b/src/Infrastructure/Config/examples/ESMC_ConfigOverviewEx.C
@@ -1,6 +1,6 @@
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Config/examples/ESMC_ConfigOverviewEx.C
+++ b/src/Infrastructure/Config/examples/ESMC_ConfigOverviewEx.C
@@ -1,6 +1,6 @@
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Config/examples/ESMF_ConfigOverviewEx.F90
+++ b/src/Infrastructure/Config/examples/ESMF_ConfigOverviewEx.F90
@@ -1,6 +1,6 @@
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Config/examples/ESMF_ConfigOverviewEx.F90
+++ b/src/Infrastructure/Config/examples/ESMF_ConfigOverviewEx.F90
@@ -1,6 +1,6 @@
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Config/include/ESMCI_Config.h
+++ b/src/Infrastructure/Config/include/ESMCI_Config.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/include/ESMCI_Config.h
+++ b/src/Infrastructure/Config/include/ESMCI_Config.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/include/ESMC_Config.h
+++ b/src/Infrastructure/Config/include/ESMC_Config.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/include/ESMC_Config.h
+++ b/src/Infrastructure/Config/include/ESMC_Config.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/interface/ESMC_Config.C
+++ b/src/Infrastructure/Config/interface/ESMC_Config.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/interface/ESMC_Config.C
+++ b/src/Infrastructure/Config/interface/ESMC_Config.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/interface/ESMF_Config_C.F90
+++ b/src/Infrastructure/Config/interface/ESMF_Config_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/interface/ESMF_Config_C.F90
+++ b/src/Infrastructure/Config/interface/ESMF_Config_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/src/ESMF_Config.F90
+++ b/src/Infrastructure/Config/src/ESMF_Config.F90
@@ -2,7 +2,7 @@
 !==============================================================================
 ! Earth System Modeling Framework
 !
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/src/ESMF_Config.F90
+++ b/src/Infrastructure/Config/src/ESMF_Config.F90
@@ -2,7 +2,7 @@
 !==============================================================================
 ! Earth System Modeling Framework
 !
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/tests/ESMC_ConfigUTest.c
+++ b/src/Infrastructure/Config/tests/ESMC_ConfigUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/tests/ESMC_ConfigUTest.c
+++ b/src/Infrastructure/Config/tests/ESMC_ConfigUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/tests/ESMF_ConfigUTest.F90
+++ b/src/Infrastructure/Config/tests/ESMF_ConfigUTest.F90
@@ -2,7 +2,7 @@
 !==============================================================================
 ! Earth System Modeling Framework
 !
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Config/tests/ESMF_ConfigUTest.F90
+++ b/src/Infrastructure/Config/tests/ESMF_ConfigUTest.F90
@@ -2,7 +2,7 @@
 !==============================================================================
 ! Earth System Modeling Framework
 !
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Container/include/ESMCI_Container.h
+++ b/src/Infrastructure/Container/include/ESMCI_Container.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Container/include/ESMCI_Container.h
+++ b/src/Infrastructure/Container/include/ESMCI_Container.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Container/interface/ESMCI_Container_F.C
+++ b/src/Infrastructure/Container/interface/ESMCI_Container_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Container/interface/ESMCI_Container_F.C
+++ b/src/Infrastructure/Container/interface/ESMCI_Container_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Container/interface/ESMF_Container.F90
+++ b/src/Infrastructure/Container/interface/ESMF_Container.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Container/interface/ESMF_Container.F90
+++ b/src/Infrastructure/Container/interface/ESMF_Container.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Container/tests/ESMF_ContainerUTest.F90
+++ b/src/Infrastructure/Container/tests/ESMF_ContainerUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Container/tests/ESMF_ContainerUTest.F90
+++ b/src/Infrastructure/Container/tests/ESMF_ContainerUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/doc/CommMem_syn.tex
+++ b/src/Infrastructure/DELayout/doc/CommMem_syn.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/doc/CommMem_syn.tex
+++ b/src/Infrastructure/DELayout/doc/CommMem_syn.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/doc/DELayout_crefdoc.ctex
+++ b/src/Infrastructure/DELayout/doc/DELayout_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/doc/DELayout_crefdoc.ctex
+++ b/src/Infrastructure/DELayout/doc/DELayout_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/doc/DELayout_options.tex
+++ b/src/Infrastructure/DELayout/doc/DELayout_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/doc/DELayout_options.tex
+++ b/src/Infrastructure/DELayout/doc/DELayout_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/doc/DELayout_refdoc.ctex
+++ b/src/Infrastructure/DELayout/doc/DELayout_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/doc/DELayout_refdoc.ctex
+++ b/src/Infrastructure/DELayout/doc/DELayout_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/examples/ESMF_DELayoutEx.F90
+++ b/src/Infrastructure/DELayout/examples/ESMF_DELayoutEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/examples/ESMF_DELayoutEx.F90
+++ b/src/Infrastructure/DELayout/examples/ESMF_DELayoutEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/include/ESMCI_DELayout.h
+++ b/src/Infrastructure/DELayout/include/ESMCI_DELayout.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/include/ESMCI_DELayout.h
+++ b/src/Infrastructure/DELayout/include/ESMCI_DELayout.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/interface/ESMCI_DELayout_F.C
+++ b/src/Infrastructure/DELayout/interface/ESMCI_DELayout_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/interface/ESMCI_DELayout_F.C
+++ b/src/Infrastructure/DELayout/interface/ESMCI_DELayout_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/interface/ESMF_DELayout.F90
+++ b/src/Infrastructure/DELayout/interface/ESMF_DELayout.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/interface/ESMF_DELayout.F90
+++ b/src/Infrastructure/DELayout/interface/ESMF_DELayout.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
+++ b/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
+++ b/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/tests/ESMF_DELayoutUTest.F90
+++ b/src/Infrastructure/DELayout/tests/ESMF_DELayoutUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/tests/ESMF_DELayoutUTest.F90
+++ b/src/Infrastructure/DELayout/tests/ESMF_DELayoutUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/tests/ESMF_DELayoutWorkQueueUTest.F90
+++ b/src/Infrastructure/DELayout/tests/ESMF_DELayoutWorkQueueUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DELayout/tests/ESMF_DELayoutWorkQueueUTest.F90
+++ b/src/Infrastructure/DELayout/tests/ESMF_DELayoutWorkQueueUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DistGrid/doc/DistGrid_cdesc.tex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_cdesc.tex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_crefdoc.ctex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_crefdoc.ctex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_desc.tex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_desc.tex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_options.tex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_options.tex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_refdoc.ctex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/doc/DistGrid_refdoc.ctex
+++ b/src/Infrastructure/DistGrid/doc/DistGrid_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/examples/ESMF_DistGridEx.F90
+++ b/src/Infrastructure/DistGrid/examples/ESMF_DistGridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DistGrid/examples/ESMF_DistGridEx.F90
+++ b/src/Infrastructure/DistGrid/examples/ESMF_DistGridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DistGrid/include/ESMCI_DistGrid.h
+++ b/src/Infrastructure/DistGrid/include/ESMCI_DistGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/include/ESMCI_DistGrid.h
+++ b/src/Infrastructure/DistGrid/include/ESMCI_DistGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/include/ESMC_DistGrid.h
+++ b/src/Infrastructure/DistGrid/include/ESMC_DistGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/include/ESMC_DistGrid.h
+++ b/src/Infrastructure/DistGrid/include/ESMC_DistGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMCI_DistGrid_F.C
+++ b/src/Infrastructure/DistGrid/interface/ESMCI_DistGrid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMCI_DistGrid_F.C
+++ b/src/Infrastructure/DistGrid/interface/ESMCI_DistGrid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMC_DistGrid.C
+++ b/src/Infrastructure/DistGrid/interface/ESMC_DistGrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMC_DistGrid.C
+++ b/src/Infrastructure/DistGrid/interface/ESMC_DistGrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMF_DistGrid.F90
+++ b/src/Infrastructure/DistGrid/interface/ESMF_DistGrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMF_DistGrid.F90
+++ b/src/Infrastructure/DistGrid/interface/ESMF_DistGrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMF_DistGridConnection.F90
+++ b/src/Infrastructure/DistGrid/interface/ESMF_DistGridConnection.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMF_DistGridConnection.F90
+++ b/src/Infrastructure/DistGrid/interface/ESMF_DistGridConnection.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMF_DistGridRegDecomp.F90
+++ b/src/Infrastructure/DistGrid/interface/ESMF_DistGridRegDecomp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/interface/ESMF_DistGridRegDecomp.F90
+++ b/src/Infrastructure/DistGrid/interface/ESMF_DistGridRegDecomp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/src/ESMCI_DistGrid.C
+++ b/src/Infrastructure/DistGrid/src/ESMCI_DistGrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/src/ESMCI_DistGrid.C
+++ b/src/Infrastructure/DistGrid/src/ESMCI_DistGrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/tests/ESMC_DistGridUTest.c
+++ b/src/Infrastructure/DistGrid/tests/ESMC_DistGridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/tests/ESMC_DistGridUTest.c
+++ b/src/Infrastructure/DistGrid/tests/ESMC_DistGridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/DistGrid/tests/ESMF_DistGridCreateGetUTest.F90
+++ b/src/Infrastructure/DistGrid/tests/ESMF_DistGridCreateGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/DistGrid/tests/ESMF_DistGridCreateGetUTest.F90
+++ b/src/Infrastructure/DistGrid/tests/ESMF_DistGridCreateGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldArbGridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldArbGridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldArbGridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldArbGridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldCommEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldCommEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldCommEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldCommEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldCreateEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldCreateEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldCreateEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldCreateEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldHaloEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldHaloEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldMeshRegridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldMeshRegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldMeshRegridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldMeshRegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRedistEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRedistEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRedistEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRedistEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRegridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRegridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRegridMaskEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRegridMaskEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRegridMaskEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRegridMaskEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRepDimEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRepDimEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldRepDimEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldRepDimEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldSMMEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldSMMEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldSMMEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldSMMEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldSphereRegridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldSphereRegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/examples/ESMF_FieldSphereRegridEx.F90
+++ b/src/Infrastructure/Field/examples/ESMF_FieldSphereRegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/include/ESMCI_Field.h
+++ b/src/Infrastructure/Field/include/ESMCI_Field.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/include/ESMCI_Field.h
+++ b/src/Infrastructure/Field/include/ESMCI_Field.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/include/ESMC_Field.h
+++ b/src/Infrastructure/Field/include/ESMC_Field.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/include/ESMC_Field.h
+++ b/src/Infrastructure/Field/include/ESMC_Field.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/interface/ESMCI_Field.C
+++ b/src/Infrastructure/Field/interface/ESMCI_Field.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/interface/ESMCI_Field.C
+++ b/src/Infrastructure/Field/interface/ESMCI_Field.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/interface/ESMCI_Field_F.C
+++ b/src/Infrastructure/Field/interface/ESMCI_Field_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/interface/ESMCI_Field_F.C
+++ b/src/Infrastructure/Field/interface/ESMCI_Field_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/interface/ESMC_Field.C
+++ b/src/Infrastructure/Field/interface/ESMC_Field.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/interface/ESMC_Field.C
+++ b/src/Infrastructure/Field/interface/ESMC_Field.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/interface/ESMF_Field_C.F90
+++ b/src/Infrastructure/Field/interface/ESMF_Field_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/interface/ESMF_Field_C.F90
+++ b/src/Infrastructure/Field/interface/ESMF_Field_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_Field.F90
+++ b/src/Infrastructure/Field/src/ESMF_Field.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_Field.F90
+++ b/src/Infrastructure/Field/src/ESMF_Field.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldCreate.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldCreate.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldCreate.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldCreate.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldGetAllocBounds.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGetAllocBounds.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldGetAllocBounds.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGetAllocBounds.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldHalo.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldHalo.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldHalo.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldHalo.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldPr.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldPr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldPr.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldPr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_FieldRedist.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldRedist.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldRedist.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldRedist.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldRegrid.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldRegrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldRegrid.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldRegrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldSMM.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldSMM.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldSMM.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldSMM.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldScatter.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldScatter.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldScatter.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldScatter.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldSet.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldSet.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldSet.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldSet.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldWr.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldWr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_FieldWr.F90
+++ b/src/Infrastructure/Field/src/ESMF_FieldWr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/src/ESMF_UtilRWG.F90
+++ b/src/Infrastructure/Field/src/ESMF_UtilRWG.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/src/ESMF_UtilRWG.F90
+++ b/src/Infrastructure/Field/src/ESMF_UtilRWG.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridCsrvUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridCsrvUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridCsrvUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridCsrvUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridGridRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegrid2UTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegrid2UTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegrid2UTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegrid2UTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrv2UTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrv2UTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrv2UTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrv2UTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrvUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrvUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrvUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridCsrvUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridParUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridParUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridParUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridParUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldGridRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldGridRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldRegridCsrvUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldRegridCsrvUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldRegridCsrvUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldRegridCsrvUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldSMMFromFileUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldSMMFromFileUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldSMMFromFileUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldSMMFromFileUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Field/tests/ESMC_FieldTripoleRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldTripoleRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldTripoleRegridUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldTripoleRegridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMC_FieldUTest.c
+++ b/src/Infrastructure/Field/tests/ESMC_FieldUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldArbGridUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldArbGridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldArbGridUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldArbGridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldCreateGetUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldCreateGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldCreateGetUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldCreateGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldGatherUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldGatherUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldHaloUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldHaloUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldHaloUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldHaloUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldIOUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldIOUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldLSSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldLSSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldLSSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldLSSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldMeshSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldMeshSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldMeshSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldMeshSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRedistArbUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRedistArbUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRedistArbUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRedistArbUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRedistUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRedistUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCSUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCSUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCSUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCSUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrv2ndUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrv2ndUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrv2ndUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrv2ndUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrvUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrvUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrvUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrvUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridXGSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridXGSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridXGSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridXGSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridXGUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridXGUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridXGUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridXGUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldSMMFromFileUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldSMMFromFileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldSMMFromFileUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldSMMFromFileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldStressUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldStressUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldStressUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldStressUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Field/tests/ESMF_FieldUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleHaloEx.F90
+++ b/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleHaloEx.F90
+++ b/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleHaloEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleRedistEx.F90
+++ b/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleRedistEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleRedistEx.F90
+++ b/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleRedistEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleSMMEx.F90
+++ b/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleSMMEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleSMMEx.F90
+++ b/src/Infrastructure/FieldBundle/examples/ESMF_FieldBundleSMMEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/interface/ESMCI_FieldBundle_F.C
+++ b/src/Infrastructure/FieldBundle/interface/ESMCI_FieldBundle_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/FieldBundle/interface/ESMCI_FieldBundle_F.C
+++ b/src/Infrastructure/FieldBundle/interface/ESMCI_FieldBundle_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/FieldBundle/interface/ESMF_FieldBundle_C.F90
+++ b/src/Infrastructure/FieldBundle/interface/ESMF_FieldBundle_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/FieldBundle/interface/ESMF_FieldBundle_C.F90
+++ b/src/Infrastructure/FieldBundle/interface/ESMF_FieldBundle_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
+++ b/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
+++ b/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleCrGetUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleCrGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleCrGetUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleCrGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleIOUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleIOUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRedistUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRedistUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRedistUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRegridUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRegridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRegridUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleRegridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleSMMUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleSMMUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleSMMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GeomBase/interface/ESMCI_GeomBase_F.C
+++ b/src/Infrastructure/GeomBase/interface/ESMCI_GeomBase_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GeomBase/interface/ESMCI_GeomBase_F.C
+++ b/src/Infrastructure/GeomBase/interface/ESMCI_GeomBase_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GeomBase/src/ESMF_GeomBase.F90
+++ b/src/Infrastructure/GeomBase/src/ESMF_GeomBase.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GeomBase/src/ESMF_GeomBase.F90
+++ b/src/Infrastructure/GeomBase/src/ESMF_GeomBase.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/doc/Grid.bib
+++ b/src/Infrastructure/Grid/doc/Grid.bib
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid.bib
+++ b/src/Infrastructure/Grid/doc/Grid.bib
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_cdesc.tex
+++ b/src/Infrastructure/Grid/doc/Grid_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_cdesc.tex
+++ b/src/Infrastructure/Grid/doc/Grid_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_crefdoc.ctex
+++ b/src/Infrastructure/Grid/doc/Grid_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_crefdoc.ctex
+++ b/src/Infrastructure/Grid/doc/Grid_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_desc.tex
+++ b/src/Infrastructure/Grid/doc/Grid_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_desc.tex
+++ b/src/Infrastructure/Grid/doc/Grid_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_desdoc.bib
+++ b/src/Infrastructure/Grid/doc/Grid_desdoc.bib
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_desdoc.bib
+++ b/src/Infrastructure/Grid/doc/Grid_desdoc.bib
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_glos.tex
+++ b/src/Infrastructure/Grid/doc/Grid_glos.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_glos.tex
+++ b/src/Infrastructure/Grid/doc/Grid_glos.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_obj.tex
+++ b/src/Infrastructure/Grid/doc/Grid_obj.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/doc/Grid_obj.tex
+++ b/src/Infrastructure/Grid/doc/Grid_obj.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/doc/Grid_refdoc.ctex
+++ b/src/Infrastructure/Grid/doc/Grid_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_refdoc.ctex
+++ b/src/Infrastructure/Grid/doc/Grid_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_req.tex
+++ b/src/Infrastructure/Grid/doc/Grid_req.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/doc/Grid_req.tex
+++ b/src/Infrastructure/Grid/doc/Grid_req.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateFromF90ArraysEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateFromF90ArraysEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateFromF90ArraysEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateFromF90ArraysEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateRegFromDGEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateRegFromDGEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateRegFromDGEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateRegFromDGEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateSph2DPlus1Ex.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateSph2DPlus1Ex.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateSph2DPlus1Ex.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateSph2DPlus1Ex.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateTripoleEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateTripoleEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridCreateTripoleEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridCreateTripoleEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridUsageEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridUsageEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/examples/ESMF_GridUsageEx.F90
+++ b/src/Infrastructure/Grid/examples/ESMF_GridUsageEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/include/ESMCI_Grid.h
+++ b/src/Infrastructure/Grid/include/ESMCI_Grid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/include/ESMCI_Grid.h
+++ b/src/Infrastructure/Grid/include/ESMCI_Grid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/include/ESMC_Grid.h
+++ b/src/Infrastructure/Grid/include/ESMC_Grid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/include/ESMC_Grid.h
+++ b/src/Infrastructure/Grid/include/ESMC_Grid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/interface/ESMCI_Grid_F.C
+++ b/src/Infrastructure/Grid/interface/ESMCI_Grid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/interface/ESMCI_Grid_F.C
+++ b/src/Infrastructure/Grid/interface/ESMCI_Grid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/interface/ESMC_Grid.C
+++ b/src/Infrastructure/Grid/interface/ESMC_Grid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/interface/ESMC_Grid.C
+++ b/src/Infrastructure/Grid/interface/ESMC_Grid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/interface/ESMF_Grid.F90
+++ b/src/Infrastructure/Grid/interface/ESMF_Grid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/interface/ESMF_Grid.F90
+++ b/src/Infrastructure/Grid/interface/ESMF_Grid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/interface/ESMF_Grid_C.F90
+++ b/src/Infrastructure/Grid/interface/ESMF_Grid_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/interface/ESMF_Grid_C.F90
+++ b/src/Infrastructure/Grid/interface/ESMF_Grid_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/interface/ESMF_StaggerLoc.F90
+++ b/src/Infrastructure/Grid/interface/ESMF_StaggerLoc.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/interface/ESMF_StaggerLoc.F90
+++ b/src/Infrastructure/Grid/interface/ESMF_StaggerLoc.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/src/ESMCI_Grid.C
+++ b/src/Infrastructure/Grid/src/ESMCI_Grid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/src/ESMCI_Grid.C
+++ b/src/Infrastructure/Grid/src/ESMCI_Grid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Grid/tests/ESMC_GridUTest.c
+++ b/src/Infrastructure/Grid/tests/ESMC_GridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMC_GridUTest.c
+++ b/src/Infrastructure/Grid/tests/ESMC_GridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridArbitraryUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridArbitraryUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridArbitraryUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridArbitraryUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridCoordUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridCoordUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridCoordUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridCoordUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridCreateUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridCreateUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridItemUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridItemUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Grid/tests/ESMF_GridItemUTest.F90
+++ b/src/Infrastructure/Grid/tests/ESMF_GridItemUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/include/ESMCI_GridToMesh.h
+++ b/src/Infrastructure/GridUtil/include/ESMCI_GridToMesh.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/GridUtil/include/ESMCI_GridToMesh.h
+++ b/src/Infrastructure/GridUtil/include/ESMCI_GridToMesh.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/GridUtil/include/ESMCI_Ptypes.h
+++ b/src/Infrastructure/GridUtil/include/ESMCI_Ptypes.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/include/ESMCI_Ptypes.h
+++ b/src/Infrastructure/GridUtil/include/ESMCI_Ptypes.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/interface/ESMCI_GridUtil_F.C
+++ b/src/Infrastructure/GridUtil/interface/ESMCI_GridUtil_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/interface/ESMCI_GridUtil_F.C
+++ b/src/Infrastructure/GridUtil/interface/ESMCI_GridUtil_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/interface/ESMF_GridUtil.F90
+++ b/src/Infrastructure/GridUtil/interface/ESMF_GridUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/interface/ESMF_GridUtil.F90
+++ b/src/Infrastructure/GridUtil/interface/ESMF_GridUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/src/ESMCI_GridToMesh.C
+++ b/src/Infrastructure/GridUtil/src/ESMCI_GridToMesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/src/ESMCI_GridToMesh.C
+++ b/src/Infrastructure/GridUtil/src/ESMCI_GridToMesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/tests/ESMF_GridToMeshUTest.F90
+++ b/src/Infrastructure/GridUtil/tests/ESMF_GridToMeshUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/GridUtil/tests/ESMF_GridToMeshUTest.F90
+++ b/src/Infrastructure/GridUtil/tests/ESMF_GridToMeshUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/HConfig/include/ESMCI_HConfig.h
+++ b/src/Infrastructure/HConfig/include/ESMCI_HConfig.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/include/ESMCI_HConfig.h
+++ b/src/Infrastructure/HConfig/include/ESMCI_HConfig.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/interface/ESMCI_HConfig_F.C
+++ b/src/Infrastructure/HConfig/interface/ESMCI_HConfig_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/interface/ESMCI_HConfig_F.C
+++ b/src/Infrastructure/HConfig/interface/ESMCI_HConfig_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
+++ b/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
+++ b/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
+++ b/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
+++ b/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/HConfig/tests/ESMF_HConfigUTest.F90
+++ b/src/Infrastructure/HConfig/tests/ESMF_HConfigUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/HConfig/tests/ESMF_HConfigUTest.F90
+++ b/src/Infrastructure/HConfig/tests/ESMF_HConfigUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_IO.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_Gridspec.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Gridspec.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_Gridspec.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Gridspec.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_Handler.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Handler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_Handler.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Handler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_NetCDF.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_NetCDF.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_IO_NetCDF.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_NetCDF.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_IO_Schema.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Schema.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_Schema.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Schema.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_Scrip.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Scrip.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_Scrip.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_Scrip.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_IO_XML.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_XML.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_IO_XML.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_XML.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_IO_YAML.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_YAML.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_IO_YAML.h
+++ b/src/Infrastructure/IO/include/ESMCI_IO_YAML.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_PIO_Handler.h
+++ b/src/Infrastructure/IO/include/ESMCI_PIO_Handler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_PIO_Handler.h
+++ b/src/Infrastructure/IO/include/ESMCI_PIO_Handler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/ESMCI_SAX2ReadHandler.h
+++ b/src/Infrastructure/IO/include/ESMCI_SAX2ReadHandler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_SAX2ReadHandler.h
+++ b/src/Infrastructure/IO/include/ESMCI_SAX2ReadHandler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_SAX2WriteHandler.h
+++ b/src/Infrastructure/IO/include/ESMCI_SAX2WriteHandler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMCI_SAX2WriteHandler.h
+++ b/src/Infrastructure/IO/include/ESMCI_SAX2WriteHandler.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMC_IOScrip2ESMF.h
+++ b/src/Infrastructure/IO/include/ESMC_IOScrip2ESMF.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/ESMC_IOScrip2ESMF.h
+++ b/src/Infrastructure/IO/include/ESMC_IOScrip2ESMF.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/include/esmf_io_debug.h
+++ b/src/Infrastructure/IO/include/esmf_io_debug.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/include/esmf_io_debug.h
+++ b/src/Infrastructure/IO/include/esmf_io_debug.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/interface/ESMCI_IO_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/interface/ESMCI_IO_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/interface/ESMCI_IO_NetCDF_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_NetCDF_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMCI_IO_NetCDF_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_NetCDF_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMCI_IO_XML_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_XML_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/interface/ESMCI_IO_XML_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_XML_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/interface/ESMCI_IO_YAML_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_YAML_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/interface/ESMCI_IO_YAML_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_YAML_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/IO/interface/ESMC_IOScrip2ESMF.C
+++ b/src/Infrastructure/IO/interface/ESMC_IOScrip2ESMF.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMC_IOScrip2ESMF.C
+++ b/src/Infrastructure/IO/interface/ESMC_IOScrip2ESMF.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMC_IO_Gridspec.C
+++ b/src/Infrastructure/IO/interface/ESMC_IO_Gridspec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMC_IO_Gridspec.C
+++ b/src/Infrastructure/IO/interface/ESMC_IO_Gridspec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMC_IO_Scrip.C
+++ b/src/Infrastructure/IO/interface/ESMC_IO_Scrip.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMC_IO_Scrip.C
+++ b/src/Infrastructure/IO/interface/ESMC_IO_Scrip.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOFileTypeCheck.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOFileTypeCheck.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOFileTypeCheck.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOFileTypeCheck.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOGridmosaic.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOGridmosaic.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOGridmosaic.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOGridmosaic.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOGridspec.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOGridspec.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOGridspec.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOGridspec.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOScrip.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOScrip.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOScrip.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOScrip.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOUGrid.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOUGrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IOUGrid.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IOUGrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_Gridspec_C.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_Gridspec_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_Gridspec_C.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_Gridspec_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_NCPutGet.cppF90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_NCPutGet.cppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_NCPutGet.cppF90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_NCPutGet.cppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_NetCDF.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_NetCDF.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_NetCDF.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_NetCDF.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_Scrip_C.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_Scrip_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_Scrip_C.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_Scrip_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_YAML.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_YAML.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/interface/ESMF_IO_YAML.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_YAML.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Gridspec.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Gridspec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Gridspec.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Gridspec.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Handler.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Handler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Handler.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Handler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_NetCDF.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_NetCDF.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_NetCDF.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_NetCDF.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Schema.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Schema.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Schema.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Schema.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Scrip.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Scrip.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_Scrip.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_Scrip.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_XML.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_XML.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_XML.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_XML.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_YAML.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_YAML.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_IO_YAML.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_YAML.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_PIO_Handler.C
+++ b/src/Infrastructure/IO/src/ESMCI_PIO_Handler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_PIO_Handler.C
+++ b/src/Infrastructure/IO/src/ESMCI_PIO_Handler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_SAX2ReadHandler.C
+++ b/src/Infrastructure/IO/src/ESMCI_SAX2ReadHandler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_SAX2ReadHandler.C
+++ b/src/Infrastructure/IO/src/ESMCI_SAX2ReadHandler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_SAX2WriteHandler.C
+++ b/src/Infrastructure/IO/src/ESMCI_SAX2WriteHandler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/src/ESMCI_SAX2WriteHandler.C
+++ b/src/Infrastructure/IO/src/ESMCI_SAX2WriteHandler.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMCI_IO_NetCDFUTest.C
+++ b/src/Infrastructure/IO/tests/ESMCI_IO_NetCDFUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMCI_IO_NetCDFUTest.C
+++ b/src/Infrastructure/IO/tests/ESMCI_IO_NetCDFUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMCI_IO_PIOUTest.C
+++ b/src/Infrastructure/IO/tests/ESMCI_IO_PIOUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMCI_IO_PIOUTest.C
+++ b/src/Infrastructure/IO/tests/ESMCI_IO_PIOUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMC_IO_InqUTest.c
+++ b/src/Infrastructure/IO/tests/ESMC_IO_InqUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMC_IO_InqUTest.c
+++ b/src/Infrastructure/IO/tests/ESMC_IO_InqUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMF_IOUTest.F90
+++ b/src/Infrastructure/IO/tests/ESMF_IOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMF_IOUTest.F90
+++ b/src/Infrastructure/IO/tests/ESMF_IOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMF_IO_MultitileUTest.F90
+++ b/src/Infrastructure/IO/tests/ESMF_IO_MultitileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMF_IO_MultitileUTest.F90
+++ b/src/Infrastructure/IO/tests/ESMF_IO_MultitileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMF_IO_YAMLUTest.F90
+++ b/src/Infrastructure/IO/tests/ESMF_IO_YAMLUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/IO/tests/ESMF_IO_YAMLUTest.F90
+++ b/src/Infrastructure/IO/tests/ESMF_IO_YAMLUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/doc/LocStream_crefdoc.ctex
+++ b/src/Infrastructure/LocStream/doc/LocStream_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/doc/LocStream_crefdoc.ctex
+++ b/src/Infrastructure/LocStream/doc/LocStream_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/doc/LocStream_desc.tex
+++ b/src/Infrastructure/LocStream/doc/LocStream_desc.tex
@@ -1,6 +1,6 @@
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/doc/LocStream_desc.tex
+++ b/src/Infrastructure/LocStream/doc/LocStream_desc.tex
@@ -1,6 +1,6 @@
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/doc/LocStream_refdoc.ctex
+++ b/src/Infrastructure/LocStream/doc/LocStream_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/doc/LocStream_refdoc.ctex
+++ b/src/Infrastructure/LocStream/doc/LocStream_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/examples/ESMF_LocStreamEx.F90
+++ b/src/Infrastructure/LocStream/examples/ESMF_LocStreamEx.F90
@@ -1,6 +1,6 @@
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/examples/ESMF_LocStreamEx.F90
+++ b/src/Infrastructure/LocStream/examples/ESMF_LocStreamEx.F90
@@ -1,6 +1,6 @@
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/include/ESMCI_LocStream.h
+++ b/src/Infrastructure/LocStream/include/ESMCI_LocStream.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/include/ESMCI_LocStream.h
+++ b/src/Infrastructure/LocStream/include/ESMCI_LocStream.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/include/ESMC_LocStream.h
+++ b/src/Infrastructure/LocStream/include/ESMC_LocStream.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/include/ESMC_LocStream.h
+++ b/src/Infrastructure/LocStream/include/ESMC_LocStream.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/interface/ESMCI_LocStream.C
+++ b/src/Infrastructure/LocStream/interface/ESMCI_LocStream.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/interface/ESMCI_LocStream.C
+++ b/src/Infrastructure/LocStream/interface/ESMCI_LocStream.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/interface/ESMCI_LocStream_F.C
+++ b/src/Infrastructure/LocStream/interface/ESMCI_LocStream_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/interface/ESMCI_LocStream_F.C
+++ b/src/Infrastructure/LocStream/interface/ESMCI_LocStream_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/interface/ESMC_LocStream.C
+++ b/src/Infrastructure/LocStream/interface/ESMC_LocStream.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/interface/ESMC_LocStream.C
+++ b/src/Infrastructure/LocStream/interface/ESMC_LocStream.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/interface/ESMF_LocStream_C.F90
+++ b/src/Infrastructure/LocStream/interface/ESMF_LocStream_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/interface/ESMF_LocStream_C.F90
+++ b/src/Infrastructure/LocStream/interface/ESMF_LocStream_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/src/ESMF_LocStream.F90
+++ b/src/Infrastructure/LocStream/src/ESMF_LocStream.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/src/ESMF_LocStream.F90
+++ b/src/Infrastructure/LocStream/src/ESMF_LocStream.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocStream/tests/ESMC_LocStreamUTest.c
+++ b/src/Infrastructure/LocStream/tests/ESMC_LocStreamUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/tests/ESMC_LocStreamUTest.c
+++ b/src/Infrastructure/LocStream/tests/ESMC_LocStreamUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/tests/ESMF_LocStreamUTest.F90
+++ b/src/Infrastructure/LocStream/tests/ESMF_LocStreamUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocStream/tests/ESMF_LocStreamUTest.F90
+++ b/src/Infrastructure/LocStream/tests/ESMF_LocStreamUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocalArray/doc/LocalArray_refdoc.ctex
+++ b/src/Infrastructure/LocalArray/doc/LocalArray_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/doc/LocalArray_refdoc.ctex
+++ b/src/Infrastructure/LocalArray/doc/LocalArray_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/include/ESMCI_LocalArray.h
+++ b/src/Infrastructure/LocalArray/include/ESMCI_LocalArray.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/include/ESMCI_LocalArray.h
+++ b/src/Infrastructure/LocalArray/include/ESMCI_LocalArray.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMCI_LocalArray_F.C
+++ b/src/Infrastructure/LocalArray/interface/ESMCI_LocalArray_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMCI_LocalArray_F.C
+++ b/src/Infrastructure/LocalArray/interface/ESMCI_LocalArray_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArray.F90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArray.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArray.F90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArray.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayCreate.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayCreate.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayCreate.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayCreate.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayWrapperType.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayWrapperType.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayWrapperType.cppF90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArrayWrapperType.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArray_C.F90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArray_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/interface/ESMF_LocalArray_C.F90
+++ b/src/Infrastructure/LocalArray/interface/ESMF_LocalArray_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/src/ESMCI_LocalArray.C
+++ b/src/Infrastructure/LocalArray/src/ESMCI_LocalArray.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/src/ESMCI_LocalArray.C
+++ b/src/Infrastructure/LocalArray/src/ESMCI_LocalArray.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayDataUTest.F90
+++ b/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayDataUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayDataUTest.F90
+++ b/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayDataUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/doc/LogErr_background.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_background.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_background.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_background.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_cdesc.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_cdesc.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_cex.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_cex.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_cex.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_cex.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_coptions.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_coptions.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_coptions.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_coptions.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_crefdoc.ctex
+++ b/src/Infrastructure/LogErr/doc/LogErr_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_crefdoc.ctex
+++ b/src/Infrastructure/LogErr/doc/LogErr_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_desc.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_desc.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_design.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_design.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_design.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_design.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_implnotes.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_implnotes.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_implnotes.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_implnotes.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_obj.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_obj.tex
@@ -1,7 +1,7 @@
 %$Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_obj.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_obj.tex
@@ -1,7 +1,7 @@
 %$Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_options.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_options.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_refdoc.ctex
+++ b/src/Infrastructure/LogErr/doc/LogErr_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_refdoc.ctex
+++ b/src/Infrastructure/LogErr/doc/LogErr_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_rest.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/doc/LogErr_rest.tex
+++ b/src/Infrastructure/LogErr/doc/LogErr_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/examples/ESMF_LogErrEx.F90
+++ b/src/Infrastructure/LogErr/examples/ESMF_LogErrEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/examples/ESMF_LogErrEx.F90
+++ b/src/Infrastructure/LogErr/examples/ESMF_LogErrEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/include/ESMCI_ErrMsgs.C
+++ b/src/Infrastructure/LogErr/include/ESMCI_ErrMsgs.C
@@ -1,7 +1,7 @@
 //$Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/include/ESMCI_ErrMsgs.C
+++ b/src/Infrastructure/LogErr/include/ESMCI_ErrMsgs.C
@@ -1,7 +1,7 @@
 //$Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/include/ESMCI_LogErr.h
+++ b/src/Infrastructure/LogErr/include/ESMCI_LogErr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/include/ESMCI_LogErr.h
+++ b/src/Infrastructure/LogErr/include/ESMCI_LogErr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/include/ESMC_LogErr.h
+++ b/src/Infrastructure/LogErr/include/ESMC_LogErr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/include/ESMC_LogErr.h
+++ b/src/Infrastructure/LogErr/include/ESMC_LogErr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/interface/ESMCI_LogErr_F.C
+++ b/src/Infrastructure/LogErr/interface/ESMCI_LogErr_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/interface/ESMCI_LogErr_F.C
+++ b/src/Infrastructure/LogErr/interface/ESMCI_LogErr_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/interface/ESMC_LogErr.C
+++ b/src/Infrastructure/LogErr/interface/ESMC_LogErr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/interface/ESMC_LogErr.C
+++ b/src/Infrastructure/LogErr/interface/ESMC_LogErr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/interface/ESMF_LogErr_C.F90
+++ b/src/Infrastructure/LogErr/interface/ESMF_LogErr_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/interface/ESMF_LogErr_C.F90
+++ b/src/Infrastructure/LogErr/interface/ESMF_LogErr_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/interface/ESMF_LogPublic.F90
+++ b/src/Infrastructure/LogErr/interface/ESMF_LogPublic.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/interface/ESMF_LogPublic.F90
+++ b/src/Infrastructure/LogErr/interface/ESMF_LogPublic.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/src/ESMCI_LogErr.C
+++ b/src/Infrastructure/LogErr/src/ESMCI_LogErr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/src/ESMCI_LogErr.C
+++ b/src/Infrastructure/LogErr/src/ESMCI_LogErr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMCI_LogErrPerfUTest.C
+++ b/src/Infrastructure/LogErr/tests/ESMCI_LogErrPerfUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/tests/ESMCI_LogErrPerfUTest.C
+++ b/src/Infrastructure/LogErr/tests/ESMCI_LogErrPerfUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/LogErr/tests/ESMCI_TestError.C
+++ b/src/Infrastructure/LogErr/tests/ESMCI_TestError.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMCI_TestError.C
+++ b/src/Infrastructure/LogErr/tests/ESMCI_TestError.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMC_LogErrUTest.c
+++ b/src/Infrastructure/LogErr/tests/ESMC_LogErrUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMC_LogErrUTest.c
+++ b/src/Infrastructure/LogErr/tests/ESMC_LogErrUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMF_LogErrHaltUTest.F90
+++ b/src/Infrastructure/LogErr/tests/ESMF_LogErrHaltUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMF_LogErrHaltUTest.F90
+++ b/src/Infrastructure/LogErr/tests/ESMF_LogErrHaltUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMF_LogErrPerfUTest.F90
+++ b/src/Infrastructure/LogErr/tests/ESMF_LogErrPerfUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMF_LogErrPerfUTest.F90
+++ b/src/Infrastructure/LogErr/tests/ESMF_LogErrPerfUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMF_LogErrUTest.F90
+++ b/src/Infrastructure/LogErr/tests/ESMF_LogErrUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/LogErr/tests/ESMF_LogErrUTest.F90
+++ b/src/Infrastructure/LogErr/tests/ESMF_LogErrUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/doc/Mesh_crefdoc.ctex
+++ b/src/Infrastructure/Mesh/doc/Mesh_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/doc/Mesh_crefdoc.ctex
+++ b/src/Infrastructure/Mesh/doc/Mesh_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_DCatEx.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_DCatEx.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_DCatEx.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_DCatEx.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_DPart.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_DPart.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_DPart.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_DPart.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_RefineEx.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_RefineEx.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_RefineEx.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_RefineEx.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_RendEx.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_RendEx.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMCI_RendEx.C
+++ b/src/Infrastructure/Mesh/examples/ESMCI_RendEx.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/ESMF_MeshEx.F90
+++ b/src/Infrastructure/Mesh/examples/ESMF_MeshEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/examples/ESMF_MeshEx.F90
+++ b/src/Infrastructure/Mesh/examples/ESMF_MeshEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/examples/MeshCat
+++ b/src/Infrastructure/Mesh/examples/MeshCat
@@ -2,7 +2,7 @@
 # $Id$
 #
 # Earth System Modeling Framework
-# Copyright 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/examples/MeshCat
+++ b/src/Infrastructure/Mesh/examples/MeshCat
@@ -2,7 +2,7 @@
 # $Id$
 #
 # Earth System Modeling Framework
-# Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+# Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 # Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 # Laboratory, University of Michigan, National Centers for Environmental 
 # Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_ClumpPnts.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_ClumpPnts.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_ClumpPnts.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_ClumpPnts.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_ESMFMesh_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_ESMFMesh_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_ESMFMesh_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_ESMFMesh_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_FileIO_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_FileIO_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_FileIO_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_FileIO_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_GToM_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_GToM_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_GToM_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_GToM_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_BBox.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_BBox.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_BBox.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_BBox.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Bilinear.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Bilinear.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Bilinear.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Bilinear.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Conserve.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Conserve.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Conserve.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Conserve.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Dual.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Dual.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Dual.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Dual.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Extrapolation.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Extrapolation.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Extrapolation.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Extrapolation.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_GToM_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_GToM_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_GToM_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_GToM_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Mapping.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Mapping.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Mapping.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Mapping.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Patch.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Patch.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Patch.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Patch.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Redist.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Redist.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Redist.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Redist.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Regrid_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Regrid_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Regrid_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Regrid_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_Elem.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_Elem.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_Elem.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_Elem.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_EtoP.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_EtoP.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_EtoP.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Rendez_EtoP.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoE.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoE.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoE.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoE.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoP.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoP.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoP.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Search_EtoP.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_ShapeFunc.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_ShapeFunc.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_ShapeFunc.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_ShapeFunc.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Types.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Types.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Types.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Types.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MBMesh_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MathUtil.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MathUtil.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MathUtil.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MathUtil.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshCXX.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshCXX.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshCXX.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshCXX.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshCap.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshCap.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshCap.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshCap.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshDual.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshDual.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshDual.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshDual.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshRedist.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshRedist.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_MeshRedist.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_MeshRedist.h
@@ -1,6 +1,6 @@
 // $Id: ESMCI_Search.h,v 1.13 2012/11/13 22:22:41 oehmke Exp $
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_FileIO.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_FileIO.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_FileIO.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_FileIO.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_GToM_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_GToM_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_GToM_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_GToM_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_Regrid_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_Regrid_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_Regrid_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_Regrid_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_XGrid_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_XGrid_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Mesh_XGrid_Glue.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Mesh_XGrid_Glue.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_OTree.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_OTree.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_OTree.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_OTree.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_RegridConstants.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_RegridConstants.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_RegridConstants.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_RegridConstants.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_Regrid_Nearest.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Regrid_Nearest.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Regrid_Nearest.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Regrid_Nearest.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Rendez_Nearest.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Rendez_Nearest.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Rendez_Nearest.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Rendez_Nearest.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Search_Nearest.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Search_Nearest.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_Search_Nearest.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_Search_Nearest.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_UGRID_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_UGRID_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_UGRID_Util.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_UGRID_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMCI_XGridUtil.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_XGridUtil.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMCI_XGridUtil.h
+++ b/src/Infrastructure/Mesh/include/ESMCI_XGridUtil.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/ESMC_Mesh.h
+++ b/src/Infrastructure/Mesh/include/ESMC_Mesh.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/ESMC_Mesh.h
+++ b/src/Infrastructure/Mesh/include/ESMC_Mesh.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Attr.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Attr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Attr.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Attr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_BBox.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_BBox.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_BBox.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_BBox.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommReg.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommReg.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommReg.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommReg.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommRel.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommRel.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommRel.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_CommRel.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Context.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Context.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Context.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Context.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_DDir.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_DDir.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_DDir.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_DDir.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Exception.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Exception.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Exception.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Exception.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_FieldReg.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_FieldReg.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_FieldReg.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_FieldReg.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_FindPnts.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_FindPnts.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_FindPnts.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_FindPnts.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Ftn.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Ftn.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Ftn.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Ftn.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_GeomRendezvous.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_GeomRendezvous.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_GeomRendezvous.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_GeomRendezvous.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_GlobalIds.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_GlobalIds.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_GlobalIds.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_GlobalIds.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_HAdapt.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_HAdapt.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_HAdapt.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_HAdapt.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_IOField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_IOField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_IOField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_IOField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Iterator.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Iterator.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Iterator.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Iterator.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Kernel.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Kernel.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Kernel.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Kernel.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_List.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_List.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_List.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_List.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MCoord.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MCoord.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MCoord.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MCoord.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEFamily.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEFamily.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEFamily.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEFamily.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEImprint.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEImprint.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEImprint.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEImprint.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEValues.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEValues.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEValues.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MEValues.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Mask.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Mask.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Mask.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Mask.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MasterElement.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MasterElement.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MasterElement.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MasterElement.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshContext.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshContext.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshContext.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshContext.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshDB.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshDB.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshDB.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshDB.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshExodus.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshExodus.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshExodus.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshExodus.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshGen.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshGen.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshGen.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshGen.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshMerge.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshMerge.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshMerge.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshMerge.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshNC.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshNC.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshNC.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshNC.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObj.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObj.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObj.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObj.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjConn.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjConn.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjConn.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjConn.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjPack.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjPack.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjPack.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjPack.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjTopo.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjTopo.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjTopo.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshObjTopo.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPNC.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPNC.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPNC.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPNC.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPartition.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPartition.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPartition.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshPartition.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRead.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRead.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRead.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRead.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRefine.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRefine.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRefine.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshRefine.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSet.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSet.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSet.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSet.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSkin.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSkin.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSkin.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshSkin.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTests.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTests.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTests.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTests.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTypes.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTypes.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTypes.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshTypes.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshUtils.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshUtils.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshUtils.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshUtils.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshVTK.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshVTK.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshVTK.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshVTK.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshllField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshllField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshllField.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_MeshllField.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Migrator.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Migrator.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Migrator.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Migrator.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParEnv.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParEnv.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParEnv.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParEnv.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParLog.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParLog.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParLog.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_ParLog.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Polynomial.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Polynomial.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Polynomial.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Polynomial.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Quadrature.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Quadrature.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Quadrature.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Quadrature.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Rebalance.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Rebalance.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Rebalance.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Rebalance.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_RefineTopo.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_RefineTopo.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_RefineTopo.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_RefineTopo.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SFuncAdaptor.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SFuncAdaptor.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SFuncAdaptor.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SFuncAdaptor.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SM.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SM.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SM.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SM.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_ShapeLagrange.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_ShapeLagrange.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_ShapeLagrange.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_ShapeLagrange.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Sintdnode.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Sintdnode.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Sintdnode.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Sintdnode.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SmallAlloc.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SmallAlloc.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SmallAlloc.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SmallAlloc.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SparseMsg.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SparseMsg.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_SparseMsg.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_SparseMsg.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Tree.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Tree.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_Tree.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_Tree.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeights.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeights.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeights.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeights.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeightsPar.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeightsPar.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeightsPar.h
+++ b/src/Infrastructure/Mesh/include/Legacy/ESMCI_WriteWeightsPar.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Conserve2ndInterp.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Conserve2ndInterp.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Conserve2ndInterp.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Conserve2ndInterp.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_ConserveInterp.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_ConserveInterp.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_ConserveInterp.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_ConserveInterp.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_CreepFill.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_CreepFill.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_CreepFill.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_CreepFill.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Extrap.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Extrap.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Extrap.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Extrap.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_ExtrapolationPoleLGC.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_ExtrapolationPoleLGC.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_ExtrapolationPoleLGC.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_ExtrapolationPoleLGC.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Integrate.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Integrate.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Integrate.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Integrate.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Interp.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Interp.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Interp.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Interp.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Mapping.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Mapping.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Mapping.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Mapping.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_MeshRegrid.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_MeshRegrid.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_MeshRegrid.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_MeshRegrid.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_PatchRecovery.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_PatchRecovery.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_PatchRecovery.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_PatchRecovery.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Regrid_Helper.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Regrid_Helper.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Regrid_Helper.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Regrid_Helper.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Search.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Search.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_Search.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_Search.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_SearchFlags.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_SearchFlags.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_SearchFlags.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_SearchFlags.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_ShapeFunc.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_ShapeFunc.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_ShapeFunc.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_ShapeFunc.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_SpaceDir.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_SpaceDir.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_SpaceDir.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_SpaceDir.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_WMat.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_WMat.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/include/Regridding/ESMCI_WMat.h
+++ b/src/Infrastructure/Mesh/include/Regridding/ESMCI_WMat.h
@@ -1,6 +1,6 @@
 // $Id$
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/interface/ESMCI_Mesh_F.C
+++ b/src/Infrastructure/Mesh/interface/ESMCI_Mesh_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/interface/ESMCI_Mesh_F.C
+++ b/src/Infrastructure/Mesh/interface/ESMCI_Mesh_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/interface/ESMC_Mesh.C
+++ b/src/Infrastructure/Mesh/interface/ESMC_Mesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/interface/ESMC_Mesh.C
+++ b/src/Infrastructure/Mesh/interface/ESMC_Mesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/interface/ESMF_Mesh.F90
+++ b/src/Infrastructure/Mesh/interface/ESMF_Mesh.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/interface/ESMF_Mesh.F90
+++ b/src/Infrastructure/Mesh/interface/ESMF_Mesh.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/interface/ESMF_Mesh_C.F90
+++ b/src/Infrastructure/Mesh/interface/ESMF_Mesh_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/interface/ESMF_Mesh_C.F90
+++ b/src/Infrastructure/Mesh/interface/ESMF_Mesh_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_ClumpPnts.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_ClumpPnts.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_ClumpPnts.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_ClumpPnts.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_ESMFMesh_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_FileIO_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_FileIO_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_FileIO_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_FileIO_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_GToM_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_GToM_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_GToM_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_GToM_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_BBox.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_BBox.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_BBox.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_BBox.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Bilinear.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Bilinear.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Bilinear.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Bilinear.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Conserve.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Conserve.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Conserve.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Conserve.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Dual.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Dual.C
@@ -1,8 +1,7 @@
 // $Id: ESMCI_MeshRedist.C,v 1.23 2012/01/06 20:17:51 svasquez Exp $
 //
 // Earth System Modeling Framework
-// Copyright 
-// 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Extrapolation.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Extrapolation.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Extrapolation.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Extrapolation.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_GToM_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_GToM_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_GToM_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_GToM_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Mapping.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Mapping.C
@@ -1,6 +1,6 @@
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Mapping.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Mapping.C
@@ -1,6 +1,6 @@
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Patch.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Patch.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Patch.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Patch.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Redist.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Redist.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Redist.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Redist.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Regrid_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Regrid_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Regrid_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Regrid_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_Elem.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_Elem.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_Elem.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_Elem.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_EtoP.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_EtoP.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_EtoP.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Rendez_EtoP.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoE.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoE.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoE.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoE.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoP.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoP.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoP.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Search_EtoP.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_ShapeFunc.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_ShapeFunc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_ShapeFunc.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_ShapeFunc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MBMesh_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MathUtil.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MathUtil.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MathUtil.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MathUtil.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshCXX.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshCXX.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshCXX.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshCXX.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshCap.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshCap.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshCap.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshCap.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshDual.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshDual.C
@@ -2,7 +2,7 @@
 // $Id: ESMCI_MeshRedist.C,v 1.23 2012/01/06 20:17:51 svasquez Exp $
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshDual.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshDual.C
@@ -2,7 +2,7 @@
 // $Id: ESMCI_MeshRedist.C,v 1.23 2012/01/06 20:17:51 svasquez Exp $
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshRedist.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshRedist.C
@@ -1,7 +1,7 @@
 // $Id: ESMCI_MeshRedist.C,v 1.23 2012/01/06 20:17:51 svasquez Exp $
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_MeshRedist.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_MeshRedist.C
@@ -1,7 +1,7 @@
 // $Id: ESMCI_MeshRedist.C,v 1.23 2012/01/06 20:17:51 svasquez Exp $
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_FileIO.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_GToM_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_GToM_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_GToM_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_GToM_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_Regrid_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_Regrid_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_Regrid_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_Regrid_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_XGrid_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_XGrid_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Mesh_XGrid_Glue.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Mesh_XGrid_Glue.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_OTree.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_OTree.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_OTree.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_OTree.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Regrid_Nearest.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Regrid_Nearest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_Regrid_Nearest.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Regrid_Nearest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_Rendez_Nearest.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Rendez_Nearest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_Rendez_Nearest.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Rendez_Nearest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_Search_Nearest.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Search_Nearest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Search_Nearest.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Search_Nearest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Search_NearestNPnts.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Search_NearestNPnts.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_Search_NearestNPnts.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_Search_NearestNPnts.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_UGRID_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_UGRID_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_UGRID_Util.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_UGRID_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/ESMCI_XGridUtil.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_XGridUtil.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/ESMCI_XGridUtil.C
+++ b/src/Infrastructure/Mesh/src/ESMCI_XGridUtil.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Attr.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Attr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Attr.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Attr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_BBox.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_BBox.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_BBox.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_BBox.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommReg.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommReg.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommReg.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommReg.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommRel.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommRel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommRel.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_CommRel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Context.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Context.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Context.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Context.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_DDir.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_DDir.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_DDir.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_DDir.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Exception.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Exception.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Exception.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Exception.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_FieldReg.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_FieldReg.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_FieldReg.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_FieldReg.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_FindPnts.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_FindPnts.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_FindPnts.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_FindPnts.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_GeomRendezvous.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_GeomRendezvous.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_GeomRendezvous.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_GeomRendezvous.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_GlobalIds.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_GlobalIds.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_GlobalIds.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_GlobalIds.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_HAdapt.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_HAdapt.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_HAdapt.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_HAdapt.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_IOField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_IOField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_IOField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_IOField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Kernel.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Kernel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Kernel.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Kernel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MCoord.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MCoord.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MCoord.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MCoord.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEFamily.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEFamily.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEFamily.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEFamily.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEImprint.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEImprint.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEImprint.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEImprint.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEValues.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEValues.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEValues.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MEValues.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElement.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElement.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElement.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElement.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElementV.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElementV.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElementV.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MasterElementV.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshDB.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshDB.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshDB.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshDB.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshExodus.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshExodus.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshExodus.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshExodus.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshGen.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshGen.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshGen.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshGen.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshMerge.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshMerge.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshMerge.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshMerge.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshNC.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshNC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshNC.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshNC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObj.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObj.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObj.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObj.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjConn.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjConn.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjConn.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjConn.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjPack.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjPack.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjPack.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjPack.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjTopo.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjTopo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjTopo.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshObjTopo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPNC.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPNC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPNC.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPNC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPartition.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPartition.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPartition.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPartition.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRead.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRead.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRead.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRead.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRefine.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRefine.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRefine.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshRefine.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshSkin.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshSkin.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshSkin.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshSkin.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshUtils.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshUtils.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshUtils.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshUtils.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshVTK.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshVTK.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshVTK.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshVTK.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshllField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshllField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshllField.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshllField.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Migrator.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Migrator.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Migrator.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Migrator.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParEnv.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParEnv.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParEnv.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParEnv.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParLog.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParLog.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParLog.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_ParLog.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Polynomial.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Polynomial.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Polynomial.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Polynomial.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Quadrature.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Quadrature.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Quadrature.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Quadrature.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Rebalance.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Rebalance.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_Rebalance.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_Rebalance.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_RefineTopo.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_RefineTopo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_RefineTopo.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_RefineTopo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SFuncAdaptor.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SFuncAdaptor.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SFuncAdaptor.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SFuncAdaptor.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SM.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SM.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SM.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SM.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_ShapeLagrange.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_ShapeLagrange.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_ShapeLagrange.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_ShapeLagrange.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SmallAlloc.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SmallAlloc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SmallAlloc.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SmallAlloc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SparseMsg.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SparseMsg.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_SparseMsg.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_SparseMsg.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeights.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeights.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeights.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeights.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeightsPar.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeightsPar.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeightsPar.C
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeightsPar.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMF_SolverUtil_C.F90
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMF_SolverUtil_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Legacy/ESMF_SolverUtil_C.F90
+++ b/src/Infrastructure/Mesh/src/Legacy/ESMF_SolverUtil_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Conserve2ndInterp.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Conserve2ndInterp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Conserve2ndInterp.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Conserve2ndInterp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_ConserveInterp.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_ConserveInterp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_ConserveInterp.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_ConserveInterp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_CreepFill.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_CreepFill.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_CreepFill.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_CreepFill.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Extrap.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Extrap.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Extrap.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Extrap.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_ExtrapolationPoleLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_ExtrapolationPoleLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_ExtrapolationPoleLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_ExtrapolationPoleLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Integrate.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Integrate.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Integrate.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Integrate.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Interp.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Interp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Interp.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Interp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Mapping.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Mapping.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Mapping.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Mapping.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_MeshRegrid.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_MeshRegrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_MeshRegrid.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_MeshRegrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_PatchRecovery.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_PatchRecovery.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_PatchRecovery.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_PatchRecovery.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Regrid_Helper.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Regrid_Helper.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Regrid_Helper.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Regrid_Helper.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Search.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Search.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_Search.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_Search.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestDToSLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestDToSLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestDToSLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestDToSLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestNPntsLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestNPntsLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestNPntsLGC.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SearchNearestNPntsLGC.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_ShapeFunc.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_ShapeFunc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_ShapeFunc.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_ShapeFunc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SpaceDir.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SpaceDir.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_SpaceDir.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_SpaceDir.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_WMat.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_WMat.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/src/Regridding/ESMCI_WMat.C
+++ b/src/Infrastructure/Mesh/src/Regridding/ESMCI_WMat.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_IntegrateUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_IntegrateUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/tests/ESMCI_IntegrateUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_IntegrateUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_ExtrapolateUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_ExtrapolateUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_ExtrapolateUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_ExtrapolateUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_UtilUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_UtilUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_UtilUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MBMesh_UtilUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MCT.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MCT.C
@@ -1,7 +1,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MCT.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MCT.C
@@ -1,7 +1,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MCTGen.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MCTGen.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MCTGen.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MCTGen.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshCapRegridUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshCapRegridUTest.C
@@ -1,7 +1,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshCapRegridUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshCapRegridUTest.C
@@ -1,7 +1,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshCapUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshCapUTest.C
@@ -1,7 +1,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshCapUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshCapUTest.C
@@ -1,7 +1,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshMOABUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshMOABUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshMOABUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshMOABUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshTestGenPL.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshTestGenPL.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshTestGenPL.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshTestGenPL.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_NearestUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_NearestUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_NearestUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_NearestUTest.C
@@ -2,7 +2,7 @@
 //==============================================================================
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_Proj4UTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_Proj4UTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMCI_Proj4UTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_Proj4UTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMC_MeshVTKUTest.c
+++ b/src/Infrastructure/Mesh/tests/ESMC_MeshVTKUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMC_MeshVTKUTest.c
+++ b/src/Infrastructure/Mesh/tests/ESMC_MeshVTKUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMF_MeshFileIOUTest.F90
+++ b/src/Infrastructure/Mesh/tests/ESMF_MeshFileIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMF_MeshFileIOUTest.F90
+++ b/src/Infrastructure/Mesh/tests/ESMF_MeshFileIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMF_MeshOpUTest.F90
+++ b/src/Infrastructure/Mesh/tests/ESMF_MeshOpUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMF_MeshOpUTest.F90
+++ b/src/Infrastructure/Mesh/tests/ESMF_MeshOpUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMF_MeshUTest.F90
+++ b/src/Infrastructure/Mesh/tests/ESMF_MeshUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Mesh/tests/ESMF_MeshUTest.F90
+++ b/src/Infrastructure/Mesh/tests/ESMF_MeshUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/include/ESMCI_PointList.h
+++ b/src/Infrastructure/PointList/include/ESMCI_PointList.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/PointList/include/ESMCI_PointList.h
+++ b/src/Infrastructure/PointList/include/ESMCI_PointList.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/PointList/interface/ESMCI_PointList_F.C
+++ b/src/Infrastructure/PointList/interface/ESMCI_PointList_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/interface/ESMCI_PointList_F.C
+++ b/src/Infrastructure/PointList/interface/ESMCI_PointList_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/interface/ESMF_PointList.F90
+++ b/src/Infrastructure/PointList/interface/ESMF_PointList.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/interface/ESMF_PointList.F90
+++ b/src/Infrastructure/PointList/interface/ESMF_PointList.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/src/ESMCI_PointList.C
+++ b/src/Infrastructure/PointList/src/ESMCI_PointList.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/src/ESMCI_PointList.C
+++ b/src/Infrastructure/PointList/src/ESMCI_PointList.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/tests/ESMF_PointListUTest.F90
+++ b/src/Infrastructure/PointList/tests/ESMF_PointListUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/PointList/tests/ESMF_PointListUTest.F90
+++ b/src/Infrastructure/PointList/tests/ESMF_PointListUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/doc/Regrid.bib
+++ b/src/Infrastructure/Regrid/doc/Regrid.bib
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid.bib
+++ b/src/Infrastructure/Regrid/doc/Regrid.bib
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid_desc.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid_desc.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid_glos.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_glos.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid_glos.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_glos.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid_obj.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_obj.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/doc/Regrid_obj.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_obj.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/doc/Regrid_refdoc.ctex
+++ b/src/Infrastructure/Regrid/doc/Regrid_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid_refdoc.ctex
+++ b/src/Infrastructure/Regrid/doc/Regrid_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/doc/Regrid_req.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_req.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/doc/Regrid_req.tex
+++ b/src/Infrastructure/Regrid/doc/Regrid_req.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/examples/ESMF_RegridEx.F90
+++ b/src/Infrastructure/Regrid/examples/ESMF_RegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/examples/ESMF_RegridEx.F90
+++ b/src/Infrastructure/Regrid/examples/ESMF_RegridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/interface/ESMCI_Regrid_F.C
+++ b/src/Infrastructure/Regrid/interface/ESMCI_Regrid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/interface/ESMCI_Regrid_F.C
+++ b/src/Infrastructure/Regrid/interface/ESMCI_Regrid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/interface/ESMF_Regrid_C.F90
+++ b/src/Infrastructure/Regrid/interface/ESMF_Regrid_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/interface/ESMF_Regrid_C.F90
+++ b/src/Infrastructure/Regrid/interface/ESMF_Regrid_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Regrid/src/ESMF_Regrid.F90
+++ b/src/Infrastructure/Regrid/src/ESMF_Regrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Regrid/src/ESMF_Regrid.F90
+++ b/src/Infrastructure/Regrid/src/ESMF_Regrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/doc/RHandle_crefdoc.ctex
+++ b/src/Infrastructure/Route/doc/RHandle_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/doc/RHandle_crefdoc.ctex
+++ b/src/Infrastructure/Route/doc/RHandle_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/doc/RHandle_desc.tex
+++ b/src/Infrastructure/Route/doc/RHandle_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/doc/RHandle_desc.tex
+++ b/src/Infrastructure/Route/doc/RHandle_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/doc/RHandle_refdoc.ctex
+++ b/src/Infrastructure/Route/doc/RHandle_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/doc/RHandle_refdoc.ctex
+++ b/src/Infrastructure/Route/doc/RHandle_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/examples/ESMF_RHandleBitForBitEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleBitForBitEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleBitForBitEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleBitForBitEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleDynamicMaskingEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleDynamicMaskingEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleDynamicMaskingEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleDynamicMaskingEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleFromFileEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleFromFileEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleFromFileEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleFromFileEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleFromRHandleEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleFromRHandleEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleFromRHandleEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleFromRHandleEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleReusabilityEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleReusabilityEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleReusabilityEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleReusabilityEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleVMEpochEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleVMEpochEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/examples/ESMF_RHandleVMEpochEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleVMEpochEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/include/ESMCI_RHandle.h
+++ b/src/Infrastructure/Route/include/ESMCI_RHandle.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/include/ESMCI_RHandle.h
+++ b/src/Infrastructure/Route/include/ESMCI_RHandle.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/include/ESMC_RHandle.h
+++ b/src/Infrastructure/Route/include/ESMC_RHandle.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/include/ESMC_RHandle.h
+++ b/src/Infrastructure/Route/include/ESMC_RHandle.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/interface/ESMCI_RHandle_F.C
+++ b/src/Infrastructure/Route/interface/ESMCI_RHandle_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/interface/ESMCI_RHandle_F.C
+++ b/src/Infrastructure/Route/interface/ESMCI_RHandle_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/interface/ESMC_RHandle.C
+++ b/src/Infrastructure/Route/interface/ESMC_RHandle.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/interface/ESMC_RHandle.C
+++ b/src/Infrastructure/Route/interface/ESMC_RHandle.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/interface/ESMF_RHandle.F90
+++ b/src/Infrastructure/Route/interface/ESMF_RHandle.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/interface/ESMF_RHandle.F90
+++ b/src/Infrastructure/Route/interface/ESMF_RHandle.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/src/ESMCI_RHandle.C
+++ b/src/Infrastructure/Route/src/ESMCI_RHandle.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/src/ESMCI_RHandle.C
+++ b/src/Infrastructure/Route/src/ESMCI_RHandle.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/tests/ESMC_RouteHandleUTest.c
+++ b/src/Infrastructure/Route/tests/ESMC_RouteHandleUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/tests/ESMC_RouteHandleUTest.c
+++ b/src/Infrastructure/Route/tests/ESMC_RouteHandleUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMC_ClockEx.C
+++ b/src/Infrastructure/TimeMgr/examples/ESMC_ClockEx.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/examples/ESMC_ClockEx.C
+++ b/src/Infrastructure/TimeMgr/examples/ESMC_ClockEx.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/examples/ESMF_AlarmEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_AlarmEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_AlarmEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_AlarmEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_CalendarEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_CalendarEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_CalendarEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_CalendarEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_ClockEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_ClockEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_ClockEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_ClockEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_TimeEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_TimeEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_TimeEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_TimeEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_TimeIntervalEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_TimeIntervalEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/examples/ESMF_TimeIntervalEx.F90
+++ b/src/Infrastructure/TimeMgr/examples/ESMF_TimeIntervalEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Alarm.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Alarm.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Alarm.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Alarm.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_BaseTime.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_BaseTime.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_BaseTime.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_BaseTime.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Calendar.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Calendar.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Calendar.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Calendar.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Clock.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Clock.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Clock.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Clock.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Time.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Time.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_Time.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_Time.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_TimeInterval.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_TimeInterval.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMCI_TimeInterval.h
+++ b/src/Infrastructure/TimeMgr/include/ESMCI_TimeInterval.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_Calendar.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_Calendar.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_Calendar.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_Calendar.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_Clock.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_Clock.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_Clock.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_Clock.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_Time.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_Time.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_Time.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_Time.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_TimeInterval.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_TimeInterval.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMC_TimeInterval.h
+++ b/src/Infrastructure/TimeMgr/include/ESMC_TimeInterval.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMF_TimeMgr.inc
+++ b/src/Infrastructure/TimeMgr/include/ESMF_TimeMgr.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/include/ESMF_TimeMgr.inc
+++ b/src/Infrastructure/TimeMgr/include/ESMF_TimeMgr.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Alarm_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Alarm_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Alarm_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Alarm_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_BaseTime_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_BaseTime_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_BaseTime_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_BaseTime_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Calendar_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Calendar_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Calendar_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Calendar_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Clock_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Clock_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Clock_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Clock_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_TimeInterval_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_TimeInterval_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_TimeInterval_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_TimeInterval_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Time_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Time_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Time_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Time_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_Calendar.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_Calendar.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_Calendar.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_Calendar.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_Clock.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_Clock.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_Clock.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_Clock.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_Time.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_Time.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_Time.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_Time.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_TimeInterval.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_TimeInterval.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMC_TimeInterval.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMC_TimeInterval.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Alarm.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Alarm.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Alarm.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Alarm.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_AlarmType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_AlarmType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_AlarmType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_AlarmType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Calendar.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Calendar.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Calendar.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Calendar.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Clock.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Clock.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Clock.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Clock.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_ClockType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_ClockType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_ClockType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_ClockType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Time.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Time.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_Time.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_Time.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_TimeInterval.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_TimeInterval.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_TimeInterval.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_TimeInterval.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_TimeIntervalType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_TimeIntervalType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_TimeIntervalType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_TimeIntervalType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_TimeType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_TimeType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/interface/ESMF_TimeType.F90
+++ b/src/Infrastructure/TimeMgr/interface/ESMF_TimeType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Alarm.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Alarm.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Alarm.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Alarm.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/src/ESMCI_BaseTime.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_BaseTime.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_BaseTime.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_BaseTime.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Calendar.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Calendar.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Calendar.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Calendar.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Clock.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Clock.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Clock.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Clock.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
@@ -1,7 +1,7 @@
 // $Id$"
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
@@ -1,7 +1,7 @@
 // $Id$"
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_TimeInterval.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_TimeInterval.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/src/ESMCI_TimeInterval.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_TimeInterval.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMC_CalendarUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_CalendarUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMC_CalendarUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_CalendarUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMC_ClockUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_ClockUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMC_ClockUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_ClockUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMC_TimeIntervalUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_TimeIntervalUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMC_TimeIntervalUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_TimeIntervalUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMC_TimeUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_TimeUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMC_TimeUTest.c
+++ b/src/Infrastructure/TimeMgr/tests/ESMC_TimeUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/TimeMgr/tests/ESMF_AlarmUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_AlarmUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_AlarmUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_AlarmUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_CalRangeUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_CalRangeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_CalRangeUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_CalRangeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_CalendarUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_CalendarUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_CalendarUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_CalendarUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_ClockUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_ClockUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_ClockUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_ClockUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_TimeIntervalUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_TimeIntervalUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_TimeIntervalUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_TimeIntervalUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_TimeUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_TimeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/TimeMgr/tests/ESMF_TimeUTest.F90
+++ b/src/Infrastructure/TimeMgr/tests/ESMF_TimeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/doc/Trace_desc.tex
+++ b/src/Infrastructure/Trace/doc/Trace_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/doc/Trace_desc.tex
+++ b/src/Infrastructure/Trace/doc/Trace_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/doc/Trace_refdoc.ctex
+++ b/src/Infrastructure/Trace/doc/Trace_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/doc/Trace_refdoc.ctex
+++ b/src/Infrastructure/Trace/doc/Trace_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/doc/Trace_rest.tex
+++ b/src/Infrastructure/Trace/doc/Trace_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/doc/Trace_rest.tex
+++ b/src/Infrastructure/Trace/doc/Trace_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/doc/Trace_usage.tex
+++ b/src/Infrastructure/Trace/doc/Trace_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/doc/Trace_usage.tex
+++ b/src/Infrastructure/Trace/doc/Trace_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/examples/ESMF_TraceEx.F90
+++ b/src/Infrastructure/Trace/examples/ESMF_TraceEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/examples/ESMF_TraceEx.F90
+++ b/src/Infrastructure/Trace/examples/ESMF_TraceEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/examples/ESMF_TraceUserEx.F90
+++ b/src/Infrastructure/Trace/examples/ESMF_TraceUserEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/examples/ESMF_TraceUserEx.F90
+++ b/src/Infrastructure/Trace/examples/ESMF_TraceUserEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/gen_trace_metadata.py
+++ b/src/Infrastructure/Trace/gen_trace_metadata.py
@@ -15,7 +15,7 @@ template_esmci_metadata_c = """
  * Standard trace metadata used by all ESMF traces.
  *
  * Earth System Modeling Framework
- * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/gen_trace_metadata.py
+++ b/src/Infrastructure/Trace/gen_trace_metadata.py
@@ -15,7 +15,7 @@ template_esmci_metadata_c = """
  * Standard trace metadata used by all ESMF traces.
  *
  * Earth System Modeling Framework
- * Copyright 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_RegionNode.h
+++ b/src/Infrastructure/Trace/include/ESMCI_RegionNode.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_RegionNode.h
+++ b/src/Infrastructure/Trace/include/ESMCI_RegionNode.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_RegionSummary.h
+++ b/src/Infrastructure/Trace/include/ESMCI_RegionSummary.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_RegionSummary.h
+++ b/src/Infrastructure/Trace/include/ESMCI_RegionSummary.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_Trace.h
+++ b/src/Infrastructure/Trace/include/ESMCI_Trace.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_Trace.h
+++ b/src/Infrastructure/Trace/include/ESMCI_Trace.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_TraceMacros.h
+++ b/src/Infrastructure/Trace/include/ESMCI_TraceMacros.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_TraceMacros.h
+++ b/src/Infrastructure/Trace/include/ESMCI_TraceMacros.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_TraceRegion.h
+++ b/src/Infrastructure/Trace/include/ESMCI_TraceRegion.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_TraceRegion.h
+++ b/src/Infrastructure/Trace/include/ESMCI_TraceRegion.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_TraceUtil.h
+++ b/src/Infrastructure/Trace/include/ESMCI_TraceUtil.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMCI_TraceUtil.h
+++ b/src/Infrastructure/Trace/include/ESMCI_TraceUtil.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/include/ESMF_TraceRegion.inc
+++ b/src/Infrastructure/Trace/include/ESMF_TraceRegion.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/include/ESMF_TraceRegion.inc
+++ b/src/Infrastructure/Trace/include/ESMF_TraceRegion.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/interface/ESMF_Trace.F90
+++ b/src/Infrastructure/Trace/interface/ESMF_Trace.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/interface/ESMF_Trace.F90
+++ b/src/Infrastructure/Trace/interface/ESMF_Trace.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/src/ESMCI_Trace.C
+++ b/src/Infrastructure/Trace/src/ESMCI_Trace.C
@@ -3,7 +3,7 @@
  * Writes trace events to the file system.
  *
  * Earth System Modeling Framework
- * Copyright 2002-2022, University Corporation for Atmospheric Research,
+ * Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  * Laboratory, University of Michigan, National Centers for Environmental
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/src/ESMCI_Trace.C
+++ b/src/Infrastructure/Trace/src/ESMCI_Trace.C
@@ -3,7 +3,7 @@
  * Writes trace events to the file system.
  *
  * Earth System Modeling Framework
- * Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+ * Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  * Laboratory, University of Michigan, National Centers for Environmental
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/src/ESMCI_TraceClock.C
+++ b/src/Infrastructure/Trace/src/ESMCI_TraceClock.C
@@ -3,7 +3,7 @@
  * Functions to get the timestamps from the system for trace events
  *
  * Earth System Modeling Framework
- * Copyright 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/src/ESMCI_TraceClock.C
+++ b/src/Infrastructure/Trace/src/ESMCI_TraceClock.C
@@ -3,7 +3,7 @@
  * Functions to get the timestamps from the system for trace events
  *
  * Earth System Modeling Framework
- * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/src/ESMCI_TraceMetadata.C
+++ b/src/Infrastructure/Trace/src/ESMCI_TraceMetadata.C
@@ -5,7 +5,7 @@
  * Standard trace metadata used by all ESMF traces.
  *
  * Earth System Modeling Framework
- * Copyright 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/src/ESMCI_TraceMetadata.C
+++ b/src/Infrastructure/Trace/src/ESMCI_TraceMetadata.C
@@ -5,7 +5,7 @@
  * Standard trace metadata used by all ESMF traces.
  *
  * Earth System Modeling Framework
- * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/src/ESMCI_TraceWrap.C
+++ b/src/Infrastructure/Trace/src/ESMCI_TraceWrap.C
@@ -1,7 +1,7 @@
 // $Id$
 /*
  * Earth System Modeling Framework
- * Copyright 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/src/ESMCI_TraceWrap.C
+++ b/src/Infrastructure/Trace/src/ESMCI_TraceWrap.C
@@ -1,7 +1,7 @@
 // $Id$
 /*
  * Earth System Modeling Framework
- * Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+ * Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
  * Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
  * Laboratory, University of Michigan, National Centers for Environmental 
  * Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/tests/ESMCI_TraceRegionUTest.C
+++ b/src/Infrastructure/Trace/tests/ESMCI_TraceRegionUTest.C
@@ -3,7 +3,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/tests/ESMCI_TraceRegionUTest.C
+++ b/src/Infrastructure/Trace/tests/ESMCI_TraceRegionUTest.C
@@ -3,7 +3,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Trace/tests/ESMF_ProfileUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_ProfileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_ProfileUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_ProfileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_SimpleComp.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_SimpleComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_SimpleComp.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_SimpleComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_SimpleCompB.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_SimpleCompB.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_SimpleCompB.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_SimpleCompB.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoSyncUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoSyncUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoSyncUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoSyncUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceClkMonoUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceIOUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceIOUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceIOUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceMPIUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceMPIUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceMPIUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceMPIUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Trace/tests/ESMF_TraceUTest.F90
+++ b/src/Infrastructure/Trace/tests/ESMF_TraceUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/doc/IOUtil_refdoc.ctex
+++ b/src/Infrastructure/Util/doc/IOUtil_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/doc/IOUtil_refdoc.ctex
+++ b/src/Infrastructure/Util/doc/IOUtil_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/include/ESMCI_Arg.h
+++ b/src/Infrastructure/Util/include/ESMCI_Arg.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/include/ESMCI_Arg.h
+++ b/src/Infrastructure/Util/include/ESMCI_Arg.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/include/ESMCI_CoordSys.h
+++ b/src/Infrastructure/Util/include/ESMCI_CoordSys.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_CoordSys.h
+++ b/src/Infrastructure/Util/include/ESMCI_CoordSys.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_F90Interface.h
+++ b/src/Infrastructure/Util/include/ESMCI_F90Interface.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_F90Interface.h
+++ b/src/Infrastructure/Util/include/ESMCI_F90Interface.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_Fraction.h
+++ b/src/Infrastructure/Util/include/ESMCI_Fraction.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_Fraction.h
+++ b/src/Infrastructure/Util/include/ESMCI_Fraction.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_Macros.h
+++ b/src/Infrastructure/Util/include/ESMCI_Macros.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_Macros.h
+++ b/src/Infrastructure/Util/include/ESMCI_Macros.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_Util.h
+++ b/src/Infrastructure/Util/include/ESMCI_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMCI_Util.h
+++ b/src/Infrastructure/Util/include/ESMCI_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_Arg.h
+++ b/src/Infrastructure/Util/include/ESMC_Arg.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/include/ESMC_Arg.h
+++ b/src/Infrastructure/Util/include/ESMC_Arg.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/include/ESMC_CoordSys.h
+++ b/src/Infrastructure/Util/include/ESMC_CoordSys.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_CoordSys.h
+++ b/src/Infrastructure/Util/include/ESMC_CoordSys.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_Interface.h
+++ b/src/Infrastructure/Util/include/ESMC_Interface.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/include/ESMC_Interface.h
+++ b/src/Infrastructure/Util/include/ESMC_Interface.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/include/ESMC_Macros.h
+++ b/src/Infrastructure/Util/include/ESMC_Macros.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_Macros.h
+++ b/src/Infrastructure/Util/include/ESMC_Macros.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_ReturnCodes.h
+++ b/src/Infrastructure/Util/include/ESMC_ReturnCodes.h
@@ -2,7 +2,7 @@
 $Id$
 
   Earth System Modeling Framework
-  Copyright 2002-2022, University Corporation for Atmospheric Research,
+  Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
   Massachusetts Institute of Technology, Geophysical Fluid Dynamics
   Laboratory, University of Michigan, National Centers for Environmental
   Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_ReturnCodes.h
+++ b/src/Infrastructure/Util/include/ESMC_ReturnCodes.h
@@ -2,7 +2,7 @@
 $Id$
 
   Earth System Modeling Framework
-  Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+  Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
   Massachusetts Institute of Technology, Geophysical Fluid Dynamics
   Laboratory, University of Michigan, National Centers for Environmental
   Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_Util.h
+++ b/src/Infrastructure/Util/include/ESMC_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMC_Util.h
+++ b/src/Infrastructure/Util/include/ESMC_Util.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF.h
+++ b/src/Infrastructure/Util/include/ESMF.h
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF.h
+++ b/src/Infrastructure/Util/include/ESMF.h
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_ErrReturnCodes.inc
+++ b/src/Infrastructure/Util/include/ESMF_ErrReturnCodes.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_ErrReturnCodes.inc
+++ b/src/Infrastructure/Util/include/ESMF_ErrReturnCodes.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_InitMacros.inc
+++ b/src/Infrastructure/Util/include/ESMF_InitMacros.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_InitMacros.inc
+++ b/src/Infrastructure/Util/include/ESMF_InitMacros.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_LogConstants.inc
+++ b/src/Infrastructure/Util/include/ESMF_LogConstants.inc
@@ -2,7 +2,7 @@
  $Id$
 
  Earth System Modeling Framework
- Copyright 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_LogConstants.inc
+++ b/src/Infrastructure/Util/include/ESMF_LogConstants.inc
@@ -2,7 +2,7 @@
  $Id$
 
  Earth System Modeling Framework
- Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_LogErr.inc
+++ b/src/Infrastructure/Util/include/ESMF_LogErr.inc
@@ -2,7 +2,7 @@
  $Id$
 
  Earth System Modeling Framework
- Copyright 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_LogErr.inc
+++ b/src/Infrastructure/Util/include/ESMF_LogErr.inc
@@ -2,7 +2,7 @@
  $Id$
 
  Earth System Modeling Framework
- Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_LogMacros.inc
+++ b/src/Infrastructure/Util/include/ESMF_LogMacros.inc
@@ -2,7 +2,7 @@
  $Id$
 
  Earth System Modeling Framework
- Copyright 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_LogMacros.inc
+++ b/src/Infrastructure/Util/include/ESMF_LogMacros.inc
@@ -2,7 +2,7 @@
  $Id$
 
  Earth System Modeling Framework
- Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+ Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
  Massachusetts Institute of Technology, Geophysical Fluid Dynamics
  Laboratory, University of Michigan, National Centers for Environmental
  Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_Macros.inc
+++ b/src/Infrastructure/Util/include/ESMF_Macros.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_Macros.inc
+++ b/src/Infrastructure/Util/include/ESMF_Macros.inc
@@ -2,7 +2,7 @@
 $Id$
 
 Earth System Modeling Framework
-Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 Laboratory, University of Michigan, National Centers for Environmental
 Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_TypeKindMacros.hcppF90
+++ b/src/Infrastructure/Util/include/ESMF_TypeKindMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_TypeKindMacros.hcppF90
+++ b/src/Infrastructure/Util/include/ESMF_TypeKindMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_TypeKindRankMacros.hcppF90
+++ b/src/Infrastructure/Util/include/ESMF_TypeKindRankMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/include/ESMF_TypeKindRankMacros.hcppF90
+++ b/src/Infrastructure/Util/include/ESMF_TypeKindRankMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/interface/ESMCI_F90Interface_F.C
+++ b/src/Infrastructure/Util/interface/ESMCI_F90Interface_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMCI_F90Interface_F.C
+++ b/src/Infrastructure/Util/interface/ESMCI_F90Interface_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMCI_Fraction_F.C
+++ b/src/Infrastructure/Util/interface/ESMCI_Fraction_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMCI_Fraction_F.C
+++ b/src/Infrastructure/Util/interface/ESMCI_Fraction_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMCI_Util_F.C
+++ b/src/Infrastructure/Util/interface/ESMCI_Util_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/interface/ESMCI_Util_F.C
+++ b/src/Infrastructure/Util/interface/ESMCI_Util_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/interface/ESMC_Interface.C
+++ b/src/Infrastructure/Util/interface/ESMC_Interface.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMC_Interface.C
+++ b/src/Infrastructure/Util/interface/ESMC_Interface.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMC_Util.C
+++ b/src/Infrastructure/Util/interface/ESMC_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMC_Util.C
+++ b/src/Infrastructure/Util/interface/ESMC_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMF_F90Interface.F90
+++ b/src/Infrastructure/Util/interface/ESMF_F90Interface.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMF_F90Interface.F90
+++ b/src/Infrastructure/Util/interface/ESMF_F90Interface.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMF_Fraction.F90
+++ b/src/Infrastructure/Util/interface/ESMF_Fraction.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/interface/ESMF_Fraction.F90
+++ b/src/Infrastructure/Util/interface/ESMF_Fraction.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/interface/ESMF_Util.F90
+++ b/src/Infrastructure/Util/interface/ESMF_Util.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/interface/ESMF_Util.F90
+++ b/src/Infrastructure/Util/interface/ESMF_Util.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/interface/ESMF_Util_C.F90
+++ b/src/Infrastructure/Util/interface/ESMF_Util_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/interface/ESMF_Util_C.F90
+++ b/src/Infrastructure/Util/interface/ESMF_Util_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/src/ESMCI_CoordSys.C
+++ b/src/Infrastructure/Util/src/ESMCI_CoordSys.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMCI_CoordSys.C
+++ b/src/Infrastructure/Util/src/ESMCI_CoordSys.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMCI_F90Interface.C
+++ b/src/Infrastructure/Util/src/ESMCI_F90Interface.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/src/ESMCI_F90Interface.C
+++ b/src/Infrastructure/Util/src/ESMCI_F90Interface.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/Util/src/ESMCI_Fraction.C
+++ b/src/Infrastructure/Util/src/ESMCI_Fraction.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMCI_Fraction.C
+++ b/src/Infrastructure/Util/src/ESMCI_Fraction.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMCI_Util.C
+++ b/src/Infrastructure/Util/src/ESMCI_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMCI_Util.C
+++ b/src/Infrastructure/Util/src/ESMCI_Util.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_AttPackType.F90
+++ b/src/Infrastructure/Util/src/ESMF_AttPackType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_AttPackType.F90
+++ b/src/Infrastructure/Util/src/ESMF_AttPackType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_IOUtil.F90
+++ b/src/Infrastructure/Util/src/ESMF_IOUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_IOUtil.F90
+++ b/src/Infrastructure/Util/src/ESMF_IOUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_InitMacros.F90
+++ b/src/Infrastructure/Util/src/ESMF_InitMacros.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_InitMacros.F90
+++ b/src/Infrastructure/Util/src/ESMF_InitMacros.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_LogErr.F90
+++ b/src/Infrastructure/Util/src/ESMF_LogErr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_LogErr.F90
+++ b/src/Infrastructure/Util/src/ESMF_LogErr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_StaggerLocType.F90
+++ b/src/Infrastructure/Util/src/ESMF_StaggerLocType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_StaggerLocType.F90
+++ b/src/Infrastructure/Util/src/ESMF_StaggerLocType.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_TypeKindGet.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_TypeKindGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_TypeKindGet.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_TypeKindGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_UtilCubedSphere.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilCubedSphere.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_UtilCubedSphere.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilCubedSphere.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_UtilSort.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_UtilString.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilString.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_UtilString.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilString.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,
@@ -2396,7 +2396,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         print *, ""
         print *, "Earth System Modeling Framework"
         print *, ""
-        print *, "Copyright (c) 2002-2022 University Corporation for Atmospheric Research,"
+        print *, "Copyright (c) 2002-2023 University Corporation for Atmospheric Research,"
         print *, "Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory,"
         print *, "University of Michigan, National Centers for Environmental Prediction,"
         print *, "Los Alamos National Laboratory, Argonne National Laboratory,"

--- a/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_FortranWordsizeUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_FortranWordsizeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_FortranWordsizeUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_FortranWordsizeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_InitMacrosTestTypes.F90
+++ b/src/Infrastructure/Util/tests/ESMF_InitMacrosTestTypes.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_InitMacrosTestTypes.F90
+++ b/src/Infrastructure/Util/tests/ESMF_InitMacrosTestTypes.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_InitMacrosUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_InitMacrosUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_InitMacrosUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_InitMacrosUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_TypeKindGetUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_TypeKindGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_TypeKindGetUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_TypeKindGetUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_UtilUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_UtilUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/Util/tests/ESMF_UtilUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_UtilUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/doc/VM_cdesc.tex
+++ b/src/Infrastructure/VM/doc/VM_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_cdesc.tex
+++ b/src/Infrastructure/VM/doc/VM_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_crefdoc.ctex
+++ b/src/Infrastructure/VM/doc/VM_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_crefdoc.ctex
+++ b/src/Infrastructure/VM/doc/VM_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_desc.tex
+++ b/src/Infrastructure/VM/doc/VM_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_desc.tex
+++ b/src/Infrastructure/VM/doc/VM_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_options.tex
+++ b/src/Infrastructure/VM/doc/VM_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_options.tex
+++ b/src/Infrastructure/VM/doc/VM_options.tex
@@ -1,7 +1,7 @@
 % $Id$
 
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_refdoc.ctex
+++ b/src/Infrastructure/VM/doc/VM_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/doc/VM_refdoc.ctex
+++ b/src/Infrastructure/VM/doc/VM_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$ 
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/examples/ESMF_VMAllFullReduceEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMAllFullReduceEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMAllFullReduceEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMAllFullReduceEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMComponentEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMComponentEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMComponentEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMComponentEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMDefaultBasicsEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMDefaultBasicsEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMDefaultBasicsEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMDefaultBasicsEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorF08Ex.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorF08Ex.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorF08Ex.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMGetMPICommunicatorF08Ex.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMHigherRankDataEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMHigherRankDataEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMHigherRankDataEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMHigherRankDataEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMNonBlockingEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMNonBlockingEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMNonBlockingEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMNonBlockingEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMScatterVMGatherEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMScatterVMGatherEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMScatterVMGatherEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMScatterVMGatherEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMSendVMRecvEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMSendVMRecvEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMSendVMRecvEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMSendVMRecvEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommMultiEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommMultiEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommMultiEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMUserMpiCommMultiEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMUserMpiEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMUserMpiEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/examples/ESMF_VMUserMpiEx.F90
+++ b/src/Infrastructure/VM/examples/ESMF_VMUserMpiEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/include/ESMCI_AccInfo.h
+++ b/src/Infrastructure/VM/include/ESMCI_AccInfo.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/include/ESMCI_AccInfo.h
+++ b/src/Infrastructure/VM/include/ESMCI_AccInfo.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/include/ESMCI_VM.h
+++ b/src/Infrastructure/VM/include/ESMCI_VM.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/include/ESMCI_VM.h
+++ b/src/Infrastructure/VM/include/ESMCI_VM.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/include/ESMCI_VMKernel.h
+++ b/src/Infrastructure/VM/include/ESMCI_VMKernel.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/include/ESMCI_VMKernel.h
+++ b/src/Infrastructure/VM/include/ESMCI_VMKernel.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/include/ESMC_VM.h
+++ b/src/Infrastructure/VM/include/ESMC_VM.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/include/ESMC_VM.h
+++ b/src/Infrastructure/VM/include/ESMC_VM.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/interface/ESMCI_VM_F.C
+++ b/src/Infrastructure/VM/interface/ESMCI_VM_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/interface/ESMCI_VM_F.C
+++ b/src/Infrastructure/VM/interface/ESMCI_VM_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/interface/ESMC_VM.C
+++ b/src/Infrastructure/VM/interface/ESMC_VM.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/interface/ESMC_VM.C
+++ b/src/Infrastructure/VM/interface/ESMC_VM.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/interface/ESMF_VM.F90
+++ b/src/Infrastructure/VM/interface/ESMF_VM.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/interface/ESMF_VM.F90
+++ b/src/Infrastructure/VM/interface/ESMF_VM.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/ESMCI_VM.C
+++ b/src/Infrastructure/VM/src/ESMCI_VM.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/src/ESMCI_VM.C
+++ b/src/Infrastructure/VM/src/ESMCI_VM.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/src/ESMCI_VMKernel.C
+++ b/src/Infrastructure/VM/src/ESMCI_VMKernel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/ESMCI_VMKernel.C
+++ b/src/Infrastructure/VM/src/ESMCI_VMKernel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_IntelMICInfo.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_IntelMICInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_IntelMICInfo.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_IntelMICInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_OpenACCInfo.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_OpenACCInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_OpenACCInfo.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_OpenACCInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_OpenCLInfo.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_OpenCLInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_OpenCLInfo.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_OpenCLInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_OpenMP4Info.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_OpenMP4Info.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/src/acc/ESMCI_OpenMP4Info.C
+++ b/src/Infrastructure/VM/src/acc/ESMCI_OpenMP4Info.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/VM/tests/ESMC_VMUTest.c
+++ b/src/Infrastructure/VM/tests/ESMC_VMUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMC_VMUTest.c
+++ b/src/Infrastructure/VM/tests/ESMC_VMUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAccUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAccUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAccUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAccUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllGatherUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllGatherUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllGatherVUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllGatherVUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllGatherVUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllGatherVUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllToAllUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllToAllUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllToAllUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllToAllUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllToAllVUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllToAllVUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMAllToAllVUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMAllToAllVUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMBarrierUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMBarrierUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMBarrierUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMBarrierUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMBroadcastUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMBroadcastUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMBroadcastUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMBroadcastUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMComponentUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMComponentUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMComponentUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMComponentUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMEpochLargeMsgUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMEpochLargeMsgUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMEpochLargeMsgUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMEpochLargeMsgUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMGatherUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMGatherUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMGatherUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMOpenMPUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMOpenMPUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMOpenMPUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMOpenMPUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMScatterUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMScatterUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMScatterUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMScatterUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendNbVMRecvNbUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendNbVMRecvNbUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendNbVMRecvNbUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendNbVMRecvNbUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendRecvNbUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendRecvNbUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendRecvNbUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendRecvNbUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendRecvUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendRecvUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendRecvUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendRecvUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendVMRecvUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendVMRecvUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMSendVMRecvUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendVMRecvUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMUserMpiInitUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMUserMpiInitUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/VM/tests/ESMF_VMUserMpiInitUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMUserMpiInitUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/examples/ESMF_XGridEx.F90
+++ b/src/Infrastructure/XGrid/examples/ESMF_XGridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/examples/ESMF_XGridEx.F90
+++ b/src/Infrastructure/XGrid/examples/ESMF_XGridEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/examples/ESMF_XGridSparseMatEx.F90
+++ b/src/Infrastructure/XGrid/examples/ESMF_XGridSparseMatEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/examples/ESMF_XGridSparseMatEx.F90
+++ b/src/Infrastructure/XGrid/examples/ESMF_XGridSparseMatEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/include/ESMCI_XGrid.h
+++ b/src/Infrastructure/XGrid/include/ESMCI_XGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/include/ESMCI_XGrid.h
+++ b/src/Infrastructure/XGrid/include/ESMCI_XGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/include/ESMC_XGrid.h
+++ b/src/Infrastructure/XGrid/include/ESMC_XGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/include/ESMC_XGrid.h
+++ b/src/Infrastructure/XGrid/include/ESMC_XGrid.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/interface/ESMCI_XGrid.C
+++ b/src/Infrastructure/XGrid/interface/ESMCI_XGrid.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/interface/ESMCI_XGrid.C
+++ b/src/Infrastructure/XGrid/interface/ESMCI_XGrid.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/interface/ESMCI_XGrid_F.C
+++ b/src/Infrastructure/XGrid/interface/ESMCI_XGrid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/interface/ESMCI_XGrid_F.C
+++ b/src/Infrastructure/XGrid/interface/ESMCI_XGrid_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/interface/ESMC_XGrid.C
+++ b/src/Infrastructure/XGrid/interface/ESMC_XGrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/interface/ESMC_XGrid.C
+++ b/src/Infrastructure/XGrid/interface/ESMC_XGrid.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/interface/ESMF_XGrid_C.F90
+++ b/src/Infrastructure/XGrid/interface/ESMF_XGrid_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/interface/ESMF_XGrid_C.F90
+++ b/src/Infrastructure/XGrid/interface/ESMF_XGrid_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/src/ESMF_XGrid.F90
+++ b/src/Infrastructure/XGrid/src/ESMF_XGrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/src/ESMF_XGrid.F90
+++ b/src/Infrastructure/XGrid/src/ESMF_XGrid.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/src/ESMF_XGridCreate.F90
+++ b/src/Infrastructure/XGrid/src/ESMF_XGridCreate.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/src/ESMF_XGridCreate.F90
+++ b/src/Infrastructure/XGrid/src/ESMF_XGridCreate.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/src/ESMF_XGridGet.F90
+++ b/src/Infrastructure/XGrid/src/ESMF_XGridGet.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/src/ESMF_XGridGet.F90
+++ b/src/Infrastructure/XGrid/src/ESMF_XGridGet.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/XGrid/tests/ESMC_XGridUTest.c
+++ b/src/Infrastructure/XGrid/tests/ESMC_XGridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/tests/ESMC_XGridUTest.c
+++ b/src/Infrastructure/XGrid/tests/ESMC_XGridUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/tests/ESMF_XGridMaskingUTest.F90
+++ b/src/Infrastructure/XGrid/tests/ESMF_XGridMaskingUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/tests/ESMF_XGridMaskingUTest.F90
+++ b/src/Infrastructure/XGrid/tests/ESMF_XGridMaskingUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/tests/ESMF_XGridUTest.F90
+++ b/src/Infrastructure/XGrid/tests/ESMF_XGridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGrid/tests/ESMF_XGridUTest.F90
+++ b/src/Infrastructure/XGrid/tests/ESMF_XGridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGridGeomBase/interface/ESMCI_XGridGeomBase_F.C
+++ b/src/Infrastructure/XGridGeomBase/interface/ESMCI_XGridGeomBase_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGridGeomBase/interface/ESMCI_XGridGeomBase_F.C
+++ b/src/Infrastructure/XGridGeomBase/interface/ESMCI_XGridGeomBase_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGridGeomBase/src/ESMF_XGridGeomBase.F90
+++ b/src/Infrastructure/XGridGeomBase/src/ESMF_XGridGeomBase.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/XGridGeomBase/src/ESMF_XGridGeomBase.F90
+++ b/src/Infrastructure/XGridGeomBase/src/ESMF_XGridGeomBase.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Infrastructure/stubs/pthread/ESMF_Pthread.h
+++ b/src/Infrastructure/stubs/pthread/ESMF_Pthread.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Infrastructure/stubs/pthread/ESMF_Pthread.h
+++ b/src/Infrastructure/stubs/pthread/ESMF_Pthread.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_crefdoc.ctex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_crefdoc.ctex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_creqmethodsintro.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_creqmethodsintro.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_creqmethodsintro.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_creqmethodsintro.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_desc.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_desc.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_design.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_design.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_design.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_design.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_refdoc.ctex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_refdoc.ctex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_reqmethods.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_reqmethods.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_reqmethods.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_reqmethods.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_reqmethodsintro.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_reqmethodsintro.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_reqmethodsintro.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_reqmethodsintro.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_rest.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_rest.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_usage.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AppDriver/doc/AppDriver_usage.tex
+++ b/src/Superstructure/AppDriver/doc/AppDriver_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_desc.tex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_desc.tex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_refdoc.ctex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_refdoc.ctex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_rest.tex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_rest.tex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_usage.tex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/doc/AttachMethods_usage.tex
+++ b/src/Superstructure/AttachMethods/doc/AttachMethods_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/examples/ESMF_AttachMethodsEx.F90
+++ b/src/Superstructure/AttachMethods/examples/ESMF_AttachMethodsEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttachMethods/examples/ESMF_AttachMethodsEx.F90
+++ b/src/Superstructure/AttachMethods/examples/ESMF_AttachMethodsEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttachMethods/src/ESMF_AttachMethods.F90
+++ b/src/Superstructure/AttachMethods/src/ESMF_AttachMethods.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttachMethods/src/ESMF_AttachMethods.F90
+++ b/src/Superstructure/AttachMethods/src/ESMF_AttachMethods.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/AttributeAPI/doc/AttributeAPI_refdoc.ctex
+++ b/src/Superstructure/AttributeAPI/doc/AttributeAPI_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/doc/AttributeAPI_refdoc.ctex
+++ b/src/Superstructure/AttributeAPI/doc/AttributeAPI_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/interface/ESMF_Attribute.F90
+++ b/src/Superstructure/AttributeAPI/interface/ESMF_Attribute.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/interface/ESMF_Attribute.F90
+++ b/src/Superstructure/AttributeAPI/interface/ESMF_Attribute.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackABundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackABundleUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackABundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackABundleUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackArrayUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackArrayUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackArrayUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackArrayUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackCplCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackCplCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackCplCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackCplCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackDistGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackDistGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackDistGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackDistGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFBundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFBundleUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFBundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFBundleUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFieldUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFieldUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFieldUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFieldUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackLocStreamUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackLocStreamUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackLocStreamUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackLocStreamUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackSciCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackSciCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackSciCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackSciCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackStateUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackStateUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackStateUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackStateUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackTestMacros.hcppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackTestMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackTestMacros.hcppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackTestMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeABundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeABundleUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeABundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeABundleUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeArrayUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeArrayUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeArrayUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeArrayUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeCplCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeCplCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeCplCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeCplCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeDistGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeDistGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeDistGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeDistGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFBundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFBundleUTest.cppF90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFBundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFBundleUTest.cppF90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFieldUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFieldUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFieldUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeFieldUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeGridUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeLocStreamUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeLocStreamUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeLocStreamUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeLocStreamUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeProfileUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeProfileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeProfileUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeProfileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeSciCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeSciCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeSciCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeSciCompUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeStateUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeStateUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeStateUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeStateUTest.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeTestMacros.hcppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeTestMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeTestMacros.hcppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeTestMacros.hcppF90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateComponentUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateComponentUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateComponentUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateComponentUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateContainerStressUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateContainerStressUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateContainerStressUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateContainerStressUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateMultiReconcileUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateMultiReconcileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateMultiReconcileUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateMultiReconcileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateReconcileUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateReconcileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateReconcileUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateReconcileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateRemoveOnlyUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateRemoveOnlyUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateRemoveOnlyUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateRemoveOnlyUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUpdateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUtilUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUtilUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUtilUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUtilUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/doc/CompTunnel_desc.tex
+++ b/src/Superstructure/Component/doc/CompTunnel_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CompTunnel_desc.tex
+++ b/src/Superstructure/Component/doc/CompTunnel_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CompTunnel_rest.tex
+++ b/src/Superstructure/Component/doc/CompTunnel_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CompTunnel_rest.tex
+++ b/src/Superstructure/Component/doc/CompTunnel_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CompTunnel_usage.tex
+++ b/src/Superstructure/Component/doc/CompTunnel_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CompTunnel_usage.tex
+++ b/src/Superstructure/Component/doc/CompTunnel_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_crefdoc.ctex
+++ b/src/Superstructure/Component/doc/Component_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_crefdoc.ctex
+++ b/src/Superstructure/Component/doc/Component_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_glos.tex
+++ b/src/Superstructure/Component/doc/Component_glos.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_glos.tex
+++ b/src/Superstructure/Component/doc/Component_glos.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_obj.tex
+++ b/src/Superstructure/Component/doc/Component_obj.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_obj.tex
+++ b/src/Superstructure/Component/doc/Component_obj.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_refdoc.ctex
+++ b/src/Superstructure/Component/doc/Component_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_refdoc.ctex
+++ b/src/Superstructure/Component/doc/Component_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_req.tex
+++ b/src/Superstructure/Component/doc/Component_req.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/Component_req.tex
+++ b/src/Superstructure/Component/doc/Component_req.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_cdesc.tex
+++ b/src/Superstructure/Component/doc/CplComp_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_cdesc.tex
+++ b/src/Superstructure/Component/doc/CplComp_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_desc.tex
+++ b/src/Superstructure/Component/doc/CplComp_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_desc.tex
+++ b/src/Superstructure/Component/doc/CplComp_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_rest.tex
+++ b/src/Superstructure/Component/doc/CplComp_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_rest.tex
+++ b/src/Superstructure/Component/doc/CplComp_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_usage.tex
+++ b/src/Superstructure/Component/doc/CplComp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/CplComp_usage.tex
+++ b/src/Superstructure/Component/doc/CplComp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_cdesc.tex
+++ b/src/Superstructure/Component/doc/GridComp_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_cdesc.tex
+++ b/src/Superstructure/Component/doc/GridComp_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_desc.tex
+++ b/src/Superstructure/Component/doc/GridComp_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_desc.tex
+++ b/src/Superstructure/Component/doc/GridComp_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_rest.tex
+++ b/src/Superstructure/Component/doc/GridComp_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_rest.tex
+++ b/src/Superstructure/Component/doc/GridComp_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_usage.tex
+++ b/src/Superstructure/Component/doc/GridComp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/GridComp_usage.tex
+++ b/src/Superstructure/Component/doc/GridComp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_cdesc.tex
+++ b/src/Superstructure/Component/doc/SciComp_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_cdesc.tex
+++ b/src/Superstructure/Component/doc/SciComp_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_desc.tex
+++ b/src/Superstructure/Component/doc/SciComp_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_desc.tex
+++ b/src/Superstructure/Component/doc/SciComp_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_rest.tex
+++ b/src/Superstructure/Component/doc/SciComp_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_rest.tex
+++ b/src/Superstructure/Component/doc/SciComp_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_usage.tex
+++ b/src/Superstructure/Component/doc/SciComp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/SciComp_usage.tex
+++ b/src/Superstructure/Component/doc/SciComp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/comp_usage.tex
+++ b/src/Superstructure/Component/doc/comp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/doc/comp_usage.tex
+++ b/src/Superstructure/Component/doc/comp_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/examples/ESMF_AppMainEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_AppMainEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_AppMainEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_AppMainEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_CompTunnelEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_CompTunnelEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, GEOEhysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_CompTunnelEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_CompTunnelEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, GEOEhysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_CplEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_CplEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_CplEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_CplEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_GCompEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_GCompEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_GCompEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_GCompEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_InternalStateEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_InternalStateEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_InternalStateEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_InternalStateEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_InternalStateModEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_InternalStateModEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_InternalStateModEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_InternalStateModEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_SCompEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_SCompEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/examples/ESMF_SCompEx.F90
+++ b/src/Superstructure/Component/examples/ESMF_SCompEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/include/ESMCI_Comp.h
+++ b/src/Superstructure/Component/include/ESMCI_Comp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMCI_Comp.h
+++ b/src/Superstructure/Component/include/ESMCI_Comp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMCI_CompTunnel.h
+++ b/src/Superstructure/Component/include/ESMCI_CompTunnel.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMCI_CompTunnel.h
+++ b/src/Superstructure/Component/include/ESMCI_CompTunnel.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMCI_FTable.h
+++ b/src/Superstructure/Component/include/ESMCI_FTable.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMCI_FTable.h
+++ b/src/Superstructure/Component/include/ESMCI_FTable.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMCI_MethodTable.h
+++ b/src/Superstructure/Component/include/ESMCI_MethodTable.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMCI_MethodTable.h
+++ b/src/Superstructure/Component/include/ESMCI_MethodTable.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMC_CplComp.h
+++ b/src/Superstructure/Component/include/ESMC_CplComp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMC_CplComp.h
+++ b/src/Superstructure/Component/include/ESMC_CplComp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMC_GridComp.h
+++ b/src/Superstructure/Component/include/ESMC_GridComp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMC_GridComp.h
+++ b/src/Superstructure/Component/include/ESMC_GridComp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMC_SciComp.h
+++ b/src/Superstructure/Component/include/ESMC_SciComp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/include/ESMC_SciComp.h
+++ b/src/Superstructure/Component/include/ESMC_SciComp.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/interface/ESMCI_Comp.C
+++ b/src/Superstructure/Component/interface/ESMCI_Comp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/interface/ESMCI_Comp.C
+++ b/src/Superstructure/Component/interface/ESMCI_Comp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/interface/ESMC_Comp.C
+++ b/src/Superstructure/Component/interface/ESMC_Comp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/interface/ESMC_Comp.C
+++ b/src/Superstructure/Component/interface/ESMC_Comp.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/interface/ESMF_Comp_C.F90
+++ b/src/Superstructure/Component/interface/ESMF_Comp_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/interface/ESMF_Comp_C.F90
+++ b/src/Superstructure/Component/interface/ESMF_Comp_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/src/ESMCI_CompTunnel.C
+++ b/src/Superstructure/Component/src/ESMCI_CompTunnel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/src/ESMCI_CompTunnel.C
+++ b/src/Superstructure/Component/src/ESMCI_CompTunnel.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/src/ESMCI_FTable.C
+++ b/src/Superstructure/Component/src/ESMCI_FTable.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMCI_FTable.C
+++ b/src/Superstructure/Component/src/ESMCI_FTable.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMCI_MethodTable.C
+++ b/src/Superstructure/Component/src/ESMCI_MethodTable.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMCI_MethodTable.C
+++ b/src/Superstructure/Component/src/ESMCI_MethodTable.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMF_Comp.F90
+++ b/src/Superstructure/Component/src/ESMF_Comp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/src/ESMF_Comp.F90
+++ b/src/Superstructure/Component/src/ESMF_Comp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/src/ESMF_CplComp.F90
+++ b/src/Superstructure/Component/src/ESMF_CplComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMF_CplComp.F90
+++ b/src/Superstructure/Component/src/ESMF_CplComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMF_GridComp.F90
+++ b/src/Superstructure/Component/src/ESMF_GridComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMF_GridComp.F90
+++ b/src/Superstructure/Component/src/ESMF_GridComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMF_InternalState.F90
+++ b/src/Superstructure/Component/src/ESMF_InternalState.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMF_InternalState.F90
+++ b/src/Superstructure/Component/src/ESMF_InternalState.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/src/ESMF_SciComp.F90
+++ b/src/Superstructure/Component/src/ESMF_SciComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/src/ESMF_SciComp.F90
+++ b/src/Superstructure/Component/src/ESMF_SciComp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/tests/ESMC_ComponentUTest.c
+++ b/src/Superstructure/Component/tests/ESMC_ComponentUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/tests/ESMC_ComponentUTest.c
+++ b/src/Superstructure/Component/tests/ESMC_ComponentUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Component/tests/ESMF_CompSetServUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_CompSetServUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_CompSetServUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_CompSetServUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_CompTunnelUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_CompTunnelUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_CompTunnelUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_CompTunnelUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_CplCompCreateUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_CplCompCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_CplCompCreateUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_CplCompCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_GridCompCreateUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_GridCompCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_GridCompCreateUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_GridCompCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_MyRegistrationInFortran.F90
+++ b/src/Superstructure/Component/tests/ESMF_MyRegistrationInFortran.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_MyRegistrationInFortran.F90
+++ b/src/Superstructure/Component/tests/ESMF_MyRegistrationInFortran.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_SciCompCreateUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_SciCompCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_SciCompCreateUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_SciCompCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_SetServCode.F90
+++ b/src/Superstructure/Component/tests/ESMF_SetServCode.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_SetServCode.F90
+++ b/src/Superstructure/Component/tests/ESMF_SetServCode.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_StdCompMethodsUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_StdCompMethodsUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Component/tests/ESMF_StdCompMethodsUTest.F90
+++ b/src/Superstructure/Component/tests/ESMF_StdCompMethodsUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/include/ESMC.h
+++ b/src/Superstructure/ESMFMod/include/ESMC.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/include/ESMC.h
+++ b/src/Superstructure/ESMFMod/include/ESMC.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/include/ESMCI.h
+++ b/src/Superstructure/ESMFMod/include/ESMCI.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/include/ESMCI.h
+++ b/src/Superstructure/ESMFMod/include/ESMCI.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/include/ESMCI_Init.h
+++ b/src/Superstructure/ESMFMod/include/ESMCI_Init.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/include/ESMCI_Init.h
+++ b/src/Superstructure/ESMFMod/include/ESMCI_Init.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/include/ESMC_Init.h
+++ b/src/Superstructure/ESMFMod/include/ESMC_Init.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/include/ESMC_Init.h
+++ b/src/Superstructure/ESMFMod/include/ESMC_Init.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMCI_Init.C
+++ b/src/Superstructure/ESMFMod/interface/ESMCI_Init.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMCI_Init.C
+++ b/src/Superstructure/ESMFMod/interface/ESMCI_Init.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMCI_Init_F.C
+++ b/src/Superstructure/ESMFMod/interface/ESMCI_Init_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMCI_Init_F.C
+++ b/src/Superstructure/ESMFMod/interface/ESMCI_Init_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMC_Init.C
+++ b/src/Superstructure/ESMFMod/interface/ESMC_Init.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMC_Init.C
+++ b/src/Superstructure/ESMFMod/interface/ESMC_Init.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMF_Init_C.F90
+++ b/src/Superstructure/ESMFMod/interface/ESMF_Init_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/interface/ESMF_Init_C.F90
+++ b/src/Superstructure/ESMFMod/interface/ESMF_Init_C.F90
@@ -1,7 +1,7 @@
 !  $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/src/ESMF.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/src/ESMF.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/src/ESMF_Init.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF_Init.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/src/ESMF_Init.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF_Init.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/src/ESMF_Overloads.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF_Overloads.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/src/ESMF_Overloads.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF_Overloads.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/ESMFMod/tests/ESMF_FrameworkUTest.F90
+++ b/src/Superstructure/ESMFMod/tests/ESMF_FrameworkUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/ESMFMod/tests/ESMF_FrameworkUTest.F90
+++ b/src/Superstructure/ESMFMod/tests/ESMF_FrameworkUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/interface/ESMFIO.F90
+++ b/src/Superstructure/IOAPI/interface/ESMFIO.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/interface/ESMFIO.F90
+++ b/src/Superstructure/IOAPI/interface/ESMFIO.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/interface/ESMF_IO.F90
+++ b/src/Superstructure/IOAPI/interface/ESMF_IO.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/interface/ESMF_IO.F90
+++ b/src/Superstructure/IOAPI/interface/ESMF_IO.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/tests/ESMF_IOCompUTest.F90
+++ b/src/Superstructure/IOAPI/tests/ESMF_IOCompUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/tests/ESMF_IOCompUTest.F90
+++ b/src/Superstructure/IOAPI/tests/ESMF_IOCompUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/tests/ESMF_IOGridCompUTest.F90
+++ b/src/Superstructure/IOAPI/tests/ESMF_IOGridCompUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/IOAPI/tests/ESMF_IOGridCompUTest.F90
+++ b/src/Superstructure/IOAPI/tests/ESMF_IOGridCompUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/interface/ESMF_InfoCache.F90
+++ b/src/Superstructure/InfoAPI/interface/ESMF_InfoCache.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/interface/ESMF_InfoCache.F90
+++ b/src/Superstructure/InfoAPI/interface/ESMF_InfoCache.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/interface/ESMF_InfoDescribe.F90
+++ b/src/Superstructure/InfoAPI/interface/ESMF_InfoDescribe.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/interface/ESMF_InfoDescribe.F90
+++ b/src/Superstructure/InfoAPI/interface/ESMF_InfoDescribe.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/interface/ESMF_InfoSync.F90
+++ b/src/Superstructure/InfoAPI/interface/ESMF_InfoSync.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/interface/ESMF_InfoSync.F90
+++ b/src/Superstructure/InfoAPI/interface/ESMF_InfoSync.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/src/ESMC_InfoCacheCDef.C
+++ b/src/Superstructure/InfoAPI/src/ESMC_InfoCacheCDef.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/src/ESMC_InfoCacheCDef.C
+++ b/src/Superstructure/InfoAPI/src/ESMC_InfoCacheCDef.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/src/ESMC_InfoDescribeCDef.C
+++ b/src/Superstructure/InfoAPI/src/ESMC_InfoDescribeCDef.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/src/ESMC_InfoDescribeCDef.C
+++ b/src/Superstructure/InfoAPI/src/ESMC_InfoDescribeCDef.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoCacheUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoCacheUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoCacheUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoCacheUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoDescribeUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoDescribeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoDescribeUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoDescribeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoGetInterfaceArrayUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoGetInterfaceArrayUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoGetInterfaceArrayUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoGetInterfaceArrayUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoSyncUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoSyncUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/InfoAPI/tests/ESMF_InfoSyncUTest.F90
+++ b/src/Superstructure/InfoAPI/tests/ESMF_InfoSyncUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Mapper/interface/ESMCI_Mapper_F.C
+++ b/src/Superstructure/Mapper/interface/ESMCI_Mapper_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Mapper/interface/ESMCI_Mapper_F.C
+++ b/src/Superstructure/Mapper/interface/ESMCI_Mapper_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Mapper/interface/ESMC_Mapper.C
+++ b/src/Superstructure/Mapper/interface/ESMC_Mapper.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Mapper/interface/ESMC_Mapper.C
+++ b/src/Superstructure/Mapper/interface/ESMC_Mapper.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/Mapper/interface/ESMF_Mapper.F90
+++ b/src/Superstructure/Mapper/interface/ESMF_Mapper.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Mapper/interface/ESMF_Mapper.F90
+++ b/src/Superstructure/Mapper/interface/ESMF_Mapper.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Mapper/interface/ESMF_MapperUtil.F90
+++ b/src/Superstructure/Mapper/interface/ESMF_MapperUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Mapper/interface/ESMF_MapperUtil.F90
+++ b/src/Superstructure/Mapper/interface/ESMF_MapperUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Mapper/src/ESMF_MapperRunSeqUtil.F90
+++ b/src/Superstructure/Mapper/src/ESMF_MapperRunSeqUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/Mapper/src/ESMF_MapperRunSeqUtil.F90
+++ b/src/Superstructure/Mapper/src/ESMF_MapperRunSeqUtil.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/NamedAlias/src/ESMF_NamedAlias.F90
+++ b/src/Superstructure/NamedAlias/src/ESMF_NamedAlias.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/NamedAlias/src/ESMF_NamedAlias.F90
+++ b/src/Superstructure/NamedAlias/src/ESMF_NamedAlias.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/NamedAlias/tests/ESMF_NamedAliasUTest.F90
+++ b/src/Superstructure/NamedAlias/tests/ESMF_NamedAliasUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/NamedAlias/tests/ESMF_NamedAliasUTest.F90
+++ b/src/Superstructure/NamedAlias/tests/ESMF_NamedAliasUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_FileRegrid.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_FileRegrid.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_FileRegrid.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_FileRegrid.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_FileRegridCheck.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_FileRegridCheck.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_FileRegridCheck.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_FileRegridCheck.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGen.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGen.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGen.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGen.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGenCheck.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGenCheck.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGenCheck.F90
+++ b/src/Superstructure/PreESMFMod/src/ESMF_RegridWeightGenCheck.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/tests/ESMF_FileRegridUTest.F90
+++ b/src/Superstructure/PreESMFMod/tests/ESMF_FileRegridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/tests/ESMF_FileRegridUTest.F90
+++ b/src/Superstructure/PreESMFMod/tests/ESMF_FileRegridUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/tests/ESMF_RegridWeightGenUTest.F90
+++ b/src/Superstructure/PreESMFMod/tests/ESMF_RegridWeightGenUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/PreESMFMod/tests/ESMF_RegridWeightGenUTest.F90
+++ b/src/Superstructure/PreESMFMod/tests/ESMF_RegridWeightGenUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/doc/State_cdesc.tex
+++ b/src/Superstructure/State/doc/State_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_cdesc.tex
+++ b/src/Superstructure/State/doc/State_cdesc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_crefdoc.ctex
+++ b/src/Superstructure/State/doc/State_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_crefdoc.ctex
+++ b/src/Superstructure/State/doc/State_crefdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_crest.tex
+++ b/src/Superstructure/State/doc/State_crest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_crest.tex
+++ b/src/Superstructure/State/doc/State_crest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_desc.tex
+++ b/src/Superstructure/State/doc/State_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_desc.tex
+++ b/src/Superstructure/State/doc/State_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_design.tex
+++ b/src/Superstructure/State/doc/State_design.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_design.tex
+++ b/src/Superstructure/State/doc/State_design.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_implnotes.tex
+++ b/src/Superstructure/State/doc/State_implnotes.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_implnotes.tex
+++ b/src/Superstructure/State/doc/State_implnotes.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_refdoc.ctex
+++ b/src/Superstructure/State/doc/State_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_refdoc.ctex
+++ b/src/Superstructure/State/doc/State_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_rest.tex
+++ b/src/Superstructure/State/doc/State_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_rest.tex
+++ b/src/Superstructure/State/doc/State_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_usage.tex
+++ b/src/Superstructure/State/doc/State_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/doc/State_usage.tex
+++ b/src/Superstructure/State/doc/State_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/examples/ESMF_StateEx.F90
+++ b/src/Superstructure/State/examples/ESMF_StateEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/examples/ESMF_StateEx.F90
+++ b/src/Superstructure/State/examples/ESMF_StateEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/examples/ESMF_StateReadWriteEx.F90
+++ b/src/Superstructure/State/examples/ESMF_StateReadWriteEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/examples/ESMF_StateReadWriteEx.F90
+++ b/src/Superstructure/State/examples/ESMF_StateReadWriteEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/include/ESMCI_State.h
+++ b/src/Superstructure/State/include/ESMCI_State.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/include/ESMCI_State.h
+++ b/src/Superstructure/State/include/ESMCI_State.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/include/ESMCI_StateItem.h
+++ b/src/Superstructure/State/include/ESMCI_StateItem.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/include/ESMCI_StateItem.h
+++ b/src/Superstructure/State/include/ESMCI_StateItem.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/include/ESMC_State.h
+++ b/src/Superstructure/State/include/ESMC_State.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/include/ESMC_State.h
+++ b/src/Superstructure/State/include/ESMC_State.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/interface/ESMCI_State.C
+++ b/src/Superstructure/State/interface/ESMCI_State.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/interface/ESMCI_State.C
+++ b/src/Superstructure/State/interface/ESMCI_State.C
@@ -1,7 +1,7 @@
 //$1.10 2007/04/26 16:13:59 rosalind Exp $
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/interface/ESMCI_State_F.C
+++ b/src/Superstructure/State/interface/ESMCI_State_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/interface/ESMCI_State_F.C
+++ b/src/Superstructure/State/interface/ESMCI_State_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/interface/ESMC_State.C
+++ b/src/Superstructure/State/interface/ESMC_State.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/interface/ESMC_State.C
+++ b/src/Superstructure/State/interface/ESMC_State.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/interface/ESMF_State_C.F90
+++ b/src/Superstructure/State/interface/ESMF_State_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/interface/ESMF_State_C.F90
+++ b/src/Superstructure/State/interface/ESMF_State_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_State.F90
+++ b/src/Superstructure/State/src/ESMF_State.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_State.F90
+++ b/src/Superstructure/State/src/ESMF_State.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/src/ESMF_StateContainer.F90
+++ b/src/Superstructure/State/src/ESMF_StateContainer.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateContainer.F90
+++ b/src/Superstructure/State/src/ESMF_StateContainer.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateGet.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateGet.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateGet.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateInternals.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateInternals.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/src/ESMF_StateInternals.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateInternals.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/src/ESMF_StateItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateItem.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateItem.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateRemRep.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateRemRep.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/src/ESMF_StateRemRep.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateRemRep.cppF90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/src/ESMF_StateSet.F90
+++ b/src/Superstructure/State/src/ESMF_StateSet.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateSet.F90
+++ b/src/Superstructure/State/src/ESMF_StateSet.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateTypes.F90
+++ b/src/Superstructure/State/src/ESMF_StateTypes.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateTypes.F90
+++ b/src/Superstructure/State/src/ESMF_StateTypes.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateVa.F90
+++ b/src/Superstructure/State/src/ESMF_StateVa.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateVa.F90
+++ b/src/Superstructure/State/src/ESMF_StateVa.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateWr.F90
+++ b/src/Superstructure/State/src/ESMF_StateWr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/src/ESMF_StateWr.F90
+++ b/src/Superstructure/State/src/ESMF_StateWr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/tests/ESMC_StateUTest.c
+++ b/src/Superstructure/State/tests/ESMC_StateUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/tests/ESMC_StateUTest.c
+++ b/src/Superstructure/State/tests/ESMC_StateUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/State/tests/ESMF_StateCreateUTest.F90
+++ b/src/Superstructure/State/tests/ESMF_StateCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/tests/ESMF_StateCreateUTest.F90
+++ b/src/Superstructure/State/tests/ESMF_StateCreateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/tests/ESMF_StateReadWriteUTest.F90
+++ b/src/Superstructure/State/tests/ESMF_StateReadWriteUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/tests/ESMF_StateReadWriteUTest.F90
+++ b/src/Superstructure/State/tests/ESMF_StateReadWriteUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/tests/ESMF_StateUTest.F90
+++ b/src/Superstructure/State/tests/ESMF_StateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/State/tests/ESMF_StateUTest.F90
+++ b/src/Superstructure/State/tests/ESMF_StateUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/examples/ESMF_StateReconcileEx.F90
+++ b/src/Superstructure/StateReconcile/examples/ESMF_StateReconcileEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/examples/ESMF_StateReconcileEx.F90
+++ b/src/Superstructure/StateReconcile/examples/ESMF_StateReconcileEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/src/ESMF_StateReconcile.F90
+++ b/src/Superstructure/StateReconcile/src/ESMF_StateReconcile.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/src/ESMF_StateReconcile.F90
+++ b/src/Superstructure/StateReconcile/src/ESMF_StateReconcile.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileProxyUTest.F90
+++ b/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileProxyUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileProxyUTest.F90
+++ b/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileProxyUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileUTest.F90
+++ b/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileUTest.F90
+++ b/src/Superstructure/StateReconcile/tests/ESMF_StateReconcileUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/TraceAPI/interface/ESMF_TraceAPI.F90
+++ b/src/Superstructure/TraceAPI/interface/ESMF_TraceAPI.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/TraceAPI/interface/ESMF_TraceAPI.F90
+++ b/src/Superstructure/TraceAPI/interface/ESMF_TraceAPI.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/doc/WebServices_desc.tex
+++ b/src/Superstructure/WebServices/doc/WebServices_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/doc/WebServices_desc.tex
+++ b/src/Superstructure/WebServices/doc/WebServices_desc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/doc/WebServices_refdoc.ctex
+++ b/src/Superstructure/WebServices/doc/WebServices_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/doc/WebServices_refdoc.ctex
+++ b/src/Superstructure/WebServices/doc/WebServices_refdoc.ctex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/doc/WebServices_rest.tex
+++ b/src/Superstructure/WebServices/doc/WebServices_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/doc/WebServices_rest.tex
+++ b/src/Superstructure/WebServices/doc/WebServices_rest.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/doc/WebServices_usage.tex
+++ b/src/Superstructure/WebServices/doc/WebServices_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/doc/WebServices_usage.tex
+++ b/src/Superstructure/WebServices/doc/WebServices_usage.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/Superstructure/WebServices/examples/ESMF_WebServicesEx.F90
+++ b/src/Superstructure/WebServices/examples/ESMF_WebServicesEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/examples/ESMF_WebServicesEx.F90
+++ b/src/Superstructure/WebServices/examples/ESMF_WebServicesEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServ.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServ.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServ.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServ.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServClientInfo.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServClientInfo.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServClientInfo.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServClientInfo.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServClientSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServClientSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServClientSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServClientSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrInfo.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrInfo.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrInfo.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrInfo.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrMgr.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrMgr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrMgr.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServCompSvrMgr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServComponentSvr.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServComponentSvr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServComponentSvr.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServComponentSvr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServDataContent.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServDataContent.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServDataContent.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServDataContent.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServDataDesc.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServDataDesc.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServDataDesc.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServDataDesc.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServDataMgr.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServDataMgr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServDataMgr.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServDataMgr.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServForkClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServForkClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServForkClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServForkClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServGRAMClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServGRAMClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServGRAMClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServGRAMClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServLowLevelSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServLowLevelSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServLowLevelSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServLowLevelSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmf.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmf.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmf.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmf.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfServer.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfServer.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfServer.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServNetEsmfServer.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrl.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrl.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrl.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrl.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrlClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrlClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrlClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServProcCtrlClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServRegistrarClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServRegistrarClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServRegistrarClient.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServRegistrarClient.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureClientSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureClientSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureClientSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureClientSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureServerSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureServerSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureServerSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureServerSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureUtils.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureUtils.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSecureUtils.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSecureUtils.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServServerSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServServerSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServServerSocket.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServServerSocket.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSocketUtils.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSocketUtils.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/include/ESMCI_WebServSocketUtils.h
+++ b/src/Superstructure/WebServices/include/ESMCI_WebServSocketUtils.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServClientInfo.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServClientInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServClientInfo.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServClientInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServClientSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServClientSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServClientSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServClientSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrInfo.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrInfo.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrInfo.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrMgr.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrMgr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrMgr.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServCompSvrMgr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServComponentSvr.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServComponentSvr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServComponentSvr.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServComponentSvr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServDataContent.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServDataContent.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServDataContent.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServDataContent.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServDataDesc.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServDataDesc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServDataDesc.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServDataDesc.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServDataMgr.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServDataMgr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServDataMgr.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServDataMgr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServForkClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServForkClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServForkClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServForkClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServGRAMClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServGRAMClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServGRAMClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServGRAMClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServLowLevelSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServLowLevelSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServLowLevelSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServLowLevelSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfServer.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfServer.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfServer.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServNetEsmfServer.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrl.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrl.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrl.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrl.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrlClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrlClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrlClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServProcCtrlClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServRegistrarClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServRegistrarClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServRegistrarClient.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServRegistrarClient.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureClientSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureClientSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureClientSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureClientSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureServerSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureServerSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureServerSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureServerSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureUtils.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureUtils.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSecureUtils.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSecureUtils.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServServerSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServServerSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServServerSocket.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServServerSocket.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSocketUtils.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSocketUtils.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServSocketUtils.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServSocketUtils.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServ_F.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServ_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMCI_WebServ_F.C
+++ b/src/Superstructure/WebServices/src/ESMCI_WebServ_F.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMF_WebServ.F90
+++ b/src/Superstructure/WebServices/src/ESMF_WebServ.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMF_WebServ.F90
+++ b/src/Superstructure/WebServices/src/ESMF_WebServ.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMF_WebServComponent_C.F90
+++ b/src/Superstructure/WebServices/src/ESMF_WebServComponent_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/Superstructure/WebServices/src/ESMF_WebServComponent_C.F90
+++ b/src/Superstructure/WebServices/src/ESMF_WebServComponent_C.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/doc/NUOPC_title.tex
+++ b/src/addon/NUOPC/doc/NUOPC_title.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/doc/NUOPC_title.tex
+++ b/src/addon/NUOPC/doc/NUOPC_title.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/examples/ESMF_NUOPCAtmModelEx.F90
+++ b/src/addon/NUOPC/examples/ESMF_NUOPCAtmModelEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/examples/ESMF_NUOPCAtmModelEx.F90
+++ b/src/addon/NUOPC/examples/ESMF_NUOPCAtmModelEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/examples/ESMF_NUOPCBasicModelEx.F90
+++ b/src/addon/NUOPC/examples/ESMF_NUOPCBasicModelEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/examples/ESMF_NUOPCBasicModelEx.F90
+++ b/src/addon/NUOPC/examples/ESMF_NUOPCBasicModelEx.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/src/NUOPC.F90
+++ b/src/addon/NUOPC/src/NUOPC.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC.F90
+++ b/src/addon/NUOPC/src/NUOPC.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Auxiliary.F90
+++ b/src/addon/NUOPC/src/NUOPC_Auxiliary.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Auxiliary.F90
+++ b/src/addon/NUOPC/src/NUOPC_Auxiliary.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Base.F90
+++ b/src/addon/NUOPC/src/NUOPC_Base.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Base.F90
+++ b/src/addon/NUOPC/src/NUOPC_Base.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Comp.F90
+++ b/src/addon/NUOPC/src/NUOPC_Comp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Comp.F90
+++ b/src/addon/NUOPC/src/NUOPC_Comp.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Base.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Base.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Base.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Base.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Connector.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Connector.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Driver.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Driver.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Driver.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Driver.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Model.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Model.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Compliance_Model.F90
+++ b/src/addon/NUOPC/src/NUOPC_Compliance_Model.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Driver.F90
+++ b/src/addon/NUOPC/src/NUOPC_Driver.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/src/NUOPC_Driver.F90
+++ b/src/addon/NUOPC/src/NUOPC_Driver.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/src/NUOPC_FieldDictionaryApi.F90
+++ b/src/addon/NUOPC/src/NUOPC_FieldDictionaryApi.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_FieldDictionaryApi.F90
+++ b/src/addon/NUOPC/src/NUOPC_FieldDictionaryApi.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_FieldDictionaryDef.F90
+++ b/src/addon/NUOPC/src/NUOPC_FieldDictionaryDef.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_FieldDictionaryDef.F90
+++ b/src/addon/NUOPC/src/NUOPC_FieldDictionaryDef.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_FreeFormatDef.F90
+++ b/src/addon/NUOPC/src/NUOPC_FreeFormatDef.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_FreeFormatDef.F90
+++ b/src/addon/NUOPC/src/NUOPC_FreeFormatDef.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Mediator.F90
+++ b/src/addon/NUOPC/src/NUOPC_Mediator.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Mediator.F90
+++ b/src/addon/NUOPC/src/NUOPC_Mediator.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Model.F90
+++ b/src/addon/NUOPC/src/NUOPC_Model.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_Model.F90
+++ b/src/addon/NUOPC/src/NUOPC_Model.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_ModelBase.F90
+++ b/src/addon/NUOPC/src/NUOPC_ModelBase.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_ModelBase.F90
+++ b/src/addon/NUOPC/src/NUOPC_ModelBase.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_RunSequenceDef.F90
+++ b/src/addon/NUOPC/src/NUOPC_RunSequenceDef.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/src/NUOPC_RunSequenceDef.F90
+++ b/src/addon/NUOPC/src/NUOPC_RunSequenceDef.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/addon/NUOPC/tests/ESMF_NUOPC_UTest.F90
+++ b/src/addon/NUOPC/tests/ESMF_NUOPC_UTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/NUOPC/tests/ESMF_NUOPC_UTest.F90
+++ b/src/addon/NUOPC/tests/ESMF_NUOPC_UTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/esmpy/LICENSE
+++ b/src/addon/esmpy/LICENSE
@@ -1,6 +1,6 @@
 Earth System Modeling Framework Python Interface (ESMPy)
 
-Copyright (c) 2002-2022 University Corporation for Atmospheric Research,
+Copyright (c) 2002-2023 University Corporation for Atmospheric Research,
 Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory,
 University of Michigan, National Centers for Environmental Prediction,
 Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/addon/esmpy/README.md
+++ b/src/addon/esmpy/README.md
@@ -1,6 +1,6 @@
 # Earth System Modeling Framework Python Interface (ESMPy)
 
-> Copyright 2002-2022, University Corporation for Atmospheric Research, Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory, University of Michigan, National Centers for Environmental Prediction, Los Alamos National Laboratory, Argonne National Laboratory, NASA Goddard Space Flight Center. Licensed under the University of Illinois-NCSA License.
+> Copyright (c) 2002-2022, University Corporation for Atmospheric Research, Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory, University of Michigan, National Centers for Environmental Prediction, Los Alamos National Laboratory, Argonne National Laboratory, NASA Goddard Space Flight Center. Licensed under the University of Illinois-NCSA License.
 
  * [ESMPy Documentation](https://earthsystemmodeling.org/esmpy_doc/nightly/develop/html/)
    * [Installation](https://earthsystemmodeling.org/esmpy_doc/nightly/develop/html/install.html)

--- a/src/addon/esmpy/README.md
+++ b/src/addon/esmpy/README.md
@@ -1,6 +1,6 @@
 # Earth System Modeling Framework Python Interface (ESMPy)
 
-> Copyright (c) 2002-2022, University Corporation for Atmospheric Research, Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory, University of Michigan, National Centers for Environmental Prediction, Los Alamos National Laboratory, Argonne National Laboratory, NASA Goddard Space Flight Center. Licensed under the University of Illinois-NCSA License.
+> Copyright (c) 2002-2023, University Corporation for Atmospheric Research, Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory, University of Michigan, National Centers for Environmental Prediction, Los Alamos National Laboratory, Argonne National Laboratory, NASA Goddard Space Flight Center. Licensed under the University of Illinois-NCSA License.
 
  * [ESMPy Documentation](https://earthsystemmodeling.org/esmpy_doc/nightly/develop/html/)
    * [Installation](https://earthsystemmodeling.org/esmpy_doc/nightly/develop/html/install.html)

--- a/src/apps/ESMF_PrintInfo/ESMF_PrintInfo.F90
+++ b/src/apps/ESMF_PrintInfo/ESMF_PrintInfo.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/apps/ESMF_PrintInfo/ESMF_PrintInfo.F90
+++ b/src/apps/ESMF_PrintInfo/ESMF_PrintInfo.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 ! Laboratory, University of Michigan, National Centers for Environmental 
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/apps/ESMF_PrintInfoC/ESMF_PrintInfoC.c
+++ b/src/apps/ESMF_PrintInfoC/ESMF_PrintInfoC.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/apps/ESMF_PrintInfoC/ESMF_PrintInfoC.c
+++ b/src/apps/ESMF_PrintInfoC/ESMF_PrintInfoC.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/apps/ESMF_Regrid/ESMF_Regrid.F90
+++ b/src/apps/ESMF_Regrid/ESMF_Regrid.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/apps/ESMF_Regrid/ESMF_Regrid.F90
+++ b/src/apps/ESMF_Regrid/ESMF_Regrid.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
+++ b/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
+++ b/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
@@ -2,7 +2,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/apps/ESMF_Scrip2Unstruct/ESMF_Scrip2Unstruct.C
+++ b/src/apps/ESMF_Scrip2Unstruct/ESMF_Scrip2Unstruct.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/apps/ESMF_Scrip2Unstruct/ESMF_Scrip2Unstruct.C
+++ b/src/apps/ESMF_Scrip2Unstruct/ESMF_Scrip2Unstruct.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMC_api.tex
+++ b/src/doc/ESMC_api.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMC_api.tex
+++ b/src/doc/ESMC_api.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMC_infrautiloverview.tex
+++ b/src/doc/ESMC_infrautiloverview.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMC_infrautiloverview.tex
+++ b/src/doc/ESMC_infrautiloverview.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMF_api.tex
+++ b/src/doc/ESMF_api.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMF_api.tex
+++ b/src/doc/ESMF_api.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMF_apperr.tex
+++ b/src/doc/ESMF_apperr.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/doc/ESMF_apperr.tex
+++ b/src/doc/ESMF_apperr.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/doc/ESMF_appuml.tex
+++ b/src/doc/ESMF_appuml.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/doc/ESMF_appuml.tex
+++ b/src/doc/ESMF_appuml.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research,
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 % Laboratory, University of Michigan, National Centers for Environmental
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/doc/ESMF_infrautiloverview.tex
+++ b/src/doc/ESMF_infrautiloverview.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMF_infrautiloverview.tex
+++ b/src/doc/ESMF_infrautiloverview.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMF_superoverview.tex
+++ b/src/doc/ESMF_superoverview.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/ESMF_superoverview.tex
+++ b/src/doc/ESMF_superoverview.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/common_commands.tex
+++ b/src/doc/common_commands.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/common_commands.tex
+++ b/src/doc/common_commands.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/dev_guide/code_conv_gen.tex
+++ b/src/doc/dev_guide/code_conv_gen.tex
@@ -390,7 +390,7 @@ copyright header:
 
 \begin{verbatim}
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/doc/dev_guide/code_conv_gen.tex
+++ b/src/doc/dev_guide/code_conv_gen.tex
@@ -390,7 +390,7 @@ copyright header:
 
 \begin{verbatim}
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/doc/title_alldoc.tex
+++ b/src/doc/title_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/title_alldoc.tex
+++ b/src/doc/title_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/verstitle_alldoc.tex
+++ b/src/doc/verstitle_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/doc/verstitle_alldoc.tex
+++ b/src/doc/verstitle_alldoc.tex
@@ -1,7 +1,7 @@
 % $Id$
 %
 % Earth System Modeling Framework
-% Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+% Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 % Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 % Laboratory, University of Michigan, National Centers for Environmental 
 % Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/include/ESMCI_Test.h
+++ b/src/epilogue/include/ESMCI_Test.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/epilogue/include/ESMCI_Test.h
+++ b/src/epilogue/include/ESMCI_Test.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/epilogue/include/ESMC_Test.h
+++ b/src/epilogue/include/ESMC_Test.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/epilogue/include/ESMC_Test.h
+++ b/src/epilogue/include/ESMC_Test.h
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/epilogue/src/ESMCI_Test.C
+++ b/src/epilogue/src/ESMCI_Test.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,    
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,    
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/src/ESMCI_Test.C
+++ b/src/epilogue/src/ESMCI_Test.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,    
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,    
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/src/ESMC_Test.C
+++ b/src/epilogue/src/ESMC_Test.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,    
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,    
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/src/ESMC_Test.C
+++ b/src/epilogue/src/ESMC_Test.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,    
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,    
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/src/ESMF_Test.F90
+++ b/src/epilogue/src/ESMF_Test.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/epilogue/src/ESMF_Test.F90
+++ b/src/epilogue/src/ESMF_Test.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/epilogue/tests/ESMCI_TestUTest.C
+++ b/src/epilogue/tests/ESMCI_TestUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/tests/ESMCI_TestUTest.C
+++ b/src/epilogue/tests/ESMCI_TestUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/tests/ESMC_TestUTest.c
+++ b/src/epilogue/tests/ESMC_TestUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/tests/ESMC_TestUTest.c
+++ b/src/epilogue/tests/ESMC_TestUTest.c
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/epilogue/tests/ESMF_TestUTest.F90
+++ b/src/epilogue/tests/ESMF_TestUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/epilogue/tests/ESMF_TestUTest.F90
+++ b/src/epilogue/tests/ESMF_TestUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_ExceptionsSubr.C
+++ b/src/prologue/tests/ESMCI_ExceptionsSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_ExceptionsSubr.C
+++ b/src/prologue/tests/ESMCI_ExceptionsSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_ExceptionsUTest.C
+++ b/src/prologue/tests/ESMCI_ExceptionsUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/prologue/tests/ESMCI_ExceptionsUTest.C
+++ b/src/prologue/tests/ESMCI_ExceptionsUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/prologue/tests/ESMCI_FeatureSubr.C
+++ b/src/prologue/tests/ESMCI_FeatureSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_FeatureSubr.C
+++ b/src/prologue/tests/ESMCI_FeatureSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_FeatureUTest.C
+++ b/src/prologue/tests/ESMCI_FeatureUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/prologue/tests/ESMCI_FeatureUTest.C
+++ b/src/prologue/tests/ESMCI_FeatureUTest.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research, 
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research, 
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics 
 // Laboratory, University of Michigan, National Centers for Environmental 
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory, 

--- a/src/prologue/tests/ESMCI_StringSubr.C
+++ b/src/prologue/tests/ESMCI_StringSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_StringSubr.C
+++ b/src/prologue/tests/ESMCI_StringSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_WordsizeSubr.C
+++ b/src/prologue/tests/ESMCI_WordsizeSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMCI_WordsizeSubr.C
+++ b/src/prologue/tests/ESMCI_WordsizeSubr.C
@@ -1,7 +1,7 @@
 // $Id$
 //
 // Earth System Modeling Framework
-// Copyright 2002-2022, University Corporation for Atmospheric Research,
+// Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 // Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 // Laboratory, University of Michigan, National Centers for Environmental
 // Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_ExceptionsUTest.F90
+++ b/src/prologue/tests/ESMF_ExceptionsUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_ExceptionsUTest.F90
+++ b/src/prologue/tests/ESMF_ExceptionsUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_F90ArrayPtrUTest.F90
+++ b/src/prologue/tests/ESMF_F90ArrayPtrUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_F90ArrayPtrUTest.F90
+++ b/src/prologue/tests/ESMF_F90ArrayPtrUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_F95PtrBData.F90
+++ b/src/prologue/tests/ESMF_F95PtrBData.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_F95PtrBData.F90
+++ b/src/prologue/tests/ESMF_F95PtrBData.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_F95PtrUTest.F90
+++ b/src/prologue/tests/ESMF_F95PtrUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_F95PtrUTest.F90
+++ b/src/prologue/tests/ESMF_F95PtrUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_FeatureSubr.F90
+++ b/src/prologue/tests/ESMF_FeatureSubr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_FeatureSubr.F90
+++ b/src/prologue/tests/ESMF_FeatureSubr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_FeatureTR15581Subr.F90
+++ b/src/prologue/tests/ESMF_FeatureTR15581Subr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_FeatureTR15581Subr.F90
+++ b/src/prologue/tests/ESMF_FeatureTR15581Subr.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_FeatureUTest.F90
+++ b/src/prologue/tests/ESMF_FeatureUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_FeatureUTest.F90
+++ b/src/prologue/tests/ESMF_FeatureUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_LAPACKUTest.F90
+++ b/src/prologue/tests/ESMF_LAPACKUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_LAPACKUTest.F90
+++ b/src/prologue/tests/ESMF_LAPACKUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_StringUTest.F90
+++ b/src/prologue/tests/ESMF_StringUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_StringUTest.F90
+++ b/src/prologue/tests/ESMF_StringUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_WordsizeUTest.F90
+++ b/src/prologue/tests/ESMF_WordsizeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/prologue/tests/ESMF_WordsizeUTest.F90
+++ b/src/prologue/tests/ESMF_WordsizeUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessDistMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessDistMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessDistMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessDistMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessGridMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessGridMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessGridMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessGridMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessParser.F90
+++ b/src/test_harness/src/ESMF_TestHarnessParser.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessParser.F90
+++ b/src/test_harness/src/ESMF_TestHarnessParser.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessReportMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessReportMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessReportMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessReportMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessTypesMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessTypesMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessTypesMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessTypesMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessUTest.F90
+++ b/src/test_harness/src/ESMF_TestHarnessUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessUTest.F90
+++ b/src/test_harness/src/ESMF_TestHarnessUTest.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessUtilMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessUtilMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2023, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,

--- a/src/test_harness/src/ESMF_TestHarnessUtilMod.F90
+++ b/src/test_harness/src/ESMF_TestHarnessUtilMod.F90
@@ -1,7 +1,7 @@
 ! $Id$
 !
 ! Earth System Modeling Framework
-! Copyright 2002-2022, University Corporation for Atmospheric Research,
+! Copyright (c) 2002-2022, University Corporation for Atmospheric Research,
 ! Massachusetts Institute of Technology, Geophysical Fluid Dynamics
 ! Laboratory, University of Michigan, National Centers for Environmental
 ! Prediction, Los Alamos National Laboratory, Argonne National Laboratory,


### PR DESCRIPTION
I'm opening this for informational purposes – no need to review.

The replacements were straightforward:
1. Replaced "Copyright 2002-2022" with "Copyright (c) 2002-2022"
2. Replaced "Copyright (c) 2002-2022" with "Copyright (c) 2002-2023"

I did a quick look through the list of files changed. Finally, I checked for files with "Copyright" but not "Copyright (c) 2002-2023". I found one file that needed to be fixed (there was a line break introduced in the copyright notice; I fixed this). Other than that, instances of copyright were just in:
- Third-party things with different copyright notices
- eps files