### PR TITLE
Fix scope for undefined ESMX_EXE_NAME

### DIFF
--- a/src/addon/ESMX/Driver/CMakeLists.txt
+++ b/src/addon/ESMX/Driver/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 
 # define ESMX_EXE_NAME
 if(NOT DEFINED ESMX_EXE_NAME)
+  set(ESMX_EXE_NAME "esmx_app")
   set(ESMX_EXE_NAME "esmx_app" PARENT_SCOPE)
 else()
   set(ESMX_EXE_NAME ${ESMX_EXE_NAME} PARENT_SCOPE)


### PR DESCRIPTION
Fix the scope for ESMX_EXE_NAME when exe_name is not set in esmxBuild.yaml file.