### PR TITLE
Also add mpif90 libdirs to ESMF_F90LINKLIBS for Darwin.gfortranclang

### DIFF
--- a/scripts/libs.openmpif90_forcxx
+++ b/scripts/libs.openmpif90_forcxx
@@ -6,4 +6,14 @@ OPENMPI_MPIF90=`which $1`
 libs=`${OPENMPI_MPIF90} --showme:libs`
 # The above returns the names of the libraries without '-l'. Here we add '-l' to the start
 # of each library name:
-echo $libs | sed -E 's/(^| ) */ -l/g'
+libs_final=`echo $libs | sed -E 's/(^| ) */ -l/g'`
+
+# In the unusual case where the linking is done without an MPI compiler wrapper, we also
+# need to explicitly add the lib directories (and it should be safe to do this in general,
+# even though it is typically unnecessary)
+libdirs=`${OPENMPI_MPIF90} --showme:libdirs`
+# The above returns the paths of the lib directories without '-L'. Here we add '-L' to the start
+# of each directory:
+libdirs_final=`echo $libdirs | sed -E 's/(^| ) */ -L/g'`
+
+echo $libdirs_final $libs_final


### PR DESCRIPTION
This is needed for the unusual case where an application is being linked without the mpi compiler wrappers.

Resolves esmf-org/esmf#134 -- see that issue for details

I'm running testing on my Mac now to confirm that this doesn't break anything.
- Update: testing passes other than the one expected failure on my Mac

@theurich please let me know if you are okay with this change. @mathomp4 please let me know if this fixes the issue for you.