### PR TITLE
Fix ESMF_FieldGet localElementCount

### DIFF
--- a/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
@@ -631,9 +631,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     endif
 
     if(present(minIndex) .or. present(maxIndex) .or. &
-      present(elementCount) .or. &
-      present(localminIndex) .or. present(localmaxIndex) .or. &
-      present(localelementCount) ) then
+      present(elementCount)) then
 
       call ESMF_ArrayGet(ftype%array, rank=fieldrank, &
           localDeCount=localDeCount, &
@@ -646,13 +644,9 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       endif
 
       allocate(l_min(fieldrank), l_max(fieldrank), l_elecount(fieldrank))
-      allocate(ll_min(fieldrank), ll_max(fieldrank), ll_elecount(fieldrank))
       l_min = -1
       l_max = -1
       l_elecount = -1
-      ll_min = -1
-      ll_max = -1
-      ll_elecount = -1
 
       if(present(minIndex)) then
           if(size(minIndex) .ne. fieldrank) then
@@ -678,6 +672,211 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
              return
           endif
       endif
+
+      call ESMF_GeomGet(ftype%geom, geomtype=localGeomType, rc=localrc)
+      if (ESMF_LogFoundError(localrc, &
+        ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+
+      if(localGeomType == ESMF_GEOMTYPE_GRID) then
+        call ESMF_GeomGet(ftype%geom, &
+                  grid=l_grid, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        call ESMF_GridGet(l_grid, distgrid=distgrid, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        call ESMF_DistGridGet(distgrid, localdecount=ldecount, &
+          decount=decount, dimcount=dg_dimcount, tilecount=tilecount, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+
+        allocate(dg2gmap(dg_dimcount), dg2fmap(dg_dimcount))
+        allocate(isDist(fieldrank))
+
+        call ESMF_GridGet(l_grid, distgridToGridMap=dg2gmap, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+
+        dg2fmap = -1
+        isDist = .false.
+        do i = 1, dg_dimcount
+          dg2fmap(i) = ftype%gridToFieldMap(i)
+          isDist(dg2fmap(i)) = .true.
+        enddo
+        allocate(ldeToDeMap(1))
+        allocate(minIndexPTile(dg_dimcount, tilecount), maxIndexPTile(dg_dimcount, tileCount))
+        allocate(minIndexPDe(dg_dimcount, decount), maxIndexPDe(dg_dimcount, deCount))
+
+        call ESMF_DistGridGet(distgrid, localdeToDeMap=lDeToDeMap, &
+          minIndexPTile=minIndexPTile, maxIndexPTile = maxIndexPTile, &
+          minIndexPDe=minIndexPDe, maxIndexPDe=maxIndexPDe, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+
+        if(ldecount /= 1) then
+          call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
+             msg="Only implemented for field with 1 localDe.", &
+              ESMF_CONTEXT, rcToReturn=rc)
+          return
+        endif
+
+        if(tilecount /= 1) then
+          call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
+             msg="Cannot retrieve global information for more than 1 tile yet.", &
+              ESMF_CONTEXT, rcToReturn=rc)
+          return
+        endif
+
+        ! Calculate global bounds
+        j = 1
+        k = 1
+        do i = 1, fieldrank
+          if(isDist(i)) then
+            ! Global Global, this will be identical on all pets
+            l_min(dg2fmap(j)) = minIndexPTile(j, 1)
+            l_max(dg2fmap(j)) = maxIndexPTile(j, 1)
+            l_elecount(dg2fmap(j)) = l_max(dg2fmap(j)) - l_min(dg2fmap(j)) + 1
+            
+            j = j + 1
+          else
+            ! Global Global, this will be identical on all pets
+            l_min(i) = ftype%ungriddedLBound(k)
+            l_max(i) = ftype%ungriddedUBound(k)
+            l_elecount(i) = l_max(i) - l_min(i) + 1
+
+            k = k + 1
+          endif
+        enddo
+#if 0
+        write(*, *) 'dimcount = ', dg_dimcount
+        write(*, *) 'fieldrank = ', fieldrank
+        write(*, *) 'decount = ', decount
+        write(*, *) 'localdecount = ', ldecount
+        write(*, *) 'tileCount = ', tilecount
+        write(*, *) 'minIndexPTile = ', minIndexPTile
+        write(*, *) 'maxIndexPTile = ', maxIndexPTile
+        write(*, *) 'g2fmap = ', ftype%gridToFieldMap
+        write(*, *) 'dg2gmap = ', dg2gmap
+        write(*, *) 'dg2fmap = ', dg2fmap
+#endif
+        deallocate(dg2fmap, minIndexPTile, maxIndexPTile, minIndexPDe, maxIndexPDe) 
+        deallocate(ldeToDeMap, isDist)
+      else if(localGeomType == ESMF_GEOMTYPE_MESH) then
+        call ESMF_GeomGet(ftype%geom, &
+                  mesh=l_mesh, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        call ESMF_MeshGet(l_mesh, nodaldistgrid=distgrid, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+
+        call ESMF_DistGridGet(distgrid, localdecount=ldecount, &
+          decount=decount, dimcount=dg_dimcount, tilecount=tilecount, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+
+        allocate(dg2fmap(dg_dimcount), isDist(fieldrank))
+        dg2fmap = -1
+        isDist = .false.
+        do i = 1, dg_dimcount
+          dg2fmap(i) = ftype%gridToFieldMap(i)
+          isDist(dg2fmap(i)) = .true.
+        enddo
+
+        allocate(ldeToDeMap(1))
+        allocate(minIndexPTile(dg_dimcount, tilecount), maxIndexPTile(dg_dimcount, tileCount))
+        allocate(minIndexPDe(dg_dimcount, decount), maxIndexPDe(dg_dimcount, deCount))
+        call ESMF_DistGridGet(distgrid, localdeToDeMap=lDeToDeMap, &
+          minIndexPTile=minIndexPTile, maxIndexPTile = maxIndexPTile, &
+          minIndexPDe=minIndexPDe, maxIndexPDe=maxIndexPDe, rc=localrc)
+        if (ESMF_LogFoundError(localrc, &
+          ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        if(ldecount /= 1) then
+          call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
+             msg="Only implemented for field with 1 localDe.", &
+              ESMF_CONTEXT, rcToReturn=rc)
+          return
+        endif
+        if(tilecount /= 1) then
+          call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
+             msg="Cannot retrieve global information for more than 1 tile yet.", &
+              ESMF_CONTEXT, rcToReturn=rc)
+          return
+        endif
+
+        ! Calculate global bounds
+        j = 1
+        k = 1
+        do i = 1, fieldrank
+          if(isDist(i)) then
+            ! Global Global
+            l_min(dg2fmap(j)) = minIndexPTile(j, 1)
+            l_max(dg2fmap(j)) = maxIndexPTile(j, 1)
+            l_elecount(dg2fmap(j)) = l_max(dg2fmap(j)) - l_min(dg2fmap(j)) + 1
+            
+            j = j + 1
+          else
+            ! Global Global, this will be identical on all pets
+            l_min(i) = ftype%ungriddedLBound(k)
+            l_max(i) = ftype%ungriddedUBound(k)
+            l_elecount(i) = l_max(i) - l_min(i) + 1
+
+            k = k + 1
+          endif
+        enddo
+#if 0
+        write(*, *) 'dimcount = ', dg_dimcount
+        write(*, *) 'fieldrank = ', fieldrank
+        write(*, *) 'decount = ', decount
+        write(*, *) 'localdecount = ', ldecount
+        write(*, *) 'tileCount = ', tilecount
+        write(*, *) 'minIndexPTile = ', minIndexPTile
+        write(*, *) 'maxIndexPTile = ', maxIndexPTile
+        write(*, *) 'g2fmap = ', ftype%gridToFieldMap
+        write(*, *) 'dg2fmap = ', dg2fmap
+#endif
+        deallocate(dg2fmap, minIndexPTile, maxIndexPTile, minIndexPDe, maxIndexPDe) 
+        deallocate(ldeToDeMap, isDist)
+      else
+        call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
+           msg="Only implemented for Grid and Mesh.", &
+            ESMF_CONTEXT, rcToReturn=rc)
+        return
+      endif
+      if(present(minIndex)) minIndex(1:fieldrank) = l_min
+      if(present(maxIndex)) maxIndex(1:fieldrank) = l_max
+      if(present(elementCount)) elementCount(1:fieldrank) = l_max - l_min + 1
+      deallocate(l_min, l_max, l_elecount) 
+    endif ! present(index and elementCount)
+
+    if(present(localminIndex) .or. present(localmaxIndex) .or. &
+      present(localelementCount) ) then
+
+      call ESMF_ArrayGet(ftype%array, rank=fieldrank, &
+          localDeCount=localDeCount, &
+          rc=localrc)
+      if (localrc .ne. ESMF_SUCCESS) then
+         call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
+            msg="Cannot retrieve fieldrank from ftypep%array", &
+             ESMF_CONTEXT, rcToReturn=rc)
+         return
+      endif
+
+      allocate(ll_min(fieldrank), ll_max(fieldrank), ll_elecount(fieldrank))
+      ll_min = -1
+      ll_max = -1
+      ll_elecount = -1
+
       if(present(localminIndex)) then
           if(size(localminIndex) .ne. fieldrank) then
              call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_VALUE, &
@@ -756,22 +955,11 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
           return
         endif
 
-        if(tilecount /= 1) then
-          call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
-             msg="Cannot retrieve global information for more than 1 tile yet.", &
-              ESMF_CONTEXT, rcToReturn=rc)
-          return
-        endif
-
         ! Calculate global bounds
         j = 1
         k = 1
         do i = 1, fieldrank
           if(isDist(i)) then
-            ! Global Global, this will be identical on all pets
-            l_min(dg2fmap(j)) = minIndexPTile(j, 1)
-            l_max(dg2fmap(j)) = maxIndexPTile(j, 1)
-            l_elecount(dg2fmap(j)) = l_max(dg2fmap(j)) - l_min(dg2fmap(j)) + 1
             
             ! Global bounds on local PET
             ll_min(dg2fmap(j)) = minIndexPDe(j, ldeToDeMap(1)+1)
@@ -780,10 +968,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
             j = j + 1
           else
-            ! Global Global, this will be identical on all pets
-            l_min(i) = ftype%ungriddedLBound(k)
-            l_max(i) = ftype%ungriddedUBound(k)
-            l_elecount(i) = l_max(i) - l_min(i) + 1
 
             ! Global bounds on local PET
             ll_min(i) = ftype%ungriddedLBound(k)
@@ -847,23 +1031,12 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
               ESMF_CONTEXT, rcToReturn=rc)
           return
         endif
-        if(tilecount /= 1) then
-          call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
-             msg="Cannot retrieve global information for more than 1 tile yet.", &
-              ESMF_CONTEXT, rcToReturn=rc)
-          return
-        endif
 
         ! Calculate global bounds
         j = 1
         k = 1
         do i = 1, fieldrank
           if(isDist(i)) then
-            ! Global Global
-            l_min(dg2fmap(j)) = minIndexPTile(j, 1)
-            l_max(dg2fmap(j)) = maxIndexPTile(j, 1)
-            l_elecount(dg2fmap(j)) = l_max(dg2fmap(j)) - l_min(dg2fmap(j)) + 1
-            
             ! Global bounds on local PET
             ll_min(dg2fmap(j)) = minIndexPDe(j, ldeToDeMap(1)+1)
             ll_max(dg2fmap(j)) = maxIndexPDe(j, ldeToDeMap(1)+1)
@@ -871,11 +1044,6 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
             j = j + 1
           else
-            ! Global Global, this will be identical on all pets
-            l_min(i) = ftype%ungriddedLBound(k)
-            l_max(i) = ftype%ungriddedUBound(k)
-            l_elecount(i) = l_max(i) - l_min(i) + 1
-
             ! Global bounds on local PET
             ll_min(i) = ftype%ungriddedLBound(k)
             ll_max(i) = ftype%ungriddedUBound(k)
@@ -903,13 +1071,9 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
             ESMF_CONTEXT, rcToReturn=rc)
         return
       endif
-      if(present(minIndex)) minIndex(1:fieldrank) = l_min
-      if(present(maxIndex)) maxIndex(1:fieldrank) = l_max
-      if(present(elementCount)) elementCount(1:fieldrank) = l_max - l_min + 1
       if(present(localminIndex)) localminIndex(1:fieldrank) = ll_min
       if(present(localmaxIndex)) localmaxIndex(1:fieldrank) = ll_max
       if(present(localelementCount)) localelementCount(1:fieldrank) = ll_max - ll_min + 1
-      deallocate(l_min, l_max, l_elecount) 
       deallocate(ll_min, ll_max, ll_elecount) 
     endif ! present(index and elementCount)
 


### PR DESCRIPTION
This allows one to get the local element count for multi-tile grids rather than just failing as there seems to be no reason the LOCAL arguments to field get can not work on multi tile grids. I broke up the if present block for the get global and get local arguments into 2. The get global still fail if the number of tiles is > 1, but the localElementCount etc now work for multi-tile grids (aka the cubed-sphere for example).