### PR TITLE
Fixes #171

### DIFF
--- a/build_config/Darwin.nag.default/ESMF_Conf.inc
+++ b/build_config/Darwin.nag.default/ESMF_Conf.inc
@@ -34,8 +34,6 @@ If a bug fix for this is released, the next #define can
 be removed.
 #endif
 
-#define ESMF_HAS_ACHAR_BUG 1
-
 #if 0
 NAG before v6.2, use sizeof work-around code instead of F2008 C_SIZEOF
 #endif

--- a/src/Infrastructure/Config/src/ESMF_Config.F90
+++ b/src/Infrastructure/Config/src/ESMF_Config.F90
@@ -200,11 +200,7 @@
 
        character, parameter :: BLK = achar(32)   ! blank (space)
        character, parameter :: TAB = achar(09)   ! TAB
-#ifdef ESMF_HAS_ACHAR_BUG
-       character, parameter :: EOL = achar(12)   ! end of line mark (cr)
-#else
        character, parameter :: EOL = achar(10)   ! end of line mark (newline)
-#endif
        character, parameter :: EOB = achar(00)   ! end of buffer mark (null)
        character, parameter :: NUL = achar(00)   ! what it says
        


### PR DESCRIPTION
More testing is necessary, but my tests indicate that the `ESMF_HAS_ACHAR_BUG` is no longer needed to support NAG + Darwin.