### PR TITLE
More initialization options for ESMF -> ESMX

### DIFF
--- a/src/Infrastructure/VM/include/ESMCI_VM.h
+++ b/src/Infrastructure/VM/include/ESMCI_VM.h
@@ -148,6 +148,7 @@ class VM : public VMK {   // inherits from ESMCI::VMK class
     static void rmFObject(void **fobject);
     static bool validObject(ESMC_Base *);
     static char const *getenv(char const *name);
+    static void setenv(char const *name, char const *value);
     // misc.
     int print() const;
     int validate() const;

--- a/src/Infrastructure/VM/interface/ESMCI_VM_F.C
+++ b/src/Infrastructure/VM/interface/ESMCI_VM_F.C
@@ -1170,6 +1170,33 @@ extern "C" {
     if (rc!=NULL) *rc = ESMF_SUCCESS;
   }
 
+  void FTN_X(c_esmc_vmsetenv)(char *name, char *value, int *rc,
+    ESMCI_FortranStrLenArg name_l, ESMCI_FortranStrLenArg value_l){
+#undef  ESMC_METHOD
+#define ESMC_METHOD "c_esmc_vmsetenv()"
+    // Initialize return code; assume routine not implemented
+    if (rc!=NULL) *rc = ESMC_RC_NOT_IMPL;
+    try{
+      std::string nameStr(name, name_l);
+      std::string valueStr(value, value_l);
+      ESMCI::VM::setenv(nameStr.c_str(), valueStr.c_str());
+    }catch(int localrc){
+      if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU,
+        ESMC_CONTEXT, rc))
+        return; // bail out
+    }catch(std::exception &x){
+      ESMC_LogDefault.MsgFoundError(ESMC_RC_INTNRL_BAD, x.what(), ESMC_CONTEXT,
+        rc);
+      return; // bail out
+    }catch(...){
+      ESMC_LogDefault.MsgFoundError(ESMC_RC_INTNRL_BAD, "- Caught exception", 
+        ESMC_CONTEXT, rc);
+      return;
+    }
+    // return successfully
+    if (rc!=NULL) *rc = ESMF_SUCCESS;
+  }
+
   void FTN_X(c_esmc_vmfinalize)(ESMC_Logical *keepMpiFlag, int *rc){
 #undef  ESMC_METHOD
 #define ESMC_METHOD "c_esmc_vmfinalize()"

--- a/src/Infrastructure/VM/interface/ESMF_VM.F90
+++ b/src/Infrastructure/VM/interface/ESMF_VM.F90
@@ -458,6 +458,7 @@ module ESMF_VMMod
   public ESMF_VMInitializePreMPI
   public ESMF_VMInitialize
   public ESMF_VMSet
+  public ESMF_VMSetEnv
   public ESMF_VMFinalize
   public ESMF_VMAbort
   public ESMF_VMShutdown
@@ -9345,6 +9346,50 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present(rc)) rc = ESMF_SUCCESS
 
   end subroutine ESMF_VMSet
+!------------------------------------------------------------------------------
+
+
+! -------------------------- ESMF-internal method -----------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_VMSetEnv()"
+!BOPI
+! !IROUTINE: ESMF_VMSetEnv - Set environment variable cached in the Global VM
+
+! !INTERFACE:
+  subroutine ESMF_VMSetEnv(name, value, rc)
+!
+! !ARGUMENTS:
+    character(*), intent(in)            :: name
+    character(*), intent(in)            :: value
+    integer,      intent(out), optional :: rc
+!
+! !DESCRIPTION:
+!   Set environment variable cached in the Global VM. Potentially override what
+!   came from the shell environment.
+!
+!   The arguments are:
+!   \begin{description}
+!     \item [name]
+!        The name of the environment variable.
+!     \item [value]
+!        The value of the environment variable.
+!   \item[{[rc]}] 
+!        Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
+!   \end{description}
+!
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc      ! local return code
+
+    ! Call into the C++ interface.
+    call c_ESMC_VMSetEnv(name, value, localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+
+    ! return successfully
+    if (present(rc)) rc = ESMF_SUCCESS
+
+  end subroutine ESMF_VMSetEnv
 !------------------------------------------------------------------------------
 
 

--- a/src/Infrastructure/VM/src/ESMCI_VM.C
+++ b/src/Infrastructure/VM/src/ESMCI_VM.C
@@ -3108,7 +3108,7 @@ char const *VM::getenv(
   char const *name){
 //
 // !DESCRIPTION:
-//    Access environment variables in the global VM object
+//    Access environment variable cached within the global VM object
 //
 //EOPI
 //-----------------------------------------------------------------------------
@@ -3121,6 +3121,43 @@ char const *VM::getenv(
 
   // match found
   return esmfRuntimeEnvValue[i].c_str();
+}
+//-----------------------------------------------------------------------------
+
+
+//-----------------------------------------------------------------------------
+#undef  ESMC_METHOD
+#define ESMC_METHOD "ESMCI::VM::setenv()"
+//BOPI
+// !IROUTINE:  ESMCI::VM::setenv - set environment variable
+// !INTERFACE:
+ void VM::setenv(
+//
+// !RETURN VALUE:
+//    pointer to value or NULL
+//
+// !ARGUMENTS:
+//
+  char const *name,
+  char const *value){
+//
+// !DESCRIPTION:
+//    Set environment variable cached within the global VM object
+//
+//EOPI
+//-----------------------------------------------------------------------------
+  int count = esmfRuntimeEnv.size();
+  int i;
+  for (i=0; i<count; i++)
+    if (!esmfRuntimeEnv[i].compare(name)) break;
+  if (i == count){
+    // no match found -> add new variable
+    esmfRuntimeEnv.push_back(name);
+    esmfRuntimeEnvValue.push_back(value);
+  }else{
+    // match found -> update the value
+    esmfRuntimeEnvValue[i] = std::string(value);
+  }
 }
 //-----------------------------------------------------------------------------
 

--- a/src/Superstructure/ESMFMod/src/ESMF_Init.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF_Init.F90
@@ -1299,7 +1299,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       ! Ensure that at least the version number makes it into the log
       call ESMF_LogFlush(rc=localrc)
       
-      ! if compliance checker is on, we want logs to have high prescision timestamps
+      ! if compliance checker is on, we want logs to have high precision timestamps
       call c_esmc_getComplianceCheckJSON(complianceCheckIsOn, localrc)
       if (localrc /= ESMF_SUCCESS) then
           write (ESMF_UtilIOStderr,*) ESMF_METHOD, ": Error checking ESMF_RUNTIME_COMPLIANCECHECK env variable"
@@ -1316,7 +1316,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       ! check if tracing is on
       call c_esmc_getComplianceCheckTrace(traceIsOn, profileIsOn, localrc)
       if (localrc /= ESMF_SUCCESS) then
-          write (ESMF_UtilIOStderr,*) ESMF_METHOD, ": Error checking ESMF_RUNTIME_COMPLIANCECHECK env variable"
+          write (ESMF_UtilIOStderr,*) ESMF_METHOD, ": Error checking ESMF_RUNTIME_* env variables"
           return
       endif
       if (traceIsOn == 1 .or. profileIsOn == 1) then
@@ -1536,7 +1536,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
       call c_esmc_getComplianceCheckTrace(traceIsOn, profileIsOn, localrc)
       if (localrc /= ESMF_SUCCESS) then
-          write (ESMF_UtilIOStderr,*) ESMF_METHOD, ": Error checking ESMF_RUNTIME_COMPLIANCECHECK env variable"
+          write (ESMF_UtilIOStderr,*) ESMF_METHOD, ": Error checking ESMF_RUNTIME_* env variables"
           return
       endif
       if (traceIsOn == 1 .or. profileIsOn == 1) then

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -58,15 +58,24 @@ program ESMX_App
 
   ! Validate hconfigNode against ESMX/App controlled key vocabulary
   isFlag = ESMF_HConfigValidateMapKeys(hconfigNode, &
-    vocabulary=["defaultLogFilename   ", & ! ESMF_Initialize option
-                "logAppendFlag        ", & ! ESMF_Initialize option
-                "logKindFlag          ", & ! ESMF_Initialize option
-                "defaultCalKind       ", & ! ESMF_Initialize option
-                "globalResourceControl", & ! ESMF_Initialize option
-                "startTime            ", & ! ESMX_App option
-                "stopTime             ", & ! ESMX_App option
-                "logFlush             ", & ! ESMX_App option
-                "fieldDictionary      "  & ! ESMX_App option
+    vocabulary=["defaultLogFilename          ", & ! ESMF_Initialize option
+                "logAppendFlag               ", & ! ESMF_Initialize option
+                "logKindFlag                 ", & ! ESMF_Initialize option
+                "defaultCalKind              ", & ! ESMF_Initialize option
+                "globalResourceControl       ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE        ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE_OUTPUT ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE_PETLIST", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE          ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_CLOCK    ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_PETLIST  ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_COMPONENT", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_FLUSH    ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_COMPLIANCECHECK", & ! ESMF_Initialize option
+                "startTime                   ", & ! ESMX_App option
+                "stopTime                    ", & ! ESMX_App option
+                "logFlush                    ", & ! ESMX_App option
+                "fieldDictionary             "  & ! ESMX_App option
                 ], badKey=valueString, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -32,7 +32,7 @@ program ESMX_App
   configKey = ["ESMX", "App "]
   call ESMF_Initialize(configFilenameFromArgNum=1, & ! arg 1 to spec alt. config
     configFileName="esmxRun.yaml", configKey=configKey, &
-    config=config, defaultCalkind=ESMF_CALKIND_GREGORIAN, rc=rc)
+    config=config, defaultDefaultCalKind=ESMF_CALKIND_GREGORIAN, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
@@ -61,6 +61,7 @@ program ESMX_App
     vocabulary=["defaultLogFilename   ", & ! ESMF_Initialize option
                 "logAppendFlag        ", & ! ESMF_Initialize option
                 "logKindFlag          ", & ! ESMF_Initialize option
+                "defaultCalKind       ", & ! ESMF_Initialize option
                 "globalResourceControl", & ! ESMF_Initialize option
                 "startTime            ", & ! ESMX_App option
                 "stopTime             ", & ! ESMX_App option

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -253,9 +253,10 @@ This section affects the application level.
 | `startTime`               | string setting the application start time                 | *non-optional*  |
 | `stopTime`                | string setting the application stop time                  | *non-optional*  |
 | `globalResourceControl`   | enable/disable global resource control: `true` or `false` | `false`         |
-| `logKindFlag`             | string constant setting ESMF logging kind, see ESMF RefDoc| `ESMF_LOGKIND_Multi_On_Error`|
+| `logKindFlag`             | ESMF logging kind, see ESMF RefDoc for options            | `ESMF_LOGKIND_Multi_On_Error`|
 | `logAppendFlag`           | enable/disable log append: `true` or `false`              | `true`          |
 | `defaultLogFilename`      | name of the default ESMF log file (suffix if multi PET)   | `ESMF_LogFile`  |
+| `defaultCalKind`          | ESMF calendar kind used by default, see ESMF RefDoc for options | `ESMF_CALKIND_GREGORIAN` |
 | `logFlush`                | enable/disable log flush for each write: `true` or `false`| `false`         |
 | `fieldDictionary`         | name of the NUOPC field dictionary file to be loaded      | *None*          |
 

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -248,6 +248,8 @@ On the highest level, `ESMX Run Configuration` is expected to define the `ESMX` 
 
 This section affects the application level.
 
+**CAUTION:** Specifying any of the  `ESMF_RUNTIME_*` keys overrides the corresponding environment variables set in the user's environment.
+
 | Option key                | Description / Value options                               | Default         |
 | ------------------------- | --------------------------------------------------------- | --------------- |
 | `startTime`               | string setting the application start time                 | *non-optional*  |
@@ -259,6 +261,15 @@ This section affects the application level.
 | `defaultCalKind`          | ESMF calendar kind used by default, see ESMF RefDoc for options | `ESMF_CALKIND_GREGORIAN` |
 | `logFlush`                | enable/disable log flush for each write: `true` or `false`| `false`         |
 | `fieldDictionary`         | name of the NUOPC field dictionary file to be loaded      | *None*          |
+| `ESMF_RUNTIME_PROFILE`    | enable/disable all profiling functions: `ON` or `OFF`     | `OFF`           |
+| `ESMF_RUNTIME_PROFILE_OUTPUT` | output format; multiple can be selected: `TEXT` `SUMMARY` `BINARY` | `TEXT`      |
+| `ESMF_RUNTIME_PROFILE_PETLIST`| limit profiling to an explicit list of PETs           | *all PETs*      |
+| `ESMF_RUNTIME_TRACE`      | enable/disable all tracing functions: `ON` or `OFF`       | `OFF`           |
+| `ESMF_RUNTIME_TRACE_CLOCK`| type of clock for events: `REALTIME` or `MONOTONIC` or `MONOTONIC_SYNC`  | `REALTIME`|
+| `ESMF_RUNTIME_TRACE_PETLIST`| limit tracing to an explicit list of PETs               | *all PETs*      |
+| `ESMF_RUNTIME_TRACE_COMPONENT`| enable/disable tracing of component events: `ON` or `OFF` | `ON`        |
+| `ESMF_RUNTIME_TRACE_FLUSH`| frequency of event stream flushing to file: `DEFAULT` or `EAGER` | `DEFAULT`|
+| `ESMF_RUNTIME_COMPLIANCECHECK`| enable/disable NUOPC compliance checking: `ON` or `OFF` with `DEPTH` | `OFF`|
 
 #### ESMX/Driver Options
 


### PR DESCRIPTION
This PR implements a number of additional initialization options on the ESMF level (via `ESMF_Initialize()`), and then promotes it to the ESMX level (as ESMX/App Option). This addresses Ufuk's request to be able to change the default calendar used by ESMX, as well as Gerhard's wish to be able to set/override the ESMF_RUNTIME_* environment variables via the `esmxRun.yaml` mechanism, specifically for profiling and tracing purposes.

The new options are:

- defaultCalKind

- ESMF_RUNTIME_PROFILE
- ESMF_RUNTIME_PROFILE_OUTPUT
- ESMF_RUNTIME_PROFILE_PETLIST
- ESMF_RUNTIME_TRACE
- ESMF_RUNTIME_TRACE_CLOCK
- ESMF_RUNTIME_TRACE_PETLIST
- ESMF_RUNTIME_TRACE_COMPONENT
- ESMF_RUNTIME_TRACE_FLUSH
- ESMF_RUNTIME_COMPLIANCECHECK

The updated `ESMF_Initialize()` doc can be reviewed at https://earthsystemmodeling.org/docs/nightly/feature/more-init-opts/ESMF_refdoc/node4.html#SECTION04024100000000000000.

The update `ESMX` doc can be revied at https://github.com/esmf-org/esmf/tree/feature/more-init-opts/src/addon/ESMX#esmxapp-options
