### PR TITLE
Implement ConfigCreate() option from HConfig object.

### DIFF
--- a/src/Infrastructure/Config/examples/ESMF_ConfigOverviewEx.F90
+++ b/src/Infrastructure/Config/examples/ESMF_ConfigOverviewEx.F90
@@ -59,6 +59,7 @@
       real          :: table(7,3)    ! an array to hold the table in the RF
 
       type(ESMF_Config)   :: cf      ! the Config itself
+      type(ESMF_HConfig)  :: hconfig ! HConfig variable
 !EOC
 
 !--------------------------------------------------------
@@ -403,7 +404,7 @@
       end if
 
 !----------------------------------------------------------------
-! YAML
+! YAML File
 !----------------------------------------------------------------
 !BOE
 !\subsubsection{Loading a YAML file}
@@ -483,6 +484,20 @@
 ! {\tt cf} object, and can be accessed via the regular {\tt ESMF\_Config}
 ! methods as outlined in the previous sections.
 !
+! As an example, access the {\tt my\_table\_name} element:
+!EOE
+!BOC
+      call ESMF_ConfigFindLabel(cf, 'my_table_name::', &
+               rc=rc)        ! Step a) Set the label location to the 
+                             ! beginning of the table
+!EOC
+
+      if (rc .ne. ESMF_SUCCESS) then
+        finalrc = ESMF_FAILURE
+        print*, "*****' call ESMF_ConfigFindLabel' failed"
+      endif
+
+!BOE
 ! When done, the resources held by the Config object are released by calling
 ! the {\tt ESMF\_ConfigDestroy()} method.
 !EOE
@@ -495,6 +510,117 @@
         finalrc = ESMF_FAILURE
         print*, "*****'call ESMF_ConfigDestroy' failed"
       end if
+
+!----------------------------------------------------------------
+! YAML HConfig
+!----------------------------------------------------------------
+!BOE
+!\subsubsection{Creating from HConfig object}
+
+! The Config class supports creating a Config object from a HConfig object.
+! Here the HConfig object is created from the same YAML file as used before.
+!EOE
+
+!BOC
+      ! Create HConfig object
+      hconfig = ESMF_HConfigCreate(filename="myResourceFile.yaml", rc=rc)
+!EOC
+      if (rc .ne. ESMF_SUCCESS) then
+        finalrc = ESMF_FAILURE
+        print*, "*****' call ESMF_HConfigCreate' failed"
+      endif
+!BOE
+! The {\tt myResourceFile.yaml} contains the following YAML contents:
+!
+! \begin{verbatim}
+!# YAML representation of the myResourceFile.rc RF
+!
+!# mapping to sequences
+!
+!my_file_names:      [jan87.dat, jan88.dat, jan89.dat]  # all strings
+!constants:          [3.1415, 25]                       # float and integer
+!my_favorite_colors: [green, blue, 022]
+!
+!# mapping to scalars
+!
+!radius_of_the_earth:   6.37E6
+!parameter_1:           89
+!parameter_2:           78.2
+!input_file_name:       dummy_input.nc
+!
+!# represent table as mapping to sequence of sequences
+!
+!my_table_name:
+!- [1000,    3000,    263.0]
+!- [ 925,    3000,    263.0]
+!- [ 850,    3000,    263.0]
+!- [ 700,    3000,    269.0]
+!- [ 500,    3000,    287.0]
+!- [ 400,    3000,    295.8]
+!- [ 300,    3000,    295.8]
+! \end{verbatim}
+!
+! A Config object can be created from the HConfig object simply by passing
+! {\tt hconfig} into {\tt ESMF\_CreateConfig()} as argument.
+!EOE
+
+!BOC
+      ! Create Config object from HConfig
+      cf = ESMF_ConfigCreate(hconfig=hconfig, rc=rc)
+!EOC
+
+      if (rc .ne. ESMF_SUCCESS) then
+        finalrc = ESMF_FAILURE
+        print*, "*****'call ESMF_HConfigCreate' failed"
+      end if
+
+!BOE
+! Notice that {\tt cf} uses the specified {\tt hconfig} object via reference.
+! It remains the callers responsibility to destroy the {\tt hconfig} object
+! when finished. Care must be taken to {\em not} destroy until access via
+! {\tt cf} is complete.
+!
+! Here, as an example, access the {\tt my\_table\_name} element:
+!EOE
+!BOC
+      call ESMF_ConfigFindLabel(cf, 'my_table_name::', &
+               rc=rc)        ! Step a) Set the label location to the 
+                             ! beginning of the table
+!EOC
+
+      if (rc .ne. ESMF_SUCCESS) then
+        finalrc = ESMF_FAILURE
+        print*, "*****' call ESMF_ConfigFindLabel' failed"
+      endif
+!EOE
+
+! When done, the resources held by the Config object are released by calling
+! the {\tt ESMF\_ConfigDestroy()} method.
+!EOE
+
+!BOC
+      call ESMF_ConfigDestroy(cf, rc=rc) ! Destroy the Config object
+!EOC
+
+      if (rc .ne. ESMF_SUCCESS) then
+        finalrc = ESMF_FAILURE
+        print*, "*****'call ESMF_ConfigDestroy' failed"
+      end if
+
+!BOE
+! As discussed above, the {\tt hconfig} object requires its own destroy call
+! for a complete release.
+!EOE
+
+!BOC
+      call ESMF_HConfigDestroy(hconfig, rc=rc) ! Destroy the HConfig object
+!EOC
+
+      if (rc .ne. ESMF_SUCCESS) then
+        finalrc = ESMF_FAILURE
+        print*, "*****'call ESMF_HConfigDestroy' failed"
+      end if
+
 
 !----------------------------------------------------------------
 !----------------------------------------------------------------

--- a/src/Infrastructure/Config/src/ESMF_Config.F90
+++ b/src/Infrastructure/Config/src/ESMF_Config.F90
@@ -94,7 +94,7 @@
     interface ESMF_ConfigCreate
 
 ! !PRIVATE MEMBER FUNCTIONS:
-        module procedure ESMF_ConfigCreateEmpty
+        module procedure ESMF_ConfigCreateDefault
         module procedure ESMF_ConfigCreateFromSection
 
 ! !DESCRIPTION:
@@ -232,7 +232,8 @@
           integer :: nattr                             ! number of attributes
                                                        !   in the "used" table
           character(len=LSZ)          :: current_attr  ! the current attr label
-          type(ESMF_HConfig) :: hconfig  ! hierarchical configuration
+          type(ESMF_HConfig) :: hconfig   ! hierarchical configuration
+          logical :: hconfig_owner        ! .true. if hconfig is owned by config
           ESMF_INIT_DECLARE
        end type ESMF_ConfigClass
 
@@ -591,33 +592,41 @@
     end function ESMF_ConfigGetInit
 
 
-
 !------------------------------------------------------------------------------
 #undef  ESMF_METHOD
-#define ESMF_METHOD "ESMF_ConfigCreateEmpty"
+#define ESMF_METHOD "ESMF_ConfigCreateDefault"
 !BOP
 !
 ! !IROUTINE: ESMF_ConfigCreate - Instantiate a Config object
 !
 ! !INTERFACE:
-      ! Private name; call using ESMF_ConfigCreate()
-      type(ESMF_Config) function ESMF_ConfigCreateEmpty(keywordEnforcer, rc)
+    ! Private name; call using ESMF_ConfigCreate()
+    type(ESMF_Config) function ESMF_ConfigCreateDefault(keywordEnforcer, hconfig, rc)
 
 ! !ARGUMENTS:
 type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
-     integer,intent(out), optional              :: rc 
+      type(ESMF_HConfig), intent(in),  optional   :: hconfig
+      integer,            intent(out), optional   :: rc
 !
 !
 ! !STATUS:
 ! \begin{itemize}
 ! \item\apiStatusCompatibleVersion{5.2.0r}
+! \item\apiStatusModifiedSinceVersion{5.2.0r}
+! \begin{description}
+! \item[8.6.0] Added the {\tt hconfig} argument to support creation from HConfig
+!    object.
+! \end{description}
 ! \end{itemize}
 !
 ! !DESCRIPTION: 
-!   Instantiates an {\tt ESMF\_Config} object for use in subsequent calls.
+!   Instantiates an {\tt ESMF\_Config} object. Optionally create from HConfig.
 !
 !   The arguments are:
 !   \begin{description}
+!   \item [{[hconfig]}]
+!     If specified, create Config from HConfig. By default create an empty
+!     Config object.
 !   \item [{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 !   \end{description}
@@ -633,7 +642,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
  
 ! Initialization
       allocate(config_local, stat=memstat)
-      ESMF_ConfigCreateEmpty%cptr => config_local
+      ESMF_ConfigCreateDefault%cptr => config_local
       if (ESMF_LogFoundAllocError(memstat, msg="Allocating config class", &
                                         ESMF_CONTEXT, rcToReturn=rc)) return
 
@@ -655,16 +664,29 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
       config_local%attr_used => attr_used_local
 
-      config_local%hconfig = ESMF_HConfigCreate(rc=localrc)
-      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU,  &
-        ESMF_CONTEXT, rcToReturn=rc)) return
+      if (present(hconfig)) then
+        ! Config from HConfig (reference)
+        config_local%hconfig_owner = .false.
+        config_local%hconfig = hconfig
+        call c_ESMC_HConfigToConfig(config_local%hconfig, &
+          ESMF_ConfigCreateDefault, localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+      else
+        ! Config empty
+        config_local%hconfig_owner = .true.
+        config_local%hconfig = ESMF_HConfigCreate(rc=localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+      endif
 
       if (present( rc ))  rc = ESMF_SUCCESS
 
-      ESMF_INIT_SET_CREATED(ESMF_ConfigCreateEmpty)
+      ESMF_INIT_SET_CREATED(ESMF_ConfigCreateDefault)
       return
 
-    end function ESMF_ConfigCreateEmpty
+    end function ESMF_ConfigCreateDefault
+
 
 !------------------------------------------------------------------------------
 #undef  ESMF_METHOD
@@ -743,7 +765,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       end if
 
       ! Create and populate new Config object from parent object's section
-      ESMF_ConfigCreateFromSection = ESMF_ConfigCreateEmpty(rc=localrc)
+      ESMF_ConfigCreateFromSection = ESMF_ConfigCreate(rc=localrc)
       if (ESMF_LogFoundError(rcToCheck=localrc, &
         msg="Instantiating new config object",  &
         ESMF_CONTEXT, rcToReturn=rc)) return
@@ -772,6 +794,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       if (ESMF_LogFoundError(rcToCheck=localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
 
+      ESMF_ConfigCreateFromSection%cptr%hconfig_owner = .true.
       ESMF_ConfigCreateFromSection%cptr%hconfig = ESMF_HConfigCreate(rc=localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU,  &
         ESMF_CONTEXT, rcToReturn=rc)) return
@@ -845,9 +868,11 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       if (ESMF_LogFoundDeallocError(memstat, msg="Deallocating local buffer 1", &
         ESMF_CONTEXT, rcToReturn=rc)) return
 
-      call ESMF_HConfigDestroy(config%cptr%hconfig, rc=localrc)
-      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU,  &
-        ESMF_CONTEXT, rcToReturn=rc)) return
+      if (config%cptr%hconfig_owner) then
+        call ESMF_HConfigDestroy(config%cptr%hconfig, rc=localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU,  &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+      endif
 
       deallocate(config%cptr, stat = memstat)
       if (ESMF_LogFoundDeallocError(memstat, msg="Deallocating config type", &


### PR DESCRIPTION
This implements support for creating an ESMF_Config object from an ESMF_HConfig object.

See https://earthsystemmodeling.org/docs/nightly/feature/config-from-hconfig/ESMF_refdoc/node6.html#SECTION06093400000000000000 for online documentation of the modified API.

See https://earthsystemmodeling.org/docs/nightly/feature/config-from-hconfig/ESMF_refdoc/node6.html#SECTION06092800000000000000 for a new ref doc section that discusses the feature.