### PR TITLE
Improve HConfig/ESMX integration and associated clean-up and improvements

### DIFF
--- a/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
+++ b/src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90
@@ -4720,6 +4720,9 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
     logical                         :: rhListMatch
     type(ESMF_RouteHandle)          :: rhh
     logical                         :: verbosityFlagIntl
+    character(ESMF_MAXSTR)          :: fName
+    integer                         :: dimCount, rank
+    character(800)                  :: msgString
 
     verbosityFlagIntl = .false. ! default
     if (present(verbosityFlag)) verbosityFlagIntl = verbosityFlag
@@ -4733,6 +4736,27 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
     if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
       ESMF_CONTEXT, rcToReturn=rc)) return
 
+    if (verbosityFlagIntl) then
+      call ESMF_FieldGet(srcField, name=fName, dimCount=dimCount, rank=rank, &
+        rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      write(msgString,'(4A,I2,A,I2)') ESMF_METHOD, ": srcField: ", trim(fName), &
+        " dimCount=", dimCount, " rank=", rank
+      call ESMF_LogWrite(msgString, ESMF_LOGMSG_DEBUG, rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      call ESMF_FieldGet(dstField, name=fName, dimCount=dimCount, rank=rank, &
+        rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      write(msgString,'(4A,I2,A,I2)') ESMF_METHOD, ": dstField: ", trim(fName), &
+        " dimCount=", dimCount, " rank=", rank
+      call ESMF_LogWrite(msgString, ESMF_LOGMSG_DEBUG, rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    endif
+
     rhReuse = ((srcGeomtype==ESMF_GEOMTYPE_GRID) .or. &
                (srcGeomtype==ESMF_GEOMTYPE_MESH))
     rhReuse = rhReuse .and. ((dstGeomtype==ESMF_GEOMTYPE_GRID) .or. &
@@ -4745,17 +4769,13 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
 
       if (verbosityFlagIntl) then
         call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
-          ": Inside 'rhReuse' branch!"), &
-          ESMF_LOGMSG_DEBUG)
+          ": Inside 'rhReuse' branch!"), ESMF_LOGMSG_DEBUG, rc=localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
       endif
 
       ! access src side information
       if (srcGeomtype==ESMF_GEOMTYPE_GRID) then
-        if (verbosityFlagIntl) then
-          call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
-            ": srcGeomtype==ESMF_GEOMTYPE_GRID"), &
-            ESMF_LOGMSG_DEBUG)
-        endif
         call ESMF_FieldGet(srcField, grid=srcGrid, staggerLoc=srcStaggerLoc, &
           rc=localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
@@ -4763,17 +4783,26 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
         call ESMF_GridGet(srcGrid, dimCount=geomDimCount, rc=localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-      else if (srcGeomtype==ESMF_GEOMTYPE_MESH) then
         if (verbosityFlagIntl) then
-          call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
-            ": srcGeomtype==ESMF_GEOMTYPE_MESH"), &
-            ESMF_LOGMSG_DEBUG)
+          write(msgString,'(2A,I2)') ESMF_METHOD, &
+            ": srcGeomtype==ESMF_GEOMTYPE_GRID dimCount=", geomDimCount
+          call ESMF_LogWrite(msgString, ESMF_LOGMSG_DEBUG, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
         endif
+      else if (srcGeomtype==ESMF_GEOMTYPE_MESH) then
         call ESMF_FieldGet(srcField, mesh=srcMesh, meshLoc=srcMeshLoc, &
           rc=localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
         geomDimCount = 1  ! Mesh always stored on 1D DistGrid
+        if (verbosityFlagIntl) then
+          write(msgString,'(2A,I2)') ESMF_METHOD, &
+            ": srcGeomtype==ESMF_GEOMTYPE_MESH dimCount=", geomDimCount
+          call ESMF_LogWrite(msgString, ESMF_LOGMSG_DEBUG, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+        endif
       endif
       allocate(srcGridToFieldMap(geomDimCount))
       allocate(srcUngriddedLBound(fieldDimCount-geomDimCount), &
@@ -4786,11 +4815,6 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
 
       ! access dst side information
       if (dstGeomtype==ESMF_GEOMTYPE_GRID) then
-        if (verbosityFlagIntl) then
-          call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
-            ": dstGeomtype==ESMF_GEOMTYPE_GRID"), &
-            ESMF_LOGMSG_DEBUG)
-        endif
         call ESMF_FieldGet(dstField, grid=dstGrid, staggerLoc=dstStaggerLoc, &
           rc=localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
@@ -4798,17 +4822,26 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
         call ESMF_GridGet(dstGrid, dimCount=geomDimCount, rc=localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-      else if (dstGeomtype==ESMF_GEOMTYPE_MESH) then
         if (verbosityFlagIntl) then
-          call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
-            ": dstGeomtype==ESMF_GEOMTYPE_MESH"), &
-            ESMF_LOGMSG_DEBUG)
+          write(msgString,'(2A,I2)') ESMF_METHOD, &
+            ": dstGeomtype==ESMF_GEOMTYPE_GRID dimCount=", geomDimCount
+          call ESMF_LogWrite(msgString, ESMF_LOGMSG_DEBUG, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
         endif
+      else if (dstGeomtype==ESMF_GEOMTYPE_MESH) then
         call ESMF_FieldGet(dstField, mesh=dstMesh, meshLoc=dstMeshLoc, &
           rc=localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
         geomDimCount = 1  ! Mesh always stored on 1D DistGrid
+        if (verbosityFlagIntl) then
+          write(msgString,'(2A,I2)') ESMF_METHOD, &
+            ": dstGeomtype==ESMF_GEOMTYPE_MESH dimCount=", geomDimCount
+          call ESMF_LogWrite(msgString, ESMF_LOGMSG_DEBUG, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+        endif
       endif
       allocate(dstGridToFieldMap(geomDimCount))
       allocate(dstUngriddedLBound(fieldDimCount-geomDimCount), &
@@ -4997,7 +5030,9 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
       if (verbosityFlagIntl) then
         call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
           ": no rhListMatch -> pre-compute new remapping!"), &
-          ESMF_LOGMSG_DEBUG)
+          ESMF_LOGMSG_DEBUG, rc=localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
       endif
       if (rhReuse) then
         ! add a new rhList element
@@ -5011,7 +5046,9 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
         if (verbosityFlagIntl) then
           call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
             ": able to reuse already precomputed weight matrix!"), &
-            ESMF_LOGMSG_DEBUG)
+            ESMF_LOGMSG_DEBUG, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
         endif
         factorList=>rhListG%factorList
         factorIndexList=>rhListG%factorIndexList
@@ -5028,7 +5065,9 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
         if (verbosityFlagIntl) then
           call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
             ": must precompute full regridding!"), &
-            ESMF_LOGMSG_DEBUG)
+            ESMF_LOGMSG_DEBUG, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
         endif
         factorList=>NULL()
         factorIndexList=>NULL()
@@ -5128,7 +5167,9 @@ call ESMF_LogWrite("found rhListMatch -> reuse routehandle!", &
       if (verbosityFlagIntl) then
         call ESMF_LogWrite(ESMF_StringConcat(ESMF_METHOD, &
           ": found rhListMatch -> reuse routehandle!"), &
-          ESMF_LOGMSG_DEBUG)
+          ESMF_LOGMSG_DEBUG, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
       endif
       ! pull out the routehandle from the matching rhList element
       rhh = rhListE%rh

--- a/src/Infrastructure/HConfig/examples/ESMF_HConfigEx.F90
+++ b/src/Infrastructure/HConfig/examples/ESMF_HConfigEx.F90
@@ -94,7 +94,7 @@ program ESMF_HConfigEx
 !
 ! One way to parse the elements contained in {\tt hconfig} is to use the
 ! iterator pattern known from laguages such as C++ or Python. HConfig
-! iterators are implemented as regular {\tt type(ESMF\_HConfig)} objects that
+! iterators are implemented as {\tt type(ESMF\_HConfigIter)} objects that
 ! are initialized using one of the {\tt HConfigIter*()} methods. An iterator
 ! can then be used to traverse the elements in a {\em sequence} or {\em map}
 ! by calling the {\tt ESMF\_HConfigIterNext()} method, taking one step forward
@@ -430,6 +430,7 @@ program ESMF_HConfigEx
 ! the {\em map key} or {\em map value}, respectively.
 !EOE
 !BOC
+  ! type(ESMF_HConfigIter) :: hconfigIter
   hconfigIter = hconfigIterBegin
   do while (ESMF_HConfigIterLoop(hconfigIter, hconfigIterBegin, hconfigIterEnd, rc=rc))
 !EOC

--- a/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
+++ b/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
@@ -234,6 +234,8 @@ module ESMF_HConfigMod
   public ESMF_HConfigSetMapKey
   public ESMF_HConfigSetMapVal
 
+  public ESMF_HConfigValidateMapKeys
+
 ! - ESMF-internal methods:
   public ESMF_HConfigGetInit
 !EOPI
@@ -7166,7 +7168,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
 
 
-
 ! -------------------------- ESMF-public method -------------------------------
 #undef  ESMF_METHOD
 #define ESMF_METHOD "ESMF_HConfigCreateHConfig()"
@@ -9610,7 +9611,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
   end function
 !------------------------------------------------------------------------------
-
 
 
 ! -------------------------- ESMF-public method -------------------------------
@@ -13586,6 +13586,102 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present(rc)) rc = ESMF_SUCCESS
 
   end subroutine
+!------------------------------------------------------------------------------
+
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_HConfigValidateMapKeys()"
+!BOP
+! !IROUTINE: ESMF_HConfigValidateMapKeys - Validate map keys against list of vocabulary
+
+! !INTERFACE:
+  function ESMF_HConfigValidateMapKeys(hconfig, vocabulary, keywordEnforcer, &
+    badKey, rc)
+!
+! !RETURN VALUE:
+    logical :: ESMF_HConfigValidateMapKeys
+!
+! !ARGUMENTS:
+    type(ESMF_HConfig),        intent(in)            :: hconfig
+    character(len=*),          intent(in)            :: vocabulary(:)
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    character(:), allocatable, intent(out), optional :: badKey
+    integer,                   intent(out), optional :: rc
+!
+! !DESCRIPTION:
+!   Validate that the {\em map} held in {\tt hconfig} only uses {\em keys} that
+!   are listed in {\tt vocabulary}.
+!
+!   The arguments are:
+!   \begin{description}
+!   \item[hconfig]
+!     A map HConfig object.
+!   \item[vocabulary]
+!     List of {\em keys} to validate against.
+!   \item[{[badKey]}]
+!     If returning {\tt .false.} with {\tt ESMF\_SUCCESS}, then {\tt badKey} is
+!     set to the first {\em key} in {\tt hconfig} that was {\em not} found in
+!     {\tt vocabulary}.
+!   \item[{[rc]}]
+!     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
+!   \end{description}
+!
+!EOP
+!------------------------------------------------------------------------------
+    integer                   :: localrc        ! local return code
+    type(ESMF_HConfigIter)    :: hconfigIter, hconfigIterBegin, hconfigIterEnd
+    logical                   :: isFlag
+    character(:), allocatable :: key
+
+    ! initialize return code; assume routine not implemented
+    localrc = ESMF_RC_NOT_IMPL
+    if (present(rc)) rc = ESMF_RC_NOT_IMPL
+
+    ! initialize return value
+    ESMF_HConfigValidateMapKeys = .false.
+
+    ! ensure hconfig is map
+    isFlag = ESMF_HConfigIsMap(hconfig, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    if (.not.isFlag) then
+      call ESMF_LogSetError(ESMF_RC_ARG_INCOMP, &
+        msg="HConfig must be a map.", &
+        ESMF_CONTEXT, rcToReturn=rc)
+      return
+    endif
+
+    ! prepare iterators
+    hconfigIterBegin = ESMF_HConfigIterBegin(hconfig, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    hconfigIterEnd = ESMF_HConfigIterEnd(hconfig, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+
+    ! iterate over hconfig validating each key
+    ESMF_HConfigValidateMapKeys = .true.
+    hconfigIter = hconfigIterBegin
+    do while (ESMF_HConfigIterLoop(hconfigIter, hconfigIterBegin, &
+      hconfigIterEnd, rc=localrc))
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      key = ESMF_HConfigAsStringMapKey(hconfigIter, rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      if (.not. any(key==vocabulary)) then
+        ESMF_HConfigValidateMapKeys = .false.
+        if (present(rc)) rc = ESMF_SUCCESS
+        if (present(badKey)) badKey = key
+        return
+      endif
+    enddo
+
+    ! return successfully
+    if (present(rc)) rc = ESMF_SUCCESS
+
+  end function ESMF_HConfigValidateMapKeys
 !------------------------------------------------------------------------------
 
 

--- a/src/Infrastructure/HConfig/tests/ESMF_HConfigUTest.F90
+++ b/src/Infrastructure/HConfig/tests/ESMF_HConfigUTest.F90
@@ -62,6 +62,7 @@ program ESMF_HConfigUTest
   real              :: realList1(5), realList2(5)
   character(80)     :: strList1(3), strList2(3)
   real              :: realTable1(7,3), realTable2(7,3)
+  character(:), allocatable :: badKey
 
   logical :: raw = .false. ! switch ConfigLog() into "raw" mode or not
 
@@ -121,6 +122,35 @@ program ESMF_HConfigUTest
   write(failMsg, *) "Did not return ESMF_SUCCESS"
   call HConfigIterationTest(hconfig, rc=rc)
   call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !------------------------------------------------------------------------
+
+  !------------------------------------------------------------------------
+  !NEX_UTest
+  write(name, *) "Validate HConfig against vocabulary"
+  write(failMsg, *) "Did not return ESMF_SUCCESS"
+  compareOK = ESMF_HConfigValidateMapKeys(hconfig, &
+    vocabulary=["my_file_names      ", &
+                "constants          ", &
+                "my_favorite_colors ", &
+                "radius_of_the_earth", &
+                "parameter_1        ", &
+                "parameter_2        ", &
+                "input_file_name    ", &
+                "value_one          ", &
+                "value_two          ", &
+                "value_three        ", &
+                "value_four         ", &
+                "my_table_name      "  &
+               ], badKey=badKey, rc=rc)
+  call ESMF_Test((rc.eq.ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !------------------------------------------------------------------------
+
+  !------------------------------------------------------------------------
+  !NEX_UTest
+  write(name, *) "Validation result of HConfig against vocabulary"
+  write(failMsg, *) "Not as expected"
+  if (allocated(badKey)) write(failMsg, *) "Not as expected, badKey: "//badKey
+  call ESMF_Test((compareOK), name, failMsg, result, ESMF_SRCLINE)
   !------------------------------------------------------------------------
 
   !------------------------------------------------------------------------

--- a/src/addon/ESMX/Comps/ESMX_Data/ESMX_Data.F90
+++ b/src/addon/ESMX/Comps/ESMX_Data/ESMX_Data.F90
@@ -761,7 +761,7 @@ module esmx_data
     integer            :: stat
     logical            :: check
     type(ESMF_HConfig) :: outcfg
-    character(len=64)  :: cfgval
+    character(:), allocatable  :: cfgval
 
     rc = ESMF_SUCCESS
 
@@ -930,7 +930,7 @@ module esmx_data
     type(ESMF_HConfigIter)     :: flistcur
     type(ESMF_HConfigIter)     :: flistbeg
     type(ESMF_HConfigIter)     :: flistend
-    character(ESMF_MAXSTR)     :: fname
+    character(:), allocatable  :: fname
     type(xdata_field), pointer :: xfield
 
     rc = ESMF_SUCCESS
@@ -972,7 +972,7 @@ module esmx_data
           line=__LINE__, file=__FILE__)) return
         if (.not. check) then
           call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
-            msg=trim(xstate%cname)//": ("//trim(fname)//")" //&
+            msg=trim(xstate%cname)//": ("//fname//")" //&
             " valid options for importFields (dim, min, max)", &
           line=__LINE__,file=__FILE__, rcToReturn=rc)
           return
@@ -1053,7 +1053,7 @@ module esmx_data
           line=__LINE__, file=__FILE__)) return
         if (.not. check) then
           call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
-            msg=trim(xstate%cname)//": ("//trim(fname)//")" //&
+            msg=trim(xstate%cname)//": ("//fname//")" //&
             " valid options for exportFields (dim, val)", &
           line=__LINE__,file=__FILE__, rcToReturn=rc)
           return
@@ -1597,7 +1597,7 @@ module esmx_data
 
   function x_comp_hconfig_str(hconfig, key, defaultValue, rc)
     ! return value
-    character(ESMF_MAXSTR) :: x_comp_hconfig_str
+    character(:), allocatable :: x_comp_hconfig_str
     ! arguments
     type(ESMF_HConfig), intent(in)     :: hconfig
     character(*), intent(in)           :: key

--- a/src/addon/ESMX/Comps/ESMX_Data/ESMX_Data.F90
+++ b/src/addon/ESMX/Comps/ESMX_Data/ESMX_Data.F90
@@ -552,6 +552,7 @@ module esmx_data
     integer                    :: fc
     type(ESMF_Field), pointer  :: fl(:)
     type(ESMF_FieldBundle)     :: fb
+    character(ESMF_MAXSTR)     :: fieldName
 
     rc = ESMF_SUCCESS
 
@@ -574,12 +575,14 @@ module esmx_data
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return
 
+    ! access import- and exportState
+    call NUOPC_ModelGet(xdata, importState=importState, &
+      exportState=exportState, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, file=__FILE__)) return
+
     ! write final import and export states
     if (xstate%write_final) then
-      call NUOPC_ModelGet(xdata, importState=importState, &
-        exportState=exportState, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, file=__FILE__)) return
       call NUOPC_GetStateMemberCount(importState, fieldCount=fc, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=__FILE__)) return
@@ -624,10 +627,16 @@ module esmx_data
       endif
     endif
 
-    ! destroy import fields
+    ! remove import fields from importState and destroy
     do while (associated(xstate%imp_flds_head))
       xfield => xstate%imp_flds_head
       xstate%imp_flds_head => xfield%nfld
+      call ESMF_FieldGet(xfield%efld, name=fieldName, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=__FILE__)) return
+      call ESMF_StateRemove(importState, (/fieldName/), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=__FILE__)) return
       call ESMF_FieldDestroy(xfield%efld, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=__FILE__)) return
@@ -641,10 +650,16 @@ module esmx_data
     enddo
     xstate%imp_flds_tail => null()
 
-    ! destroy export fields
+    ! remove export fields from exportState and destroy
     do while (associated(xstate%exp_flds_head))
       xfield => xstate%exp_flds_head
       xstate%exp_flds_head => xfield%nfld
+      call ESMF_FieldGet(xfield%efld, name=fieldName, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=__FILE__)) return
+      call ESMF_StateRemove(exportState, (/fieldName/), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=__FILE__)) return
       call ESMF_FieldDestroy(xfield%efld, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=__FILE__)) return
@@ -1511,7 +1526,7 @@ module esmx_data
     rc = ESMF_SUCCESS
     x_comp_hconfig_i4 = 0
 
-    isPresent = ESMF_HConfigIsMap(hconfig, keyString=key, rc=rc)
+    isPresent = ESMF_HConfigIsScalar(hconfig, keyString=key, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return
 
@@ -1553,7 +1568,7 @@ module esmx_data
     rc = ESMF_SUCCESS
     x_comp_hconfig_r8 = 0.0_ESMF_KIND_R8
 
-    isPresent = ESMF_HConfigIsDefined(hconfig, keyString=key, rc=rc)
+    isPresent = ESMF_HConfigIsScalar(hconfig, keyString=key, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return
 
@@ -1595,7 +1610,7 @@ module esmx_data
     rc = ESMF_SUCCESS
     x_comp_hconfig_str = ' '
 
-    isPresent = ESMF_HConfigIsDefined(hconfig, keyString=key, rc=rc)
+    isPresent = ESMF_HConfigIsScalar(hconfig, keyString=key, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return
 
@@ -1637,7 +1652,7 @@ module esmx_data
     rc = ESMF_SUCCESS
     x_comp_hconfig_logical = .false.
 
-    isPresent = ESMF_HConfigIsDefined(hconfig, keyString=key, rc=rc)
+    isPresent = ESMF_HConfigIsScalar(hconfig, keyString=key, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return
 

--- a/src/addon/ESMX/Comps/ESMX_Data/README.md
+++ b/src/addon/ESMX/Comps/ESMX_Data/README.md
@@ -1,6 +1,6 @@
 # ESMX Data Component
 
-The ESMX Data component is a lightweight testing component. Each ESMX Data component provides a custom list of export fields with prescribed values and a custom list of import fields with value ranges for testing validity. Multiple ESMX Data components can be used in the same application for testing complex sets of connected components.
+The ESMX Data component is a lightweight testing component that derives from `NUOPC_Model`. Each ESMX Data component provides a custom list of export fields with prescribed values and a custom list of import fields with value ranges for testing validity. Multiple ESMX Data components can be used in the same application for testing complex sets of connected components.
 
 ## ESMX Data Build Configuration
 

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -23,7 +23,7 @@ program ESMX_App
   type(ESMF_HConfig)        :: hconfig, hconfigNode
   character(:), allocatable :: configKey(:)
   character(:), allocatable :: valueString
-  logical                   :: isPresent, logFlush
+  logical                   :: isFlag, logFlush
   type(ESMF_Time)           :: startTime, stopTime
   type(ESMF_TimeInterval)   :: timeStep
   type(ESMF_Clock)          :: clock
@@ -45,23 +45,44 @@ program ESMX_App
 
   ! Find hconfigNode that holds app level settings according to configKey
   hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
-    foundFlag=isPresent, rc=rc)
+    foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  if (.not.isPresent) then
+  if (.not.isFlag) then
     call ESMF_LogSetError(ESMF_RC_ARG_INCOMP, &
       msg="Must provide settings for: "//configKey(1)//":"//configKey(2), &
       line=__LINE__, file=FILENAME, rcToReturn=rc)
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
   endif
 
-  ! Set logFlush
-  isPresent = ESMF_HConfigIsDefined(hconfigNode, keyString="logFlush", rc=rc)
+  ! Validate hconfigNode against ESMX/App controlled key vocabulary
+  isFlag = ESMF_HConfigValidateMapKeys(hconfigNode, &
+    vocabulary=["defaultLogFilename   ", & ! ESMF_Initialize option
+                "logAppendFlag        ", & ! ESMF_Initialize option
+                "logKindFlag          ", & ! ESMF_Initialize option
+                "globalResourceControl", & ! ESMF_Initialize option
+                "startTime            ", & ! ESMX_App option
+                "stopTime             ", & ! ESMX_App option
+                "logFlush             ", & ! ESMX_App option
+                "fieldDictionary      "  & ! ESMX_App option
+                ], badKey=valueString, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  if (isPresent) then
+  if (.not.isFlag) then
+    call ESMF_LogSetError(ESMF_RC_ARG_WRONG, &
+      msg="An invalid key was found in config under ESMX/App (maybe a typo?): "//valueString, &
+      line=__LINE__, file=FILENAME, rcToReturn=rc)
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  endif
+
+  ! Set logFlush
+  isFlag = ESMF_HConfigIsDefined(hconfigNode, keyString="logFlush", rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, file=FILENAME)) &
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  if (isFlag) then
     logFlush = ESMF_HConfigAsLogical(hconfigNode, keyString="logFlush", rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME)) &
@@ -90,12 +111,12 @@ program ESMX_App
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   ! Set field dictionary
-  isPresent = ESMF_HConfigIsDefined(hconfigNode, keyString="fieldDictionary", &
+  isFlag = ESMF_HConfigIsDefined(hconfigNode, keyString="fieldDictionary", &
     rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  if (isPresent) then
+  if (isFlag) then
     valueString = ESMF_HConfigAsString(hconfigNode, &
       keyString="fieldDictionary", rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -159,11 +180,11 @@ program ESMX_App
   ! Find hconfigNode that holds driver level attributes, conditionally ingest
   configKey = ["ESMX      ", "Driver    ", "attributes"]
   hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
-    foundFlag=isPresent, rc=rc)
+    foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  if (isPresent) then
+  if (isFlag) then
     call NUOPC_CompAttributeIngest(driver, hconfigNode, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME)) &

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -108,9 +108,11 @@ tests:
     dir: path/to/test/data
 ```
 
-In this example two components are built into `esmx_app` explicitly. (Read about [dynamically loading of components from shared objects at run-time](#dynamically-loading-components-from-shared-objects-at-run-time) later.) The `ESMX_Data` component is built into `esmx_app` by default. This example disables this behavior.
+In this example two components are built into `esmx_app` explicitly. (Read about [dynamically loading of components from shared objects at run-time](#dynamically-loading-components-from-shared-objects-at-run-time) later.) Each component is given a name, here `TaWaS` and `Lumo`, respectively. Components will be referenced by this *component-name* in the run-time configuration (`esmxRun.yaml`) discussed below.
 
-Each component is given a name, here `TaWaS` and `Lumo`, respectively. Components will be referenced by this *component-name* in the run-time configuration (esmxRun.yaml) discussed below. Component names are case-sensitive!
+**CAUTION:** Component names are case-sensitive when used e.g. by default to construct library names, etc. However, they are treated case-insensitive when referenced from within the `esmxRun.yaml` file due to the case-insensitive nature of Fortran when referencing modules via the USE statement.
+
+ESMX comes with a default data component called `ESMX_Data`. It is built into `esmx_app` by default. This example disables this behavior by setting `disable_comps: ESMX_Data`.
 
 There are *three* top level sections recognized in the ESMX build file. Each is introduced by a specific key using the [YAML](https://yaml.org/) map syntax: `application:`, `components:`, and `tests:`. The value associated with each key is a map of key/value pairs. The available option keys under each top level section are discussed below.
 
@@ -165,7 +167,7 @@ This section contains a key for for each *component-name*, specifying component 
 | `test_exe`       | executable used to run test case              | ESMX_TEST_EXE          |
 | `test_tasks`     | number of tasks used to run test case         | ESMX_TEST_TASKS        |
 
-**Caution:** Downloading components using the `git_repository` option will result in a detached head. Developers making changing to component code must create or checkout a branch before making code changes. Downloading component using git_repository fails if the source_dir already exists.
+**CAUTION:** Downloading components using the `git_repository` option will result in a detached head. Developers making changing to component code must create or checkout a branch before making code changes. Downloading component using git_repository fails if the source_dir already exists.
 
 ##### Build Types:
 
@@ -331,7 +333,7 @@ The run-time configuration needed by `ESMX_Driver` can either be supplied by the
 
 ## ESMX Components
 
-ESMX includes a data component, which can be used for testing NUOPC caps. See documentation [here](Comps/ESMX_Data/README.md).
+ESMX includes a data component, which can be used for testing NUOPC caps. This component is known as [`ESMX_Data`](Comps/ESMX_Data).
 
 ## ESMX Software Dependencies
 

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -257,7 +257,9 @@ This section affects the application level.
 | `globalResourceControl`   | enable/disable global resource control: `true` or `false` | `false`         |
 | `logKindFlag`             | string constant setting ESMF logging kind, see ESMF RefDoc| `ESMF_LOGKIND_Multi_On_Error`|
 | `logAppendFlag`           | enable/disable log append: `true` or `false`              | `true`          |
+| `defaultLogFilename`      | name of the default ESMF log file (suffix if multi PET)   | `ESMF_LogFile`  |
 | `logFlush`                | enable/disable log flush for each write: `true` or `false`| `false`         |
+| `fieldDictionary`         | name of the NUOPC field dictionary file to be loaded      | *None*          |
 
 #### ESMX/Driver Options
 
@@ -266,18 +268,20 @@ This section affects the driver level.
 | Option key      | Description / Value options                                          | Default         |
 | --------------- | -------------------------------------------------------------------- | --------------- |
 | `componentList` | list of component labels, each matching a top level key in this file | *non-optional*  |
-| `attributes`    | map of key value pairs, each defining a driver attribute             | *None*          |
 | `runSequence`   | block literal string defining the run sequence                       | *NUOPC default* |
+| `attributes`    | map of key value pairs, each defining a driver attribute             | *None*          |
 
 #### Component Label Options
 
 This section affects the specific component instance.
 
-| Option key    | Description / Value options                                          | Default         |
-| ------------- | -------------------------------------------------------------------- | --------------- |
-| `model`       | string associating the instance with a *component-name* defined in `esmxBuild.yaml` | *non-optional*  |
-| `petList`     | list of PETs on which the component executes                         | *None*          |
-| `attributes`  | map of key value pairs, each defining a component attribute          | *None*          |
+| Option key            | Description / Value options                                           | Default         |
+| --------------------- | --------------------------------------------------------------------- | --------------- |
+| `model`               | string associating the instance with a *component-name* defined in `esmxBuild.yaml` | *non-optional*  |
+| `petList`             | list of PETs on which the component executes                          | *None*          |
+| `ompNumThreads`       | setting of /NUOPC/Hint/PePerPet/MaxCount (see NUOPC ref doc)          | *None*          |
+| `attributes`          | map of key value pairs, each defining a component attribute           | *None*          |
+| *model specific yaml* | each model can define its own YAML section, e.g. with key value pairs, etc. | *None*          |
 
 ### Dynamically loading components from shared objects at run-time
 


### PR DESCRIPTION
This PR is aimed at branch feature/esmx_cmake. It brings in a few changes that should be part of the final PR #106.

Overview of changes:
- Implementation of `ESMF_HConfigValidateMapKeys()`, and usage from ESMX.
- `ESMX_Data` minor changes to robustify.
- Minor doc changes.