### PR TITLE
Fixes #126 - STATEINTENT_INTERNAL

### DIFF
--- a/src/Superstructure/State/doc/State_options.tex
+++ b/src/Superstructure/State/doc/State_options.tex
@@ -17,6 +17,8 @@ The valid values are:
          Contains data to be imported into a component.
    \item [ESMF\_STATEINTENT\_EXPORT]
          Contains data to be exported out of a component.
+   \item [ESMF\_STATEINTENT\_INTERNAL]
+         Contains data that is not exposed outside of a component.
    \item [ESMF\_STATEINTENT\_UNSPECIFIED]
          The intent has not been specified.
 \end{description}

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -881,7 +881,8 @@ StateAddRepListMacro(ESMF_State,State,nestedStateList,state,nestedStateList(i)%s
 !   \item[{[stateintent]}]
 !    Import or Export {\tt ESMF\_State}.  Valid values are
 !    {\tt ESMF\_STATEINTENT\_IMPORT}, {\tt ESMF\_STATEINTENT\_EXPORT},
-!    or {\tt ESMF\_STATEINTENT\_UNSPECIFIED} The default
+!    {\tt ESMF\_STATEINTENT\_INTERNAL},
+!    or {\tt ESMF\_STATEINTENT\_UNSPECIFIED}. The default
 !    is {\tt ESMF\_STATEINTENT\_UNSPECIFIED}.
 !   \item[{[arrayList]}]
 !    A list (Fortran array) of {\tt ESMF\_Array}s.
@@ -1970,6 +1971,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
          msgbuf = "Import State"
        case (ESMF_STATEINTENT_EXPORT%state)
          msgbuf = "Export State"
+       case (ESMF_STATEINTENT_INTERNAL)
+         msgbuf = "Internal State"
        case (ESMF_STATEINTENT_UNSPECIFIED%state)
          msgbuf = "Unspecified intent direction"
        case (ESMF_STATEINTENT_INVALID%state)

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -1181,7 +1181,7 @@ ESMF_INIT_CHECK_DEEP(ESMF_RouteHandleGetInit,routehandleList(i),rc)
 !       When set to {\tt .true.}, additionally returns information from
 !       nested States
 !     \item[{[stateintent]}]
-!       Returns the type, e.g., Import or Export, of this {\tt ESMF\_State}.
+!       Returns the type, e.g., Import, Export, or Internal, of this {\tt ESMF\_State}.
 !       Possible values are listed in Section~\ref{const:stateintent}.
 !     \item[{[itemCount]}]
 !       Count of items in this {\tt ESMF\_State}.
@@ -1971,7 +1971,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
          msgbuf = "Import State"
        case (ESMF_STATEINTENT_EXPORT%state)
          msgbuf = "Export State"
-       case (ESMF_STATEINTENT_INTERNAL)
+       case (ESMF_STATEINTENT_INTERNAL%state)
          msgbuf = "Internal State"
        case (ESMF_STATEINTENT_UNSPECIFIED%state)
          msgbuf = "Unspecified intent direction"

--- a/src/Superstructure/State/src/ESMF_StateItem.F90
+++ b/src/Superstructure/State/src/ESMF_StateItem.F90
@@ -226,8 +226,9 @@
       type(ESMF_StateIntent_Flag), parameter :: &
                 ESMF_STATEINTENT_IMPORT   = ESMF_StateIntent_Flag(1), &
                 ESMF_STATEINTENT_EXPORT   = ESMF_StateIntent_Flag(2), &
-                ESMF_STATEINTENT_UNSPECIFIED = ESMF_StateIntent_Flag(3), &
-                ESMF_STATEINTENT_INVALID  = ESMF_StateIntent_Flag(4)
+                ESMF_STATEINTENT_INTERNAL  = ESMF_StateIntent_Flag(3), &
+                ESMF_STATEINTENT_UNSPECIFIED = ESMF_StateIntent_Flag(4), &
+                ESMF_STATEINTENT_INVALID  = ESMF_StateIntent_Flag(5)
 
 !------------------------------------------------------------------------------
 !     ! ESMF_StateClass
@@ -276,6 +277,7 @@
         ESMF_STATEITEM_NOTFOUND
       public ESMF_StateItemConstruct
       public ESMF_StateIntent_Flag, ESMF_STATEINTENT_IMPORT, ESMF_STATEINTENT_EXPORT, &
+                                   ESMF_STATEINTENT_INTERNAL, &
                                    ESMF_STATEINTENT_UNSPECIFIED
 #if 0
       public ESMF_NeededFlag, ESMF_NEEDED, &

--- a/src/Superstructure/State/src/ESMF_StateTypes.F90
+++ b/src/Superstructure/State/src/ESMF_StateTypes.F90
@@ -82,6 +82,7 @@
       public ESMF_StateItemWrap
       public ESMF_StateItemConstruct
       public ESMF_StateIntent_Flag, ESMF_STATEINTENT_IMPORT, ESMF_STATEINTENT_EXPORT, &
+                                   ESMF_STATEINTENT_INTERNAL, &
                                    ESMF_STATEINTENT_UNSPECIFIED
 #if ESMF_ENABLE_NEEDED
       public ESMF_NeededFlag, ESMF_NEEDED, &

--- a/src/epilogue/src/ESMF_ComplianceIC.F90
+++ b/src/epilogue/src/ESMF_ComplianceIC.F90
@@ -1276,6 +1276,8 @@ module ESMF_ComplianceICMod
         tempString = "ESMF_STATEINTENT_IMPORT"
       else if (stateintent==ESMF_STATEINTENT_EXPORT) then
         tempString = "ESMF_STATEINTENT_EXPORT"
+      else if (stateintent==ESMF_STATEINTENT_INTERNAL) then
+        tempString = "ESMF_STATEINTENT_INTERNAL"
       else if (stateintent==ESMF_STATEINTENT_UNSPECIFIED) then
         tempString = "ESMF_STATEINTENT_UNSPECIFIED"
       else


### PR DESCRIPTION
This change introduces a new constant `ESMF_STATEINTENT_INTERNAL` of type `ESMF_StateIntent_Flag`.

- Does not attempt to extend/modify built-in tests to cover the (minimal) new functionality.

- Note that the internal ids for the UNSPECIFIED/INVALID cases are changed from 3/4 to 4/5 respectievly.  This could in theory break user code that incorrectly relies on those values.

- Fixed minor typo (missing period) in documentation.