### PR TITLE
Re-enable -t, --src_type and --dst_type args in ESMF_RegridWeightGen

### DIFF
--- a/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilTypes.F90
@@ -1339,6 +1339,7 @@ interface assignment (=)
   module procedure ESMF_ptas2
   module procedure ESMF_ioas
   module procedure ESMF_ifas_string
+  module procedure ESMF_FileFormatAsString
   module procedure ESMF_FileStatusAs
 end interface  
 
@@ -1930,6 +1931,36 @@ end function ESMF_FileFormatEq
                                  FileFormat2%fileformat)
 
 end function ESMF_FileFormatNe
+!------------------------------------------------------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_FileFormatAsString"
+subroutine ESMF_FileFormatAsString(String, FileFormat)
+  character(len=*), intent(out) :: String
+  type(ESMF_FileFormat_Flag), intent(in) :: FileFormat
+
+  if (FileFormat == ESMF_FILEFORMAT_UNKNOWN) then
+     String = 'ESMF_FILEFORMAT_UNKNOWN'
+  else if (FileFormat == ESMF_FILEFORMAT_VTK) then
+     String = 'ESMF_FILEFORMAT_VTK'
+  else if (FileFormat == ESMF_FILEFORMAT_SCRIP) then
+     String = 'ESMF_FILEFORMAT_SCRIP'
+  else if (FileFormat == ESMF_FILEFORMAT_ESMFMESH) then
+     String = 'ESMF_FILEFORMAT_ESMFMESH'
+  else if (FileFormat == ESMF_FILEFORMAT_ESMFGRID) then
+     String = 'ESMF_FILEFORMAT_ESMFGRID'
+  else if (FileFormat == ESMF_FILEFORMAT_UGRID) then
+     String = 'ESMF_FILEFORMAT_UGRID'
+  else if (FileFormat == ESMF_FILEFORMAT_CFGRID) then
+     ! Note that ESMF_FILEFORMAT_CFGRID is the same as ESMF_FILEFORMAT_GRIDSPEC
+     String = 'ESMF_FILEFORMAT_CFGRID/ESMF_FILEFORMAT_GRIDSPEC'
+  else if (FileFormat == ESMF_FILEFORMAT_MOSAIC) then
+     String = 'ESMF_FILEFORMAT_MOSAIC'
+  else if (FileFormat == ESMF_FILEFORMAT_TILE) then
+     String = 'ESMF_FILEFORMAT_TILE'
+  else
+     String = '(Unexpected ESMF_FILEFORMAT value)'
+  end if
+end subroutine ESMF_FileFormatAsString
 
 !------------------------------------------------------------------------------
 #undef  ESMF_METHOD

--- a/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
+++ b/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
@@ -1353,9 +1353,9 @@ contains
     print *, "                      [--extrap_num_levels <L>]"
     print *, "                      [--ignore_unmapped|-i]"
     print *, "                      [--ignore_degenerate]"
-    print *, "                      [--src_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]"
-    print *, "                      [--dst_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]"
-    print *, "                      [-t SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]"
+    print *, "                      [--src_type SCRIP|ESMFMESH|UGRID|CFGRID|GRIDSPEC|MOSAIC|TILE]"
+    print *, "                      [--dst_type SCRIP|ESMFMESH|UGRID|CFGRID|GRIDSPEC|MOSAIC|TILE]"
+    print *, "                      [-t SCRIP|ESMFMESH|UGRID|CFGRID|GRIDSPEC|MOSAIC|TILE]"
     print *, "                      [-r]"
     print *, "                      [--src_regional]"
     print *, "                      [--dst_regional]"
@@ -1410,18 +1410,18 @@ contains
     print *, "--ignore_degenerate - ignore degenerate cells in the input grids. If not specified,"
     print *, "                          the default is to stop with an error."
     print *, "--src_type - an optional argument specifying the source grid file type."
-    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, CFGRID, GRIDSPEC, MOSAIC or TILE."
     print *, "             If neither --src_type nor -t is given, the source grid file type will be"
     print *, "             determined automatically. (Usually it is unnecessary to provide --src_type,"
     print *, "             but it can be specified when the automatic file type determination fails.)"
     print *, "--dst_type - an optional argument specifying the destination grid file type."
-    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, CFGRID, GRIDSPEC, MOSAIC or TILE."
     print *, "             If neither --dst_type nor -t is given, the destination grid file type will be"
     print *, "             determined automatically. (Usually it is unnecessary to provide --dst_type,"
     print *, "             but it can be specified when the automatic file type determination fails.)"
     print *, "-t         - an optional argument specifying the file types for both the source"
     print *, "             and the destination grid files."
-    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, CFGRID, GRIDSPEC, MOSAIC or TILE."
     print *, "             If -t is given, then neither --src_type nor --dst_type can be given."
     print *, "-r         - an optional argument specifying the source and destination grids"
     print *, "             are regional grids.  Without this argument, the grids are assumed"
@@ -1502,6 +1502,8 @@ contains
        fileType = ESMF_FILEFORMAT_ESMFMESH
     case ('UGRID')
        fileType = ESMF_FILEFORMAT_UGRID
+    case ('CFGRID')
+       fileType = ESMF_FILEFORMAT_CFGRID
     case ('GRIDSPEC')
        fileType = ESMF_FILEFORMAT_GRIDSPEC
     case ('MOSAIC')
@@ -1511,7 +1513,7 @@ contains
     case default
        write(*,*)
        print *, "ERROR: Unknown ", trim(argName), ": must be one of:"
-       print *, "SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+       print *, "SCRIP, ESMFMESH, UGRID, CFGRID, GRIDSPEC, MOSAIC or TILE."
        print *, "Use the --help argument to see an explanation of usage."
        call ESMF_Finalize(endflag=ESMF_END_ABORT)
     end select

--- a/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
+++ b/src/apps/ESMF_RegridWeightGen/ESMF_RegridWeightGen.F90
@@ -46,7 +46,8 @@ program ESMF_RegridWeightGenApp
   type(ESMF_LineType_Flag) :: lineType
   type(ESMF_PoleMethod_Flag) :: pole
    integer            :: poleptrs
-  type(ESMF_FileFormat_Flag) :: srcFileType, dstFileType
+  type(ESMF_FileFormat_Flag) :: srcFileType, dstFileType, srcFileTypeInferred, dstFileTypeInferred
+  character(len=MAXNAMELEN) :: fileTypeStr, fileTypeInferredStr
   type(ESMF_RegridMethod_Flag) :: methodflag
   type(ESMF_ExtrapMethod_Flag) :: extrapMethodFlag
   character(len=ESMF_MAXPATHLEN) :: commandbuf1(5)
@@ -59,7 +60,7 @@ program ESMF_RegridWeightGenApp
   logical              :: ignoreUnmapped, userAreaFlag, ignoreDegenerate
   type(ESMF_UnmappedAction_Flag) :: unmappedaction
   logical            :: srcMissingValue, dstMissingValue
-  logical            :: srcIsRegional, dstIsRegional, typeSetFlag
+  logical            :: srcIsRegional, dstIsRegional, typeFlagSet
   logical            :: useSrcCoordVar, useDstCoordVar
   character(len=MAXNAMELEN) :: srcvarname, dstvarname
   character(len=MAXNAMELEN) :: srcCoordNames(2), dstCoordNames(2)
@@ -360,44 +361,91 @@ program ESMF_RegridWeightGenApp
       endif
     endif
 
-    typeSetFlag = .false.  
+    typeFlagSet = .false.
     srcFileType = ESMF_FILEFORMAT_UNKNOWN
     dstFileType = ESMF_FILEFORMAT_UNKNOWN
     srcIsRegional = .false.
     dstIsRegional = .false.
-    ! deprecated
     call ESMF_UtilGetArgIndex('-t', argindex=ind, rc=rc)
     if (ind /= -1) then
-     write(*,*)
-     print *, "WARNING: deprecated switch -t will be ignored.  The file type will be detected automatically"
-    endif
+       typeFlagSet = .true.
+       call ESMF_UtilGetArg(ind+1, argvalue=flag)
+       call ParseFileTypeArg('-t', flag, srcFileType)
+       dstFileType = srcFileType
+    end if
 
     call ESMF_UtilGetArgIndex('--src_type', argindex=ind, rc=rc)
     if (ind /= -1) then
-     write(*,*)
-     print *, "WARNING: deprecated switch -src_type will be ignored.  The file type will be detected automatically"
+       if (typeFlagSet) then
+          write(*,*)
+          print *, 'ERROR: Cannot specify both -t and --src_type'
+          call ESMF_Finalize(endflag=ESMF_END_ABORT)
+       end if
+       call ESMF_UtilGetArg(ind+1, argvalue=flag)
+       call ParseFileTypeArg('--src_type', flag, srcFileType)
     endif
 
     call ESMF_UtilGetArgIndex('--dst_type', argindex=ind, rc=rc)
     if (ind /= -1) then
-     write(*,*)
-     print *, "WARNING: deprecated switch -dst_type will be ignored.  The file type will be detected automatically"
-    endif
+       if (typeFlagSet) then
+          write(*,*)
+          print *, 'ERROR: Cannot specify both -t and --dst_type'
+          call ESMF_Finalize(endflag=ESMF_END_ABORT)
+       end if
+       call ESMF_UtilGetArg(ind+1, argvalue=flag)
+       call ParseFileTypeArg('--dst_type', flag, dstFileType)
+    end if
 
     ! Check the srcfile type and dstfile type
-    call ESMF_FileTypeCheck(srcfile, srcFileType, varname=srcMeshName, rc=rc)
-    if (rc/=ESMF_SUCCESS .or. srcFileType==ESMF_FILEFORMAT_UNKNOWN) then
-        write(*,*)
-        print *, 'ERROR: Unable to detect the source grid file type.'
-        call ESMF_Finalize(endflag=ESMF_END_ABORT)
-    endif
-    ! Check the dstfile type and dstfile type
-    call ESMF_FileTypeCheck(dstfile, dstFileType, varname=dstMeshName, rc=rc)
-    if (rc/=ESMF_SUCCESS .or. dstFileType==ESMF_FILEFORMAT_UNKNOWN) then
-        write(*,*)
-        print *, 'ERROR: Unable to detect the destination grid file type.'
-        call ESMF_Finalize(endflag=ESMF_END_ABORT)
-    endif
+    !
+    ! Note that we call ESMF_FileTypeCheck even if the file types were explicitly
+    ! specified. This is partly to get the mesh names and partly to be able to print a
+    ! warning if the inferred file type differs from the specified file type.
+    call ESMF_FileTypeCheck(srcfile, srcFileTypeInferred, varname=srcMeshName, rc=rc)
+    if (srcFileType == ESMF_FILEFORMAT_UNKNOWN) then
+       ! src file type wasn't explicitly specified, so get it from the inferred type
+       if (rc/=ESMF_SUCCESS .or. srcFileTypeInferred==ESMF_FILEFORMAT_UNKNOWN) then
+          write(*,*)
+          print *, 'ERROR: Unable to detect the source grid file type.'
+          call ESMF_Finalize(endflag=ESMF_END_ABORT)
+       endif
+       srcFileType = srcFileTypeInferred
+    else
+       ! src file type was explicitly specified; print a warning if the inferred file
+       ! type differs from the explicitly specified type
+       if (srcFileTypeInferred /= ESMF_FILEFORMAT_UNKNOWN .and. &
+            srcFileTypeInferred /= srcFileType) then
+          fileTypeInferredStr = srcFileTypeInferred
+          fileTypeStr = srcFileType
+          write(*,*)
+          print *, 'WARNING: inferred src file type (', trim(fileTypeInferredStr), ') ', &
+               'differs from specified src file type (', trim(fileTypeStr), '); ', &
+               'using specified src file type (', trim(fileTypeStr), ').'
+       end if
+    end if
+    call ESMF_FileTypeCheck(dstfile, dstFileTypeInferred, varname=dstMeshName, rc=rc)
+    if (dstFileType == ESMF_FILEFORMAT_UNKNOWN) then
+       ! dst file type wasn't explicitly specified, so get it from the inferred type
+       if (rc/=ESMF_SUCCESS .or. dstFileTypeInferred==ESMF_FILEFORMAT_UNKNOWN) then
+          write(*,*)
+          print *, 'ERROR: Unable to detect the destination grid file type.'
+          call ESMF_Finalize(endflag=ESMF_END_ABORT)
+       endif
+       dstFileType = dstFileTypeInferred
+    else
+       ! dst file type was explicitly specified; print a warning if the inferred file
+       ! type differs from the explicitly specified type
+       if (dstFileTypeInferred /= ESMF_FILEFORMAT_UNKNOWN .and. &
+            dstFileTypeInferred /= dstFileType) then
+          fileTypeInferredStr = dstFileTypeInferred
+          fileTypeStr = dstFileType
+          write(*,*)
+          print *, 'WARNING: inferred dst file type (', trim(fileTypeInferredStr), ') ', &
+               'differs from specified dst file type (', trim(fileTypeStr), '); ', &
+               'using specified dst file type (', trim(fileTypeStr), ').'
+       end if
+    end if
+
 
     ! If the src grid type is GRIDSPEC or UGRID, check if --src_missingvalue argument is given
     call ESMF_UtilGetArgIndex('--src_missingvalue', argindex=ind, rc=rc)
@@ -1305,6 +1353,9 @@ contains
     print *, "                      [--extrap_num_levels <L>]"
     print *, "                      [--ignore_unmapped|-i]"
     print *, "                      [--ignore_degenerate]"
+    print *, "                      [--src_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]"
+    print *, "                      [--dst_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]"
+    print *, "                      [-t SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]"
     print *, "                      [-r]"
     print *, "                      [--src_regional]"
     print *, "                      [--dst_regional]"
@@ -1358,6 +1409,20 @@ contains
     print *, "                          the default is to stop with an error."
     print *, "--ignore_degenerate - ignore degenerate cells in the input grids. If not specified,"
     print *, "                          the default is to stop with an error."
+    print *, "--src_type - an optional argument specifying the source grid file type."
+    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+    print *, "             If neither --src_type nor -t is given, the source grid file type will be"
+    print *, "             determined automatically. (Usually it is unnecessary to provide --src_type,"
+    print *, "             but it can be specified when the automatic file type determination fails.)"
+    print *, "--dst_type - an optional argument specifying the destination grid file type."
+    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+    print *, "             If neither --dst_type nor -t is given, the destination grid file type will be"
+    print *, "             determined automatically. (Usually it is unnecessary to provide --dst_type,"
+    print *, "             but it can be specified when the automatic file type determination fails.)"
+    print *, "-t         - an optional argument specifying the file types for both the source"
+    print *, "             and the destination grid files."
+    print *, "             The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+    print *, "             If -t is given, then neither --src_type nor --dst_type can be given."
     print *, "-r         - an optional argument specifying the source and destination grids"
     print *, "             are regional grids.  Without this argument, the grids are assumed"
     print *, "             to be global"
@@ -1423,5 +1488,33 @@ contains
     print *, "Earth System Modeling Framework."
     print *, ""
   end subroutine PrintUsage
+
+  subroutine ParseFileTypeArg(argName, fileTypeArg, fileType)
+    ! Parse a given file type argument, returning the appropriate file type constant
+    character(len=*), intent(in) :: argName             ! name of the argument, just used for error messages
+    character(len=*), intent(in) :: fileTypeArg         ! value of the file type argument
+    type(ESMF_FileFormat_Flag), intent(out) :: fileType ! determined file type constant
+
+    select case (fileTypeArg)
+    case ('SCRIP')
+       fileType = ESMF_FILEFORMAT_SCRIP
+    case ('ESMFMESH')
+       fileType = ESMF_FILEFORMAT_ESMFMESH
+    case ('UGRID')
+       fileType = ESMF_FILEFORMAT_UGRID
+    case ('GRIDSPEC')
+       fileType = ESMF_FILEFORMAT_GRIDSPEC
+    case ('MOSAIC')
+       fileType = ESMF_FILEFORMAT_MOSAIC
+    case ('TILE')
+       fileType = ESMF_FILEFORMAT_TILE
+    case default
+       write(*,*)
+       print *, "ERROR: Unknown ", trim(argName), ": must be one of:"
+       print *, "SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE."
+       print *, "Use the --help argument to see an explanation of usage."
+       call ESMF_Finalize(endflag=ESMF_END_ABORT)
+    end select
+  end subroutine ParseFileTypeArg
 
 end program ESMF_RegridWeightGenApp

--- a/src/doc/ESMF_RegridWeightGen.tex
+++ b/src/doc/ESMF_RegridWeightGen.tex
@@ -307,6 +307,9 @@ ESMF_RegridWeightGen
         [--extrap_num_levels <L>]
         [--ignore_unmapped|-i]
         [--ignore_degenerate]
+        [--src_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]
+        [--dst_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]
+        [-t SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]
         [-r]
         [--src_regional]
         [--dst_regional]
@@ -473,6 +476,23 @@ where:
     --ignore_degenerate - ignore degenerate cells in the input grids. If not specified
                         the default is to stop with an error if an degenerate
                         cell is found.
+
+    --src_type        - an optional argument specifying the source grid file type.
+                        The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE.
+                        If neither --src_type nor -t is given, the source grid file type will be
+                        determined automatically. (Usually it is unnecessary to provide --src_type,
+                        but it can be specified when the automatic file type determination fails.)
+
+    --dst_type        - an optional argument specifying the destination grid file type.
+                        The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE.
+                        If neither --dst_type nor -t is given, the destination grid file type will be
+                        determined automatically. (Usually it is unnecessary to provide --dst_type,
+                        but it can be specified when the automatic file type determination fails.)
+
+    -t                - an optional argument specifying the file types for both the source
+                        and the destination grid files.
+                        The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE.
+                        If -t is given, then neither --src_type nor --dst_type can be given.
 
     -r                - an optional argument specifying that the source and
                         destination grids are regional grids.  If the argument

--- a/src/doc/ESMF_RegridWeightGen.tex
+++ b/src/doc/ESMF_RegridWeightGen.tex
@@ -307,9 +307,9 @@ ESMF_RegridWeightGen
         [--extrap_num_levels <L>]
         [--ignore_unmapped|-i]
         [--ignore_degenerate]
-        [--src_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]
-        [--dst_type SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]
-        [-t SCRIP|ESMFMESH|UGRID|GRIDSPEC|MOSAIC|TILE]
+        [--src_type SCRIP|ESMFMESH|UGRID|CFGRID|GRIDSPEC|MOSAIC|TILE]
+        [--dst_type SCRIP|ESMFMESH|UGRID|CFGRID|GRIDSPEC|MOSAIC|TILE]
+        [-t SCRIP|ESMFMESH|UGRID|CFGRID|GRIDSPEC|MOSAIC|TILE]
         [-r]
         [--src_regional]
         [--dst_regional]
@@ -478,20 +478,20 @@ where:
                         cell is found.
 
     --src_type        - an optional argument specifying the source grid file type.
-                        The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE.
+                        The value can be one of SCRIP, ESMFMESH, UGRID, CFGRID, GRIDSPEC, MOSAIC or TILE.
                         If neither --src_type nor -t is given, the source grid file type will be
                         determined automatically. (Usually it is unnecessary to provide --src_type,
                         but it can be specified when the automatic file type determination fails.)
 
     --dst_type        - an optional argument specifying the destination grid file type.
-                        The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE.
+                        The value can be one of SCRIP, ESMFMESH, UGRID, CFGRID, GRIDSPEC, MOSAIC or TILE.
                         If neither --dst_type nor -t is given, the destination grid file type will be
                         determined automatically. (Usually it is unnecessary to provide --dst_type,
                         but it can be specified when the automatic file type determination fails.)
 
     -t                - an optional argument specifying the file types for both the source
                         and the destination grid files.
-                        The value can be one of SCRIP, ESMFMESH, UGRID, GRIDSPEC, MOSAIC or TILE.
+                        The value can be one of SCRIP, ESMFMESH, UGRID, CFGRID, GRIDSPEC, MOSAIC or TILE.
                         If -t is given, then neither --src_type nor --dst_type can be given.
 
     -r                - an optional argument specifying that the source and


### PR DESCRIPTION
Partially addresses esmf-org/esmf#94

I would welcome a review from @oehmke or others.

I have run a bunch of manual tests:
- Ensuring that `-t`, `--src_type` and `--dst_type` all work
- Invalid values for those produce an error
- Specifying `-t` along with `--src_type` or `--dst_type` produces an error
- Explicitly specified type overrides auto-detected type
- Auto-detection of type still works if you don't explicitly specify type
- A warning is printed if explicitly specified type differs from auto-detected type
- The new function that turns a grid file type into a string works correctly for all grid file types allowed by ESMF_RegridWeightGen

I am currently running `gmake all_tests`. Is there any other testing I should do that is specific to ESMF_RegridWeightGen that isn't covered by `gmake all_tests`?