### PR TITLE
Add floating point exception flags for BOPT=g.

### DIFF
--- a/build_config/Cygwin.gfortran.default/build_rules.mk
+++ b/build_config/Cygwin.gfortran.default/build_rules.mk
@@ -116,7 +116,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer -ffpe-trap=zero,overflow
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################

--- a/build_config/Darwin.gfortran.default/build_rules.mk
+++ b/build_config/Darwin.gfortran.default/build_rules.mk
@@ -119,7 +119,7 @@ endif
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer -ffpe-trap=zero,overflow
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################

--- a/build_config/Darwin.gfortranclang.default/build_rules.mk
+++ b/build_config/Darwin.gfortranclang.default/build_rules.mk
@@ -123,7 +123,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fimplicit-none -fcheck=all,no-pointer -ffpe-trap=zero,overflow
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################

--- a/build_config/Darwin.intel.default/build_rules.mk
+++ b/build_config/Darwin.intel.default/build_rules.mk
@@ -122,8 +122,8 @@ ESMF_CXXMAJORVERSION      = $(shell $(ESMF_DIR)/scripts/version.intel 1 ${ESMF_C
 ############################################################
 # Special debug flags
 #
-ESMF_CXXOPTFLAG_G       += -Wcheck
-ESMF_F90OPTFLAG_G       += -traceback -check bounds
+ESMF_F90OPTFLAG_G       += -traceback -check bounds -fpe0
+ESMF_CXXOPTFLAG_G       += -Wcheck -fp-trap=common
 
 ############################################################
 # Enable TR15581/F2003 Allocatable array resizing

--- a/build_config/Darwin.intelclang.default/build_rules.mk
+++ b/build_config/Darwin.intelclang.default/build_rules.mk
@@ -114,7 +114,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -traceback -check bounds
+ESMF_F90OPTFLAG_G       += -traceback -check bounds -fpe0
 
 ############################################################
 # Enable TR15581/F2003 Allocatable array resizing

--- a/build_config/Darwin.intelgcc.default/build_rules.mk
+++ b/build_config/Darwin.intelgcc.default/build_rules.mk
@@ -112,8 +112,8 @@ ESMF_F90MAJORVERSION      = $(shell $(ESMF_DIR)/scripts/version.intel 1 ${ESMF_F
 ############################################################
 # Special debug flags
 #
+ESMF_F90OPTFLAG_G       += -traceback -check bounds -fpe0
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
-ESMF_F90OPTFLAG_G       += -traceback -check bounds
 
 ############################################################
 # Enable TR15581/F2003 Allocatable array resizing

--- a/build_config/Darwin.nag.default/build_rules.mk
+++ b/build_config/Darwin.nag.default/build_rules.mk
@@ -109,6 +109,11 @@ ESMF_CXXCOMPILER_VERSION    = ${ESMF_CXXCOMPILER} -v --version
 ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 
 ############################################################
+# Special debug flags
+#
+ESMF_F90OPTFLAG_G += -C=array -ieee=stop
+
+############################################################
 # See if g++ is really clang
 #
 ESMF_CLANGSTR := $(findstring clang, $(shell $(ESMF_CXXCOMPILER) --version))

--- a/build_config/Linux.absoftintel.default/build_rules.mk
+++ b/build_config/Linux.absoftintel.default/build_rules.mk
@@ -110,7 +110,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -V -v
 ############################################################
 # Special debug flags
 #
-ESMF_CXXOPTFLAG_G       += -traceback
+ESMF_CXXOPTFLAG_G       += -traceback -fp-trap=common
 
 ############################################################
 # How to specify module directories

--- a/build_config/Linux.gfortran.default/build_rules.mk
+++ b/build_config/Linux.gfortran.default/build_rules.mk
@@ -143,7 +143,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version
 # Also set environment variable UBSAN_OPTIONS="print_stacktrace=1"
 # for stacktrace at runtime.
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer -ffpe-trap=zero,overflow
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused $(ESMF_LINKOPTFLAG_G)
 
 ############################################################

--- a/build_config/Linux.gfortranclang.default/build_rules.mk
+++ b/build_config/Linux.gfortranclang.default/build_rules.mk
@@ -132,7 +132,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer -ffpe-trap=zero,overflow
 
 ############################################################
 # Fortran symbol convention

--- a/build_config/Linux.intel.default/build_rules.mk
+++ b/build_config/Linux.intel.default/build_rules.mk
@@ -151,8 +151,8 @@ ESMF_CXXMAJORVERSION      = $(shell $(ESMF_DIR)/scripts/version.intel 1 ${ESMF_C
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -traceback -check arg_temp_created,bounds,format,output_conversion,stack,uninit
-ESMF_CXXOPTFLAG_G       += -traceback -Wcheck
+ESMF_F90OPTFLAG_G       += -traceback -check arg_temp_created,bounds,format,output_conversion,stack,uninit -fpe0
+ESMF_CXXOPTFLAG_G       += -traceback -Wcheck -fp-trap=common
 
 ############################################################
 # Enable TR15581/F2003 Allocatable array resizing

--- a/build_config/Linux.intelgcc.default/build_rules.mk
+++ b/build_config/Linux.intelgcc.default/build_rules.mk
@@ -139,7 +139,7 @@ ESMF_F90MAJORVERSION        = $(shell $(ESMF_DIR)/scripts/version.intel 1 ${ESMF
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -traceback -check bounds
+ESMF_F90OPTFLAG_G       += -traceback -check bounds -fpe0
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################

--- a/build_config/Linux.nag.default/build_rules.mk
+++ b/build_config/Linux.nag.default/build_rules.mk
@@ -115,7 +115,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version
 # Also set environment variable UBSAN_OPTIONS="print_stacktrace=1"
 # for stacktrace at runtime.
 #
-ESMF_F90OPTFLAG_G       += -C=array
+ESMF_F90OPTFLAG_G       += -C=array -ieee=stop
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused $(ESMF_LINKOPTFLAG_G)
 
 ############################################################

--- a/build_config/Linux.nagintel.default/build_rules.mk
+++ b/build_config/Linux.nagintel.default/build_rules.mk
@@ -102,7 +102,8 @@ ESMF_CXXMAJORVERSION        = $(shell $(ESMF_DIR)/scripts/version.intel 1 ${ESMF
 ############################################################
 # Special debug flags
 #
-ESMF_CXXOPTFLAG_G       += -traceback
+ESMF_F90OPTFLAG_G       += -C=array -ieee=stop
+ESMF_CXXOPTFLAG_G       += -traceback -fp-trap=common
 
 ############################################################
 # Set NAG unix modules when certain non-Standard system calls

--- a/build_config/Linux.nvhpc.default/build_rules.mk
+++ b/build_config/Linux.nvhpc.default/build_rules.mk
@@ -135,6 +135,12 @@ ESMF_CXXCOMPILER_VERSION    = ${ESMF_CXXCOMPILER} --version -c
 ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version -c
 
 ############################################################
+# Special debug flags
+#
+ESMF_F90OPTFLAG_G       += -Ktrap=fp
+ESMF_CXXOPTFLAG_G       += -Ktrap=fp
+
+############################################################
 # Currently no support the Fortran2018 assumed type feature
 #
 ESMF_F90COMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE

--- a/build_config/MinGW.gfortran.default/build_rules.mk
+++ b/build_config/MinGW.gfortran.default/build_rules.mk
@@ -59,7 +59,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer -ffpe-trap=zero,overflow
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################

--- a/build_config/MinGW.intel.default/build_rules.mk
+++ b/build_config/MinGW.intel.default/build_rules.mk
@@ -154,8 +154,8 @@ ESMF_F90COMPILEFIXCPP    = -fpp
 ###########################################################
 # Special debugging flags
 #
-ESMF_F90OPTFLAG_G           = -Od -debug -traceback
-ESMF_CXXOPTFLAG_G           = -Od -debug -traceback
+ESMF_F90OPTFLAG_G           = -Od -debug -traceback -fpe0
+ESMF_CXXOPTFLAG_G           = -Od -debug -traceback -fp-trap=common
 
 ###########################################################
 # Default optlevel

--- a/build_config/MinGW.intelcl.default/build_rules.mk
+++ b/build_config/MinGW.intelcl.default/build_rules.mk
@@ -152,7 +152,7 @@ ESMF_F90COMPILEFIXCPP    = -fpp
 ###########################################################
 # Special debugging flags
 #
-ESMF_F90OPTFLAG_G           = -Od -debug -traceback
+ESMF_F90OPTFLAG_G           = -Od -debug -traceback -fpe0
 ESMF_CXXOPTFLAG_G           = -Od -Zi
 
 ###########################################################

--- a/build_config/Unicos.gfortran.default/build_rules.mk
+++ b/build_config/Unicos.gfortran.default/build_rules.mk
@@ -50,7 +50,7 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
+ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer -ffpe-trap=zero,overflow
 ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################

--- a/build_config/Unicos.intel.default/build_rules.mk
+++ b/build_config/Unicos.intel.default/build_rules.mk
@@ -50,8 +50,8 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -V
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -traceback -check arg_temp_created,bounds,format,output_conversion,stack,uninit
-ESMF_CXXOPTFLAG_G       += -traceback -Wcheck
+ESMF_F90OPTFLAG_G       += -traceback -check arg_temp_created,bounds,format,output_conversion,stack,uninit -fpe0
+ESMF_CXXOPTFLAG_G       += -traceback -Wcheck -fp-trap=common
 
 ############################################################
 # Enable TR15581/F2003 Allocatable array resizing

--- a/build_config/Unicos.nvhpc.default/build_rules.mk
+++ b/build_config/Unicos.nvhpc.default/build_rules.mk
@@ -54,6 +54,12 @@ ESMF_CXXCOMPILER_VERSION    = ${ESMF_CXXCOMPILER} --version -c
 ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version -c
 
 ############################################################
+# Special debug flags
+#
+ESMF_F90OPTFLAG_G       += -Ktrap=fp
+ESMF_CXXOPTFLAG_G       += -Ktrap=fp
+
+############################################################
 # Currently no support the Fortran2018 assumed type feature
 #
 ESMF_F90COMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE

--- a/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
@@ -31,6 +31,7 @@ program ESMF_ArrayCreateGetUTest
 ! !USES:
   use ESMF_TestMod     ! test methods
   use ESMF
+  use, intrinsic :: ieee_arithmetic
 
   implicit none
 
@@ -375,6 +376,9 @@ program ESMF_ArrayCreateGetUTest
   dataCorrect = .true.
   do j=lbound(farrayPtr2D,2), ubound(farrayPtr2D,2)
   do i=lbound(farrayPtr2D,1), ubound(farrayPtr2D,1)
+    if (ieee_is_nan(farrayPtr2DCpy(i,j))) then
+      farrayPtr2DCpy(i,j) = 0
+    endif
     write (msg,*) "farrayPtr2D(",i,",",j,")=", farrayPtr2D(i,j), &
       "  farrayPtr2DCpy(",i,",",j,")=", farrayPtr2DCpy(i,j)
     call ESMF_LogWrite(msg, ESMF_LOGMSG_INFO, rc=rc)
@@ -628,6 +632,7 @@ program ESMF_ArrayCreateGetUTest
   write(name, *) "ArrayCreate from Ptr with 3D farray on 2D DistGrid Test as Ptr"
   write(failMsg, *) "Did not return ESMF_SUCCESS"
   allocate(farrayPtr3D(-2:6,12,3:10))
+  farrayPtr3D = 0
   array = ESMF_ArrayCreate(farrayPtr=farrayPtr3D, distgrid=distgrid, &
     name="MyArray", rc=rc)
   call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)

--- a/src/Infrastructure/Array/tests/ESMF_ArrayRedistUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayRedistUTest.F90
@@ -2943,11 +2943,11 @@ write(100+localPet,*) "NBWAITFINISH: finishedflag = ", finishedflag, &
   ! 5     0         5     220, 213, 212, 211, 210, 201, 200
 !------------------------------------------------------------------------
   
-  write(msgString,*) "dstArray7(j=1): ", farrayPtr2D(1,:)
+  write(msgString,*) "dstArray7(j=1): ", (farrayPtr2D(1,i), i=lbound(farrayPtr2D, 2), ubound(farrayPtr2D, 2))
   call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-  write(msgString,*) "dstArray7(j=2): ", farrayPtr2D(2,:)
+  write(msgString,*) "dstArray7(j=2): ", (farrayPtr2D(2,i), i=lbound(farrayPtr2D, 2), ubound(farrayPtr2D, 2))
   call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-  write(msgString,*) "dstArray7(j=3): ", farrayPtr2D(3,:)
+  write(msgString,*) "dstArray7(j=3): ", (farrayPtr2D(3,i), i=lbound(farrayPtr2D, 2), ubound(farrayPtr2D, 2))
   call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
 
 !------------------------------------------------------------------------

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrv2ndUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrv2ndUTest.F90
@@ -6284,6 +6284,11 @@ end subroutine createTestMesh3x3_2
     rc=ESMF_FAILURE
     return
   endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
 
 
    ! deallocate node data

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrvUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridCsrvUTest.F90
@@ -6338,6 +6338,11 @@ contains
     rc=ESMF_FAILURE
     return
   endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
 
   
    ! deallocate node data
@@ -15259,6 +15264,11 @@ subroutine test_sph_csrv_w_frac_norm(itrp, csrv, rc)
     rc=ESMF_FAILURE
     return
   endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
 
 
    ! deallocate node data
@@ -18554,6 +18564,11 @@ end subroutine createTestMesh3x3
     rc=ESMF_FAILURE
     return
   endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
 
   ! Create source frac field
   srcFracField = ESMF_FieldCreate(srcMesh, arrayspec, meshloc=ESMF_MESHLOC_ELEMENT, &
@@ -19385,6 +19400,11 @@ end subroutine createTestMesh3x3
    srcField = ESMF_FieldCreate(srcMesh, arrayspec, &
                         meshLoc=ESMF_MESHLOC_ELEMENT, &
                         name="source", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
     rc=ESMF_FAILURE
     return

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
@@ -16206,21 +16206,19 @@ write(*,*) "LOCALRC=",localrc
   type(ESMF_Field) :: srcXtraField
   type(ESMF_Field) :: dstXtraField
   type(ESMF_Field) :: xdstXtraField
-  type(ESMF_Array) :: arrayB
-  type(ESMF_Array) :: srcArrayA
   type(ESMF_RouteHandle) :: routeHandle
   type(ESMF_ArraySpec) :: arrayspec
   type(ESMF_VM) :: vm
   integer(ESMF_KIND_I4), pointer :: maskB(:,:), maskA(:,:)
   real(ESMF_KIND_R8), pointer :: farrayPtrXC(:,:)
   real(ESMF_KIND_R8), pointer :: farrayPtrYC(:,:)
+  real(ESMF_KIND_R8), pointer :: srcPtr(:,:),dstPtr(:,:)
   real(ESMF_KIND_R8), pointer :: srcXtraPtr(:,:,:),dstXtraPtr(:,:,:)
   real(ESMF_KIND_R8), pointer :: xdstXtraPtr(:,:,:)
   integer :: clbnd(2),cubnd(2)
   integer :: fclbnd(3),fcubnd(3)
   integer :: i1,i2,i3, index(2)
   integer :: lDE, localDECount
-  real(ESMF_KIND_R8) :: coord(2)
   character(len=ESMF_MAXSTR) :: string
   integer src_nx, src_ny, dst_nx, dst_ny
   integer :: num_extra
@@ -16298,6 +16296,11 @@ write(*,*) "LOCALRC=",localrc
     rc=ESMF_FAILURE
     return
   endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
 
 
    dstField = ESMF_FieldCreate(dstGrid, arrayspec, &
@@ -16366,17 +16369,17 @@ write(*,*) "LOCALRC=",localrc
     return
   endif
 
-  ! Get arrays
+  ! Get pointer dstField
   ! arrayB
-  call ESMF_FieldGet(dstField, array=arrayB, rc=localrc)
+  call ESMF_FieldGet(dstField, localDe=0, farrayPtr=dstPtr, rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
     rc=ESMF_FAILURE
     return
   endif
 
 
-  ! srcArrayA
-  call ESMF_FieldGet(srcField, array=srcArrayA, rc=localrc)
+  ! get pointer srcField
+  call ESMF_FieldGet(srcField, localDe=0, farrayPtr=srcPtr, rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
     rc=ESMF_FAILURE
     return
@@ -21699,6 +21702,9 @@ write(*,*) "LOCALRC=",localrc
     ! Create the srcField.
     srcField =  ESMF_FieldCreate(srcGrid, typekind=ESMF_TYPEKIND_R8, &
       indexflag=ESMF_INDEX_GLOBAL, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, file=FILENAME)) return ! bail out
+    call ESMF_FieldFill(srcField, dataFillScheme="one", rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME)) return ! bail out
 
@@ -35148,6 +35154,11 @@ write(*,*) "LOCALRC=",localrc
       rc=ESMF_FAILURE
       return
   endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+      rc=ESMF_FAILURE
+      return
+  endif
   dstField = ESMF_FieldCreate(dstGrid, arrayspec, &
       staggerloc=ESMF_STAGGERLOC_CENTER, name="dest", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
@@ -35194,12 +35205,12 @@ write(*,*) "LOCALRC=",localrc
 
   ! Test Regrid for Quiet NaN
   ! Fill src and dst fields
-  call ESMF_FieldFill(srcField, dataFillScheme="nan", rc=rc)
+  call ESMF_FieldFill(srcField, dataFillScheme="nan", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
       rc=ESMF_FAILURE
       return
   endif
-  call ESMF_FieldFill(dstField, dataFillScheme="one", rc=rc)
+  call ESMF_FieldFill(dstField, dataFillScheme="one", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
       rc=ESMF_FAILURE
       return
@@ -35399,12 +35410,12 @@ write(*,*) "LOCALRC=",localrc
 
   ! Test Regrid for Signaling NaN
   ! Fill src and dst fields
-  call ESMF_FieldFill(srcField, dataFillScheme="snan", rc=rc)
+  call ESMF_FieldFill(srcField, dataFillScheme="snan", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
       rc=ESMF_FAILURE
       return
   endif
-  call ESMF_FieldFill(dstField, dataFillScheme="one", rc=rc)
+  call ESMF_FieldFill(dstField, dataFillScheme="one", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
       rc=ESMF_FAILURE
       return
@@ -36304,6 +36315,11 @@ write(*,*) "LOCALRC=",localrc
     rc=ESMF_FAILURE
     return
   endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
 
 
    ! deallocate node data
@@ -37096,6 +37112,11 @@ write(*,*) "LOCALRC=",localrc
 
    srcField = ESMF_FieldCreate(srcMesh, arrayspec, &
                         name="source", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
     rc=ESMF_FAILURE
     return
@@ -39297,6 +39318,11 @@ end subroutine test_regridSMMArbGrid
 
    srcField = ESMF_FieldCreate(srcMesh, arrayspec, &
                         name="source", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
     rc=ESMF_FAILURE
     return
@@ -42239,6 +42265,11 @@ end subroutine test_regridSMMArbGrid
 
    srcField = ESMF_FieldCreate(srcMesh, arrayspec, &
                         name="source", rc=localrc)
+  if (localrc /=ESMF_SUCCESS) then
+    rc=ESMF_FAILURE
+    return
+  endif
+  call ESMF_FieldFill(srcField, dataFillScheme="one", rc=localrc)
   if (localrc /=ESMF_SUCCESS) then
     rc=ESMF_FAILURE
     return

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridXGSMMUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridXGSMMUTest.F90
@@ -1260,6 +1260,10 @@ contains
     if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
+    call ESMF_FieldFill(f_atm, dataFillScheme="one", rc=localrc)
+    if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
 
     f_ocn = ESMF_FieldCreate(grid_ocn, typekind=ESMF_TYPEKIND_R8, rc=localrc)
     if (ESMF_LogFoundError(localrc, &
@@ -1561,6 +1565,10 @@ contains
     if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
+    call ESMF_FieldFill(f_atm, dataFillScheme="one", rc=localrc)
+    if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
 
     f_ocn = ESMF_FieldCreate(grid_ocn, typekind=ESMF_TYPEKIND_R8, rc=localrc)
     if (ESMF_LogFoundError(localrc, &
@@ -1855,6 +1863,10 @@ contains
 
     ! build Fields on the Grids
     f_atm = ESMF_FieldCreate(grid_atm, typekind=ESMF_TYPEKIND_R8, rc=localrc)
+    if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    call ESMF_FieldFill(f_atm, dataFillScheme="one", rc=localrc)
     if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
@@ -2164,6 +2176,10 @@ contains
 
     ! build Fields on the Grids
     f_atm = ESMF_FieldCreate(grid_atm, typekind=ESMF_TYPEKIND_R8, rc=localrc)
+    if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    call ESMF_FieldFill(f_atm, dataFillScheme="one", rc=localrc)
     if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
@@ -2486,6 +2502,10 @@ contains
 
     ! build Fields on the Grids
     f_atm = ESMF_FieldCreate(grid_atm, typekind=ESMF_TYPEKIND_R8, rc=localrc)
+    if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    call ESMF_FieldFill(f_atm, dataFillScheme="one", rc=localrc)
     if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return

--- a/src/Infrastructure/Field/tests/ESMF_FieldRegridXGUTest.F90
+++ b/src/Infrastructure/Field/tests/ESMF_FieldRegridXGUTest.F90
@@ -1160,6 +1160,10 @@ contains
     if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
+    call ESMF_FieldFill(f_atm, dataFillScheme="one", rc=localrc)
+    if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
 
     f_error = ESMF_FieldCreate(grid_atm, typekind=ESMF_TYPEKIND_R8, rc=localrc)
     if (ESMF_LogFoundError(localrc, &
@@ -1167,6 +1171,10 @@ contains
         ESMF_CONTEXT, rcToReturn=rc)) return
 
     f_ocn = ESMF_FieldCreate(grid_ocn, typekind=ESMF_TYPEKIND_R8, rc=localrc)
+    if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    call ESMF_FieldFill(f_ocn, dataFillScheme="one", rc=localrc)
     if (ESMF_LogFoundError(localrc, &
         ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return

--- a/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayUTest.F90
+++ b/src/Infrastructure/LocalArray/tests/ESMF_LocalArrayUTest.F90
@@ -558,7 +558,7 @@
        realptr(i,j) = i + ((j-1)*ni) + 0.1
      enddo
     enddo
-    print *, "partial print of realptr data = ", realptr(3:6,7:9)
+    print *, "partial print of realptr data = ", ((realptr(i,j),j=7,9),i=3,6)
 
     !--------------------------------------------------------------------------
     !EX_UTest
@@ -578,14 +578,14 @@
        realptr(i,j) = (i*2) + ((j-1)*ni) 
      enddo
     enddo
-    print *, "realptr data changed after nocopy set, now = ", realptr(3:6,7:9)
+    print *, "realptr data changed after nocopy set, now = ", ((realptr(i,j),j=7,9),i=3,6)
 
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     write(name, *) "Getting Local Array 2D Real Data Test"
     call ESMF_LocalArrayGet(array2, realptr2, datacopyflag=ESMF_DATACOPY_REFERENCE, rc=rc)
     print *, "array 2a get returned"
     print *, "bounds: ", lbound(realptr2), ubound(realptr2)
-    print *, "partial print of realptr2 data = ", realptr2(3:7,7:9)
+    print *, "partial print of realptr2 data = ", ((realptr2(i,j),j=7,9),i=3,7)
 
     !--------------------------------------------------------------------------
     !EX_UTest
@@ -633,7 +633,7 @@
     write(name, *) "Getting Local Array 2D Real Data Test"
     call ESMF_LocalArrayGet(array2, realptr2, datacopyflag=ESMF_DATACOPY_REFERENCE, rc=rc)
     print *, "array 2b get returned"
-    print *, "partial print of realptr2 data = ", realptr2(1:3,1:3)
+    print *, "partial print of realptr2 data = ", ((realptr2(i,j),j=1,3),i=1,3)
 
     !--------------------------------------------------------------------------
     !EX_UTest
@@ -689,11 +689,11 @@
        realptr(i,j) = (i*2) + ((j-1)*ni) 
      enddo
     enddo
-    print *, "realptr data changed after datacopyflag set, now = ", realptr(1:3,1:3)
+    print *, "realptr data changed after datacopyflag set, now = ", ((realptr(i,j),j=1,3),i=1,3)
 
     call ESMF_LocalArrayGet(array2, realptr2, datacopyflag=ESMF_DATACOPY_REFERENCE, rc=rc)
     print *, "array 2c get returned"
-    print *, "realptr2 data = ", realptr2(1:3,1:3)
+    print *, "realptr2 data = ", ((realptr2(i,j),j=1,3),i=1,3)
 
     !--------------------------------------------------------------------------
     !EX_UTest
@@ -710,7 +710,7 @@
     call ESMF_LocalArrayGet(array2, realptr2, datacopyflag=ESMF_DATACOPY_REFERENCE, rc=rc)
     call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
     print *, "array 2c get returned"
-    print *, "realptr2 data = ", realptr2(1:3,1:3)
+    print *, "realptr2 data = ", ((realptr2(i,j),j=1,3),i=1,3)
 
     !--------------------------------------------------------------------------
    !EX_UTest

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleUTest.F90
@@ -91,6 +91,11 @@ program ESMF_RouteHandleUTest
     line=__LINE__, &
     file=__FILE__)) &
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_FieldFill(fieldA, dataFillScheme="one", rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   gridB = ESMF_GridCreate1PeriDimUfrm(maxIndex=(/360, 160/), &
     minCornerCoord=(/0._ESMF_KIND_R8, -80._ESMF_KIND_R8/), &

--- a/src/Infrastructure/Util/tests/ESMF_FortranWordsizeUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_FortranWordsizeUTest.F90
@@ -58,9 +58,9 @@
       integer(ESMF_KIND_I4) :: vint4
       integer(ESMF_KIND_I8) :: vint8
 
-      real                :: vreal
-      real (ESMF_KIND_R4) :: vreal4
-      real (ESMF_KIND_R8) :: vreal8
+      real                :: vreal = 0.0
+      real (ESMF_KIND_R4) :: vreal4 = 0.0_ESMF_KIND_R4
+      real (ESMF_KIND_R8) :: vreal8 = 0.0_ESMF_KIND_R8
       
       integer :: datasize
 

--- a/src/Infrastructure/Util/tests/ESMF_TypeKindGetUTest.F90
+++ b/src/Infrastructure/Util/tests/ESMF_TypeKindGetUTest.F90
@@ -57,9 +57,9 @@
     integer(ESMF_KIND_I4) :: vint4
     integer(ESMF_KIND_I8) :: vint8
 
-    real                :: vreal
-    real (ESMF_KIND_R4) :: vreal4
-    real (ESMF_KIND_R8) :: vreal8
+    real                :: vreal = 0.0
+    real (ESMF_KIND_R4) :: vreal4 = 0.0_ESMF_KIND_R4
+    real (ESMF_KIND_R8) :: vreal8 = 0.0_ESMF_KIND_R8
     type(ESMF_TypeKind_Flag) :: typekind
 
 !-------------------------------------------------------------------------------

--- a/src/Infrastructure/VM/tests/ESMF_VMSendNbVMRecvNbUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendNbVMRecvNbUTest.F90
@@ -357,7 +357,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       !NEX_UTest
       write(name, *) "Sending local data Character String Test"
       write(failMsg, *) "Did not RETURN ESMF_SUCCESS"
-      write (char_data, "(i2.2,i3)") localPet, 1
+      write (char_data, "(i2.2,i5)") localPet, 1
       call ESMF_VMSend(vm, sendData=char_data, count=len(char_data), &
         dstPet=dst, syncflag=ESMF_SYNC_NONBLOCKING, rc=rc)
       call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
@@ -387,7 +387,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       write(name, *) "Verify local data after receive Character String Test"
       write(failMsg, *) "Wrong Local Data"
       CHSum=0
-      write (char_soln, "(i2.2,i3)") src, 1
+      write (char_soln, "(i2.2,i5)") src, 1
       if (char_test /= char_soln) CHSum = CHSum + 1
       call ESMF_Test( (CHSum == 0), name, failMsg, result, ESMF_SRCLINE)
       !------------------------------------------------------------------------
@@ -402,7 +402,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       write(name, *) "Sending local data Character String array Test"
       write(failMsg, *) "Did not RETURN ESMF_SUCCESS"
       do i=1, count
-        write (ch_data(i), "(i2.2,i3)") localPet, i
+        write (ch_data(i), "(i2.2,i5)") localPet, i
       enddo
       call ESMF_VMSend(vm, sendData=ch_data, count=count*len(ch_data), &
         dstPet=dst, syncflag=ESMF_SYNC_NONBLOCKING, rc=rc)
@@ -434,7 +434,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       write(failMsg, *) "Wrong Local Data"
       CHSum=0
       do i=1, count
-        write (char_soln, "(i2.2,i3)") src, i
+        write (char_soln, "(i2.2,i5)") src, i
         if (ch_test(i) /= char_soln) CHSum = CHSum + 1
       enddo
       call ESMF_Test( (CHSum == 0), name, failMsg, result, ESMF_SRCLINE)
@@ -696,7 +696,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       !NEX_UTest
       write(name, *) "Sending local data Character String Test"
       write(failMsg, *) "Did not RETURN ESMF_SUCCESS"
-      write (char_data, "(i2.2,i3)") localPet, 1
+      write (char_data, "(i2.2,i5)") localPet, 1
       call ESMF_VMSend(vm, sendData=char_data, count=len(char_data), &
         dstPet=dst, syncflag=ESMF_SYNC_NONBLOCKING, rc=rc)
       call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
@@ -725,7 +725,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       write(name, *) "Verify local data after receive Character String Test"
       write(failMsg, *) "Wrong Local Data"
       CHSum=0
-      write (char_soln, "(i2.2,i3)") src, 1
+      write (char_soln, "(i2.2,i5)") src, 1
       if (char_test /= char_soln) CHSum = CHSum + 1
       call ESMF_Test( (CHSum == 0), name, failMsg, result, ESMF_SRCLINE)
       !------------------------------------------------------------------------
@@ -740,7 +740,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       write(name, *) "Sending local data Character String array Test"
       write(failMsg, *) "Did not RETURN ESMF_SUCCESS"
       do i=1, count
-        write (ch_data(i), "(i2.2,i3)") localPet, i
+        write (ch_data(i), "(i2.2,i5)") localPet, i
       enddo
       call ESMF_VMSend(vm, sendData=ch_data, count=count*len(ch_data), &
         dstPet=dst, syncflag=ESMF_SYNC_NONBLOCKING, rc=rc)
@@ -771,7 +771,7 @@ program ESMF_VMSendNbVMRecvNbUTest
       write(failMsg, *) "Wrong Local Data"
       CHSum=0
       do i=1, count
-        write (char_soln, "(i2.2,i3)") src, i
+        write (char_soln, "(i2.2,i5)") src, i
         if (ch_test(i) /= char_soln) CHSum = CHSum + 1
       enddo
       call ESMF_Test( (CHSum == 0), name, failMsg, result, ESMF_SRCLINE)

--- a/src/Infrastructure/VM/tests/ESMF_VMSendVMRecvUTest.F90
+++ b/src/Infrastructure/VM/tests/ESMF_VMSendVMRecvUTest.F90
@@ -387,7 +387,7 @@ program ESMF_VMSendVMRecvUTest
       write(failMsg, *) "Did not RETURN ESMF_SUCCESS"
       if (localPet==0) then
         write(name, *) "Sending local data Character String Test"
-        write (char_data, "(i2.2,i3)") localPet, 1
+        write (char_data, "(i2.2,i5)") localPet, 1
         call ESMF_VMSend(vm, sendData=char_data, count=len(char_data), &
           dstPet=dst, rc=rc)
       else
@@ -395,7 +395,7 @@ program ESMF_VMSendVMRecvUTest
         call ESMF_VMRecv(vm, recvData=char_data, count=len(char_data), &
           srcPet=src, rc=rc)
         CHSum=0
-        write (char_soln, "(i2.2,i3)") src, 1
+        write (char_soln, "(i2.2,i5)") src, 1
         if (char_data /= char_soln) CHSum = CHSum + 1
       endif
       call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
@@ -409,11 +409,11 @@ program ESMF_VMSendVMRecvUTest
         call ESMF_VMRecv(vm, recvData=char_data, count=len(char_data), &
           srcPet=src, rc=rc)
         CHSum=0
-        write (char_soln, "(i2.2,i3)") src, 1
+        write (char_soln, "(i2.2,i5)") src, 1
         if (char_data /= char_soln) CHSum = CHSum + 1
       else
         write(name, *) "Sending local data Character String Test"
-        write (char_data, "(i2.2,i3)") localPet, 1
+        write (char_data, "(i2.2,i5)") localPet, 1
         call ESMF_VMSend(vm, sendData=char_data, count=len(char_data), &
           dstPet=dst, rc=rc)
       endif
@@ -439,7 +439,7 @@ program ESMF_VMSendVMRecvUTest
       if (localPet==0) then
         write(name, *) "Sending local data Character String array Test"
         do i=1, count
-          write (ch_data(i), "(i2.2,i3)") localPet, i
+          write (ch_data(i), "(i2.2,i5)") localPet, i
         enddo
         call ESMF_VMSend(vm, sendData=ch_data, count=count*len(ch_data), &
           dstPet=dst, rc=rc)
@@ -449,7 +449,7 @@ program ESMF_VMSendVMRecvUTest
           srcPet=src, rc=rc)
         CHSum=0
         do i=1, count
-          write (char_soln, "(i2.2,i3)") src, i
+          write (char_soln, "(i2.2,i5)") src, i
           if (ch_data(i) /= char_soln) CHSum = CHSum + 1
         enddo
       endif
@@ -465,13 +465,13 @@ program ESMF_VMSendVMRecvUTest
           srcPet=src, rc=rc)
         CHSum=0
         do i=1, count
-          write (char_soln, "(i2.2,i3)") src, i
+          write (char_soln, "(i2.2,i5)") src, i
           if (ch_data(i) /= char_soln) CHSum = CHSum + 1
         enddo
       else
         write(name, *) "Sending local data Character String array Test"
         do i=1, count
-          write (ch_data(i), "(i2.2,i3)") localPet, i
+          write (ch_data(i), "(i2.2,i5)") localPet, i
         enddo
         call ESMF_VMSend(vm, sendData=ch_data, count=count*len(ch_data), &
           dstPet=dst, rc=rc)


### PR DESCRIPTION
This PR originates from work by @danrosen25. The following compiler flags are being added to the ESMF_F90OPTFLAG_G and  ESMF_CXXPTFLAG_G variables in respective build_rules.mk files:
    * ifort -fpe0
    * icpc -fp-trap=common
    * gfortran -ffpe-trap=zero,overflow
    * nagfor -ieee=stop
    * nvhpc -Ktrap=fp

One outstanding issue we have noticed by activating the above flags is that in many of the ESMF regression tests that use RouteHandle Store() calls of any flavor (Regrid/Redist/SMM) do **not** initialize the source data before the Store() call. In a way this is on purpose, because user code might also do the same, and therefore we should test this scenario. However, this then leads to issues within the SMMStore() where actual SMM() is executed during the pre-compute step, but now has uninitialized data on the right hand side.

This issue must be resolved as part of this PR. Notice that the associated failures are system dependent, and can be non-deterministic as they depend on the specifics of the uninitialized data!

### Here are the tests that crashed (intel + mpt)
CRASHED: mpt/g: src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
CRASHED: mpt/g: src/Infrastructure/Array/tests/ESMF_ArrayRedistUTest.F90
CRASHED: mpt/g: src/Infrastructure/Field/tests/ESMF_FieldRegridCsrv2ndUTest.F90
CRASHED: mpt/g: src/Infrastructure/Field/tests/ESMF_FieldRegridCsrvUTest.F90
CRASHED: mpt/g: src/Infrastructure/Field/tests/ESMF_FieldRegridUTest.F90
CRASHED: mpt/g: src/Infrastructure/Field/tests/ESMF_FieldRegridXGSMMUTest.F90
CRASHED: mpt/g: src/Infrastructure/Field/tests/ESMF_FieldRegridXGUTest.F90
CRASHED: mpt/g: src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleCrGetUTest.F90
CRASHED: mpt/g: src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleSMMUTest.F90
CRASHED: mpt/g: src/Infrastructure/Grid/tests/ESMF_GridCreateUTest.F90
CRASHED: mpt/g: src/Infrastructure/LocalArray/tests/ESMF_LocalArrayUTest.F90
CRASHED: mpt/g: src/Infrastructure/Route/tests/ESMF_RouteHandleUTest.F90
CRASHED: mpt/g: src/Infrastructure/Util/tests/ESMF_FortranWordsizeUTest.F90
CRASHED: mpt/g: src/Infrastructure/Util/tests/ESMF_TypeKindGetUTest.F90
CRASHED: mpt/g: src/Infrastructure/VM/tests/ESMF_VMSendNbVMRecvNbUTest.F90
CRASHED: mpt/g: src/Infrastructure/VM/tests/ESMF_VMSendVMRecvUTest.F90
CRASHED: mpt/g: src/Infrastructure/XGrid/tests/ESMF_XGridMaskingUTest.F90
CRASHED: mpt/g: src/Infrastructure/XGrid/tests/ESMF_XGridUTest.F90
CRASHED: mpt/g: src/Superstructure/PreESMFMod/tests/ESMF_FileRegridUTest.F90
CRASHED: mpt/g: src/Superstructure/PreESMFMod/tests/ESMF_RegridWeightGenUTest.F90

### RESEARCH NOTES

**Intel**
For the 'intel' combos add -fpe0 to the ESMF_F90OPTFLAG_G in the respective build_rules.mk.
For the 'intel' combos add -fp-trap=common to the ESMF_CXXPTFLAG_G in the respective build_rules.mk

**GCC**
For the 'gfortran' and 'gfortranclang' combos add -ffpe-trap=zero,overflow to the ESMF_F90OPTFLAG_G in the respective build_rules.mk. Notice that I don't think we can add the "invalid" option here, because (as far as I could figure out) gfortran for GCC < v12 will otherwise abort even on quite NANs!
For the g++ part, let's not make any changes here!

**NAG**
For the 'nag' combo add -ieee=stop to the ESMF_F90OPTFLAG_G in the respective build_rules.mk.

**NVHPC**
Since this is a run-time environment variable, let me work on that part via the esmf-test-scripts. I will do some testing. Thanks for doing the research!

Let's not worry about any of the other compilers for 8.5.0.