### PR TITLE
Add quiet nan and signaling nan options to FieldFill.

### DIFF
--- a/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
@@ -46,8 +46,8 @@ module ESMF_FieldGatherMod
     use ESMF_FieldMod
     use ESMF_FieldGetMod
     use ESMF_ArrayMod
-    use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan, &
-                                             ieee_signaling_nan
+    use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_support_nan, &
+                                             ieee_quiet_nan, ieee_signaling_nan
     implicit none
     private
 !------------------------------------------------------------------------------
@@ -183,6 +183,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     real(ESMF_KIND_R8), pointer     :: coord1PtrR8D3(:,:,:)
     real(ESMF_KIND_R8), pointer     :: coord2PtrR8D3(:,:,:)
     real(ESMF_KIND_R8), pointer     :: coord3PtrR8D3(:,:,:)
+    real(ESMF_KIND_R8)              :: nanR8
+    real(ESMF_KIND_R4)              :: nanR4
     integer                         :: i, j, k
     integer                         :: numOwnedPoints
 
@@ -212,30 +214,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if(present(param3I4)) l_member = param3I4
     l_dataFillScheme = "sincos" ! default
     if(present(dataFillScheme)) l_dataFillScheme = dataFillScheme
-    if (trim(l_dataFillScheme)=="nan") then
-      if (ieee_support_nan(l_const1)) then
-        l_const1 = ieee_value(l_const1, ieee_quiet_nan)
-        l_dataFillScheme = "const"
-      else()
-        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-          msg="Quiet NaN is not supported on this machine.", &
-          ESMF_CONTEXT, &
-          rcToReturn=rc)
-        return ! bail out
-      endif()
-    elseif (trim(l_dataFillScheme)=="snan") then
-      if (ieee_support_nan(l_const1)) then
-        l_const1 = ieee_value(l_const1, ieee_signaling_nan)
-        l_dataFillScheme = "const"
-      else()
-        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-          msg="Signaling NaN is not supported on this machine.", &
-          ESMF_CONTEXT, &
-          rcToReturn=rc)
-        return ! bail out
-      endif()
-    endif()
-
+      
     allocate(coordDimCount(rank))
 
     if (geomtype==ESMF_GEOMTYPE_GRID) then
@@ -986,6 +965,132 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
             return  ! bail out
           ! initialize the entire array
           dataPtrR4D3 = 1._ESMF_KIND_R4
+        endif
+      enddo
+    else if (trim(l_dataFillScheme)=="nan") then
+      if (typekind==ESMF_TYPEKIND_R8 .and. ieee_support_nan(nanR8)) then
+        nanR8 = ieee_value(nanR8, ieee_quiet_nan)
+      elseif (typekind==ESMF_TYPEKIND_R4 .and. ieee_support_nan(nanR4)) then
+        nanR4 = ieee_value(nanR4, ieee_quiet_nan)
+      else
+        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+          msg="Quiet NaN is unsupported.", &
+          ESMF_CONTEXT, &
+          rcToReturn=rc)
+        return ! bail out
+      endif
+      do lde=0, ldeCount-1
+        if (typekind==ESMF_TYPEKIND_R8 .and. rank==1) then
+          ! 1D all qnan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR8D1, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR8D1 = nanR8
+        elseif (typekind==ESMF_TYPEKIND_R4 .and. rank==1) then
+          ! 1D all qnan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR4D1, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR4D1 = nanR4
+        elseif (typekind==ESMF_TYPEKIND_R8 .and. rank==2) then
+          ! 2D all qnan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR8D2, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR8D2 = nanR8
+        elseif (typekind==ESMF_TYPEKIND_R4 .and. rank==2) then
+          ! 2D all qnan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR4D2, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR4D2 = nanR4
+        elseif (typekind==ESMF_TYPEKIND_R8 .and. rank==3) then
+          ! 3D all qnan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR8D3, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR8D3 = nanR8
+        elseif (typekind==ESMF_TYPEKIND_R4 .and. rank==3) then
+          ! 3D all qnan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR4D3, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR4D3 = nanR4
+        endif
+      enddo
+    else if (trim(l_dataFillScheme)=="snan") then
+      if (typekind==ESMF_TYPEKIND_R8 .and. ieee_support_nan(nanR8)) then
+        nanR8 = ieee_value(nanR8, ieee_signaling_nan)
+      elseif (typekind==ESMF_TYPEKIND_R4 .and. ieee_support_nan(nanR4)) then 
+        nanR4 = ieee_value(nanR4, ieee_signaling_nan)
+      else
+        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+          msg="Signaling NaN is unsupported", &
+          ESMF_CONTEXT, &
+          rcToReturn=rc)
+        return ! bail out
+      endif
+      do lde=0, ldeCount-1
+        if (typekind==ESMF_TYPEKIND_R8 .and. rank==1) then
+          ! 1D all snan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR8D1, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR8D1 = nanR8
+        elseif (typekind==ESMF_TYPEKIND_R4 .and. rank==1) then
+          ! 1D all snan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR4D1, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR4D1 = nanR4
+        elseif (typekind==ESMF_TYPEKIND_R8 .and. rank==2) then
+          ! 2D all snan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR8D2, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR8D2 = nanR8
+        elseif (typekind==ESMF_TYPEKIND_R4 .and. rank==2) then
+          ! 2D all snan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR4D2, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR4D2 = nanR4
+        elseif (typekind==ESMF_TYPEKIND_R8 .and. rank==3) then
+          ! 3D all snan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR8D3, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR8D3 = nanR8
+        elseif (typekind==ESMF_TYPEKIND_R4 .and. rank==3) then
+          ! 3D all snan.
+          call ESMF_FieldGet(field, localDe=lde, farrayPtr=dataPtrR4D3, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT)) &
+            return ! bail out
+          ! initialize the entire array
+          dataPtrR4D3 = nanR4
         endif
       enddo
     else if (trim(l_dataFillScheme)=="const") then

--- a/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGather.cppF90
@@ -46,6 +46,8 @@ module ESMF_FieldGatherMod
     use ESMF_FieldMod
     use ESMF_FieldGetMod
     use ESMF_ArrayMod
+    use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan, &
+                                             ieee_signaling_nan
     implicit none
     private
 !------------------------------------------------------------------------------
@@ -114,8 +116,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[field]
 !     The {\tt ESMF\_Field} object to fill with data.
 !   \item[{[dataFillScheme]}]
-!     The fill scheme. The available options are "sincos", "one", "const", and
-!     "random". Defaults to "sincos".
+!     The fill scheme. The available options are "sincos", "one", "const",
+!     "random", "nan", and "snan". Defaults to "sincos".
 !   \item[{[const1]}]
 !     Constant of real type. Defaults to 0.
 !   \item[{[member]}]
@@ -210,7 +212,30 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if(present(param3I4)) l_member = param3I4
     l_dataFillScheme = "sincos" ! default
     if(present(dataFillScheme)) l_dataFillScheme = dataFillScheme
-      
+    if (trim(l_dataFillScheme)=="nan") then
+      if (ieee_support_nan(l_const1)) then
+        l_const1 = ieee_value(l_const1, ieee_quiet_nan)
+        l_dataFillScheme = "const"
+      else()
+        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+          msg="Quiet NaN is not supported on this machine.", &
+          ESMF_CONTEXT, &
+          rcToReturn=rc)
+        return ! bail out
+      endif()
+    elseif (trim(l_dataFillScheme)=="snan") then
+      if (ieee_support_nan(l_const1)) then
+        l_const1 = ieee_value(l_const1, ieee_signaling_nan)
+        l_dataFillScheme = "const"
+      else()
+        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+          msg="Signaling NaN is not supported on this machine.", &
+          ESMF_CONTEXT, &
+          rcToReturn=rc)
+        return ! bail out
+      endif()
+    endif()
+
     allocate(coordDimCount(rank))
 
     if (geomtype==ESMF_GEOMTYPE_GRID) then

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
@@ -14,6 +14,8 @@
 
 !------------------------------------------------------------------------------
 
+#define FILENAME "ESMF_FieldRegridUTest.F90"
+
 #include "ESMF.h"
 
 #if defined (ESMF_LAPACK)
@@ -21593,8 +21595,6 @@ write(*,*) "LOCALRC=",localrc
  end subroutine test_regridMeshToMeshMask
 
 
-#define FILE "ESMF_FieldRegridUTest.F90"
-
   subroutine test_regridSrcHoles(rc)
     integer, intent(out)  :: rc
 
@@ -21620,11 +21620,11 @@ write(*,*) "LOCALRC=",localrc
 
     call ESMF_VMGetCurrent(vm, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     call ESMF_VMGet(vm, petCount=petCount, localPet=localPet, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! --- set up the source side ---
 
@@ -21661,24 +21661,24 @@ write(*,*) "LOCALRC=",localrc
     srcDistGrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/iMax,jMax/),&
       deBlockList=deBlockList, indexflag=ESMF_INDEX_GLOBAL, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! Create the srcGrid.
     srcGrid = ESMF_GridCreate(srcDistGrid, coordSys=ESMF_COORDSYS_SPH_DEG, &
       indexflag=ESMF_INDEX_GLOBAL, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! Add coordinates to the srcGrid.
     call ESMF_GridAddCoord(srcGrid, staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! Access the longitude coordinate pointer in srcGrid and fill.
     call ESMF_GridGetCoord(srcGrid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
       coordDim=1, farrayPtr=fptr, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
     do j=lbound(fptr,2), ubound(fptr,2)
     do i=lbound(fptr,1), ubound(fptr,1)
       fptr(i,j) = (lonMaxS-lonMinS)/real(iMax) * (i-1) + lonMinS
@@ -21689,7 +21689,7 @@ write(*,*) "LOCALRC=",localrc
     call ESMF_GridGetCoord(srcGrid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
       coordDim=2, farrayPtr=fptr, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
     do j=lbound(fptr,2), ubound(fptr,2)
     do i=lbound(fptr,1), ubound(fptr,1)
       fptr(i,j) = (latMaxS-latMinS)/real(jMax) * (j-1) + latMinS
@@ -21700,7 +21700,7 @@ write(*,*) "LOCALRC=",localrc
     srcField =  ESMF_FieldCreate(srcGrid, typekind=ESMF_TYPEKIND_R8, &
       indexflag=ESMF_INDEX_GLOBAL, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! --- set up the destination side ---
 
@@ -21708,24 +21708,24 @@ write(*,*) "LOCALRC=",localrc
     dstDistGrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/iMax,jMax/),&
       indexflag=ESMF_INDEX_GLOBAL, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! Create the dstGrid.
     dstGrid = ESMF_GridCreate(dstDistGrid, coordSys=ESMF_COORDSYS_SPH_DEG, &
       indexflag=ESMF_INDEX_GLOBAL, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! Add coordinates to the dstGrid.
     call ESMF_GridAddCoord(dstGrid, staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! Access the longitude coordinate pointer in dstGrid and fill.
     call ESMF_GridGetCoord(dstGrid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
       coordDim=1, farrayPtr=fptr, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
     do j=lbound(fptr,2), ubound(fptr,2)
     do i=lbound(fptr,1), ubound(fptr,1)
       fptr(i,j) = (lonMaxD-lonMinD)/real(iMax) * (i-1) + lonMinD
@@ -21736,7 +21736,7 @@ write(*,*) "LOCALRC=",localrc
     call ESMF_GridGetCoord(dstGrid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
       coordDim=2, farrayPtr=fptr, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
     do j=lbound(fptr,2), ubound(fptr,2)
     do i=lbound(fptr,1), ubound(fptr,1)
       fptr(i,j) = (latMaxD-latMinD)/real(jMax) * (j-1) + latMinD
@@ -21747,7 +21747,7 @@ write(*,*) "LOCALRC=",localrc
     dstField =  ESMF_FieldCreate(dstGrid, typekind=ESMF_TYPEKIND_R8, &
       indexflag=ESMF_INDEX_GLOBAL, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     ! --- Regridding ---
 
@@ -21755,7 +21755,7 @@ write(*,*) "LOCALRC=",localrc
     call ESMF_FieldRegridStore(srcField=srcField, dstField=dstField, &
       routehandle=rh, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILE)) return ! bail out
+      line=__LINE__, file=FILENAME)) return ! bail out
 
     !TODO: execute the Regrid and validate the result.
     !TODO: right now it doesn't even make it that far for srcDistGrid w/ holes


### PR DESCRIPTION
### Questions

- If we add nan (a.k.a. quiet nan) and snan (a.k.a. signaling nan) options to the FieldFill will it help developers and scientists initialize fields or background data and see data issues? Yes, we believe this to be helpful.
- Is the ieee_arithmetic intrinsic module available with all compilers? IEEE arithmetic is supported for all Fortran compilers listed there except g95 https://fortranwiki.org/fortran/show/Fortran+2003+status

### Testing
I've added a test to ESMF_FieldRegridUTest. There's also a snan (signaling nan) test that will fail IF floating point exceptions are added to the build; this test is turned off.
Intel fpe flags
```
+ESMF_F90OPTFLAG_G       += -traceback -check arg_temp_created,bounds,format,output_conversion,stack,uninit -fpe0
+ESMF_CXXOPTFLAG_G       += -traceback -Wcheck -fp-trap=common
```
Testing complete with gfortran (mac os) and intel (linux)