### PR TITLE
Remove fixed GCC version from Spack build action

### DIFF
--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -136,16 +136,25 @@ fi
 
 # check given gcc compiler is found or not? If not, use newer version
 if [[ "$comp" == *"gcc"* ]]; then
+  echo "::group::Check gcc compiler"
   comp_str=${comp/@/@=}
-  if [ -z "$(cat ~/.spack/linux/compilers.yaml | grep $comp_str)" ]; then
-    echo "Given compiler ($comp) not found! Try to find another ..."
-    str=`echo $comp_str | awk -F\@ '{print $1}'`
-    comp_ver=`grep -ir "${str}@=" ~/.spack/linux/compilers.yaml | tr -d "spec: ${str}@=" | sort -n | tail -n 1`
-    comp="${str}@$comp_ver"
-    echo "New compiler is found! Using $comp ..."
-  else
-    echo "Given compiler is found. Using $comp ..."
+  str=`echo $comp_str | awk -F\@ '{print $1}'`
+  comp_ver=`grep -ir "${str}@=" ~/.spack/linux/compilers.yaml | tr -d "spec: ${str}@=" | sort -n | tail -n 1`
+
+  use_latest=0
+  if [[ "$comp" == *"gcc@latest"* ]]; then
+     echo "The gcc@latest is set. Trying to find latest available gcc compiler ..."
+     use_latest=1
+  elif [ -z "$(cat ~/.spack/linux/compilers.yaml | grep $comp_str)" ]; then
+     echo "Given compiler ($comp) is not found! Trying to find latest available gcc compiler ..."
+     use_latest=1
   fi
+
+  if [[ $use_latest == 1 ]]; then
+     comp="${str}@$comp_ver"
+  fi
+  echo "Using $comp gnu compiler."
+  echo "::endgroup::"
 fi
 
 # create spack.yaml

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -146,8 +146,8 @@ if [[ "$comp" == *"gcc"* ]]; then
      echo "The gcc@latest is set. Trying to find latest available gcc compiler ..."
      use_latest=1
   elif [ -z "$(cat ~/.spack/linux/compilers.yaml | grep $comp_str)" ]; then
-     echo "Given compiler ($comp) is not found! Trying to find latest available gcc compiler ..."
-     use_latest=1
+     echo "Given compiler ($comp) is not found! Exiting ..."
+     exit 1
   fi
 
   if [[ $use_latest == 1 ]]; then

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -134,6 +134,20 @@ if [[ "$comp" == *"oneapi"* ]]; then
   echo "::endgroup::"
 fi
 
+# check given gcc compiler is found or not? If not, use newer version
+if [[ "$comp" == *"gcc"* ]]; then
+  comp_str=${comp/@/@=}
+  if [ -z "$(cat ~/.spack/linux/compilers.yaml | grep $comp_str)" ]; then
+    echo "Given compiler ($comp) not found! Try to find another ..."
+    str=`echo $comp_str | awk -F\@ '{print $1}'`
+    comp_ver=`grep -ir "${str}@=" ~/.spack/linux/compilers.yaml | tr -d "spec: ${str}@=" | sort -n | tail -n 1`
+    comp="${str}@$comp_ver"
+    echo "New compiler is found! Using $comp ..."
+  else
+    echo "Given compiler is found. Using $comp ..."
+  fi
+fi
+
 # create spack.yaml
 echo "::group::Create spack.yaml"
 echo "spack:" > spack.yaml

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -1,7 +1,7 @@
 name: Build ESMF Using Spack
 
 env:
-  compiler: gcc@11.3.0
+  compiler: gcc@12.3.0
   esmf_version: 'esmf@develop'
   nuopc_app_version: 'develop'
 

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -8,6 +8,11 @@ env:
 on:
   workflow_dispatch:
     inputs:
+      compiler:
+        description: 'Compiler version like gcc@12.3.0'
+        required: false
+        type: string
+        default: 'gcc@12.3.0'
       esmf_version: 
         description: 'ESMF version or tag like esmf@develop or esmf@=8.5.0b23'
         required: false
@@ -39,7 +44,11 @@ jobs:
         echo "ENV  : >${{ env.esmf_version }}< >${{ env.nuopc_app_version }}<"
 
         # create matrix JSON file
-        str1="{\"compiler\": [\"${{ env.compiler }}\"],"
+        if [ -z "${{ inputs.compiler }}" ]; then
+          str1="{\"compiler\": [\"${{ env.compiler }}\"],"
+        else
+          str1="{\"compiler\": [\"${{ inputs.compiler }}\"],"  
+        fi
         if [ -z "${{ inputs.esmf_version }}" ]; then
           str2="\"esmf\": [\"${{ env.esmf_version }}+external-parallelio\", \"${{ env.esmf_version }}~external-parallelio\"]}"
           echo "nuopc_app_version=${{ env.nuopc_app_version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -1,7 +1,7 @@
 name: Build ESMF Using Spack
 
 env:
-  compiler: gcc@12.3.0
+  compiler: gcc@latest
   esmf_version: 'esmf@develop'
   nuopc_app_version: 'develop'
 
@@ -9,10 +9,10 @@ on:
   workflow_dispatch:
     inputs:
       compiler:
-        description: 'Compiler version like gcc@12.3.0'
+        description: 'Compiler version like gcc@12.3.0 or gcc@latest (latest available version on runner)'
         required: false
         type: string
-        default: 'gcc@12.3.0'
+        default: 'gcc@latest'
       esmf_version: 
         description: 'ESMF version or tag like esmf@develop or esmf@=8.5.0b23'
         required: false


### PR DESCRIPTION
This PR aims to make Spack Build action more flexible in terms of used gcc compiler. The new default is `gcc@latest`, which indicates that action will use latest available GCC compiler on runner. The user is also able to pass any specific gcc version like `gcc@11.4.0` etc. If specified compiler is missing, then action again uses latest available GCC compiler on runner.