### PR TITLE
Ensure the RPATH does not get blanked out during ESMX_App installation.

### DIFF
--- a/src/addon/ESMX/CMakeLists.txt
+++ b/src/addon/ESMX/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 add_executable(${ESMX_EXE_NAME} ESMX_App.F90)
 target_include_directories(${ESMX_EXE_NAME} PUBLIC ${PROJECT_BINARY_DIR})
 target_link_libraries(${ESMX_EXE_NAME} PUBLIC esmx_driver)
+set_target_properties(${ESMX_EXE_NAME} PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE) 
 
 # Install executable
 install(


### PR DESCRIPTION
This PR ensures that the RPATH that is correctly encoded during the ESMX_App build process is **not** blanked out during the _installation_ step. The CMake default _is_ to remove the encoded RPATH in executables during installation. I assume this is to support `LD_LIBRARY_PATH` setting during run-time.  However, for ESMF applications, and therefore ESMX, this is not a good idea. You typically encode the RPATH into the executable for good reason, so the correct shared library is found during loading without relying on `LD_LIBRARY_PATH`.