### PR TITLE
[ESMpy] Guess esmf.mk locations

### DIFF
--- a/src/addon/esmpy/doc/install.rst
+++ b/src/addon/esmpy/doc/install.rst
@@ -62,15 +62,7 @@ Installing ESMPy from Source
 ----------------------------
 
 When installing from source, ESMPy uses `pip <https://pypi.org/project/pip//>`_ 
-to build and install the package. This requires setting an environment variable 
-pointing to a file named esmf.mk that is generated during an ESMF installation.  
-The path of this file is:
-
-.. code::
-
-    <ESMF_INSTALL_DIR>/lib/lib<g<or>O>/<platform>/esmf.mk
-
-An installation of ESMPy in the default location for Python packages can be done
+to build and install the package. An installation of ESMPy in the default location for Python packages can be done
 with the following command issued from the top level ESMPy directory (``src/addon/esmpy``):
 
 .. code::
@@ -93,7 +85,8 @@ To use ESMPy in an external program, import it with:
 
     import esmpy
 
-The environment variable ``ESMFMKFILE`` must be set when using ESMPy.
+The environment variable ``ESMFMKFILE`` should be set when using ESMPy. If it is not found, the package will
+try to guess a few very common locations, but we recommend correctly setting the variable nonetheless.
 
 .. Note::
 

--- a/src/addon/esmpy/src/esmpy/interface/loadESMF.py
+++ b/src/addon/esmpy/src/esmpy/interface/loadESMF.py
@@ -24,8 +24,18 @@ except:
 esmfmk = None
 try:
     esmfmk = os.environ["ESMFMKFILE"]
-except:
-    raise ImportError('The ESMFMKFILE environment variable is not available.')
+except KeyError:
+    # Try to guess with very common paths in normal installs (especially conda)
+    guesses = [
+        os.path.join(sys.prefix, 'lib', 'esmf.mk'),  # conda build of esmf
+        os.path.join(sys.prefix, 'Library', 'lib', 'esmf.mk')
+    ]
+    for path in guesses:
+        if os.path.isfile(path):
+            esmfmk = path
+            break
+    else:
+        raise ImportError('The esmf.mk file cannot be found. Pass its path in the ESMFMKFILE environment variable.')
 
 #### INVESTIGATE esmf.mk ######################################################
 


### PR DESCRIPTION
This fixes #117 and should adress conda-forge/esmf-feedstock#91 and many issues on xESMF.

This adds a "guessing" snippet to `loadESMF.py` for cases when the `ESMFMKFILE` env var is not set.

The new behaviour in 8.4 was to depend on the env variable. The `ESMpy` conda package was updated so that this env var is set upon environment activation. However, there are many cases in which a conda env is used _without_ being activated:
- when used as a kernel in a jupyter lab/notebook instance
- when used to build documentation on ReadTheDocs
- when used as a kernel in some fancy IDEs (PyCharm for example)

This new behaviour generated many issues in xESMF, raised by users who do not really know about the mechanics of ESMF/ESMpy. This PR is in part to help those users, who rely on the "out-of-the-box" aspect of conda.

The two paths I added to the guessing are the same that `ESMpy` already guesses in its conda recipe. See: https://github.com/conda-forge/esmpy-feedstock/blob/60527fe641e89da9e2ab0b3f93a5b6f67a0d20f8/recipe/scripts/activate.sh#L11-L15

Thus I am suggesting replicating the "guessing" part from ESMpy's conda configuration directly in its code.

I also removed a few lines from the documentation. Unless I am mistaken, installing ESMpy from source does _not_ require the `esmf.mk` file anymore, no? 