### PR TITLE
Fix GitHub Actions for Deploying ESMF Docs

### DIFF
--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -42,12 +42,18 @@ jobs:
         name: esmf-docs
         path: ${{ github.workspace }}/artifacts
        
-    - name: Checkout esmf-org.github.io
-      uses: actions/checkout@v3
-      with:
-          repository: esmf-org/esmf-org.github.io
-          path: esmf-org.github.io
-          token: ${{ secrets.ESMF_WEB_TOKEN }}
+    - name: Setup deployment
+      run: | 
+        mkdir -p ~/.ssh
+        if [ -z "${{secrets.ESMF_WEB_DEPLOY_KEY}}" ]; then
+          echo "ERROR: Missing ESMF_WEB_DEPLOY_KEY!"
+          exit 1
+        fi
+        echo "${{secrets.ESMF_WEB_DEPLOY_KEY}}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git clone --depth=1 git@github.com:esmf-org/esmf-org.github.io.git ${{ github.workspace }}/esmf-org.github.io
 
     - name: Copy docs
       run: | 
@@ -66,10 +72,9 @@ jobs:
         cp -rf ./dev_guide/dev_guide/* ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/dev_guide/
         
     - name: Commit and publish docs
-      uses: actions-js/push@master
-      with:
-        repository: esmf-org/esmf-org.github.io
-        directory: ${{ github.workspace }}/esmf-org.github.io
-        branch: master
-        github_token: ${{ secrets.ESMF_WEB_TOKEN }}
-        message: 'Publish ESMF Docs'
+      run: | 
+        cd ${{ github.workspace }}/esmf-org.github.io
+        git add .
+        git diff-index --quiet HEAD || git commit --message "Publish ESMF Docs"
+        git push origin
+        rm ~/.ssh/id_rsa

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -43,14 +43,16 @@ jobs:
         path: ${{ github.workspace }}/artifacts
        
     - name: Setup deployment
+      env:
+        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
       run: | 
         mkdir -p ~/.ssh
         if [ -z "${{secrets.ESMF_WEB_DEPLOY_KEY}}" ]; then
           echo "ERROR: Missing ESMF_WEB_DEPLOY_KEY!"
           exit 1
         fi
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{secrets.ESMF_WEB_DEPLOY_KEY}}'
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add - <<< "${{secrets.ESMF_WEB_DEPLOY_KEY}}"
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git clone --depth=1 git@github.com:esmf-org/esmf-org.github.io.git ${{ github.workspace }}/esmf-org.github.io
@@ -72,6 +74,8 @@ jobs:
         cp -rf ./dev_guide/dev_guide/* ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/dev_guide/
         
     - name: Commit and publish docs
+      env:
+        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
       run: | 
         cd ${{ github.workspace }}/esmf-org.github.io
         git add .

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -42,21 +42,12 @@ jobs:
         name: esmf-docs
         path: ${{ github.workspace }}/artifacts
        
-    - name: Setup deployment
-      env:
-        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
-      run: | 
-        mkdir -p ~/.ssh
-        if [ -z "${{secrets.ESMF_WEB_DEPLOY_KEY}}" ]; then
-          echo "ERROR: Missing ESMF_WEB_DEPLOY_KEY!"
-          exit 1
-        fi
-        set +o history
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        echo "${{secrets.ESMF_WEB_DEPLOY_KEY}}" | ssh-add -
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git clone --depth=1 git@github.com:esmf-org/esmf-org.github.io.git ${{ github.workspace }}/esmf-org.github.io
+    - name: Checkout esmf-org.github.io
+      uses: actions/checkout@v3
+      with:
+          repository: esmf-org/esmf-org.github.io
+          path: ${{github.workspace}}/esmf-org.github.io
+          ssh-key: ${{secrets.ESMF_WEB_DEPLOY_KEY}}
 
     - name: Copy docs
       run: | 
@@ -75,11 +66,10 @@ jobs:
         cp -rf ./dev_guide/dev_guide/* ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/dev_guide/
         
     - name: Commit and publish docs
-      env:
-        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
       run: | 
         cd ${{ github.workspace }}/esmf-org.github.io
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git add .
         git diff-index --quiet HEAD || git commit --message "Publish ESMF Docs"
         git push origin
-        ssh-add -D

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -49,8 +49,8 @@ jobs:
           echo "ERROR: Missing ESMF_WEB_DEPLOY_KEY!"
           exit 1
         fi
-        echo "${{secrets.ESMF_WEB_DEPLOY_KEY}}" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{secrets.ESMF_WEB_DEPLOY_KEY}}'
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git clone --depth=1 git@github.com:esmf-org/esmf-org.github.io.git ${{ github.workspace }}/esmf-org.github.io
@@ -77,4 +77,4 @@ jobs:
         git add .
         git diff-index --quiet HEAD || git commit --message "Publish ESMF Docs"
         git push origin
-        rm ~/.ssh/id_rsa
+        ssh-add -D

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -51,6 +51,7 @@ jobs:
           echo "ERROR: Missing ESMF_WEB_DEPLOY_KEY!"
           exit 1
         fi
+        set +o history
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
         ssh-add - <<< "${{secrets.ESMF_WEB_DEPLOY_KEY}}"
         git config --global user.name "github-actions[bot]"

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -53,7 +53,7 @@ jobs:
         fi
         set +o history
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        ssh-add - <<< "${{secrets.ESMF_WEB_DEPLOY_KEY}}"
+        echo "${{secrets.ESMF_WEB_DEPLOY_KEY}}" | ssh-add -
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git clone --depth=1 git@github.com:esmf-org/esmf-org.github.io.git ${{ github.workspace }}/esmf-org.github.io

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -45,11 +45,11 @@ jobs:
     - name: Setup deployment
       run: | 
         mkdir -p ~/.ssh
-        if [ -z "${{secrets.ESMF_WEB_DEPLOY_KEY}}" ]; then
-          echo "ERROR: Missing ESMF_WEB_DEPLOY_KEY!"
+        if [ -z "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" ]; then
+          echo "ERROR: Missing ESMPY_WEB_DEPLOY_KEY!"
           exit 1
         fi
-        echo "${{secrets.ESMF_WEB_DEPLOY_KEY}}" > ~/.ssh/id_rsa
+        echo "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
         git config --global user.name "ESMF-Bot"
         git config --global user.email "esmf_support@ucar.edu"

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -42,21 +42,12 @@ jobs:
         name: esmpy-docs
         path: ${{ github.workspace }}/artifacts
     
-    - name: Setup deployment
-      env:
-        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
-      run: | 
-        mkdir -p ~/.ssh
-        if [ -z "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" ]; then
-          echo "ERROR: Missing ESMPY_WEB_DEPLOY_KEY!"
-          exit 1
-        fi
-        set +o history
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        echo "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" | ssh-add -
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git clone --depth=1 git@github.com:esmf-org/esmpy_doc.git ${{ github.workspace }}/esmpy_doc
+    - name: Checkout esmpy_doc
+      uses: actions/checkout@v3
+      with:
+          repository: esmf-org/esmpy_doc
+          path: ${{github.workspace}}/esmpy_doc
+          ssh-key: ${{secrets.ESMPY_WEB_DEPLOY_KEY}}
     
     - name: Copy docs
       run: | 
@@ -69,11 +60,10 @@ jobs:
         cp -rf latex/ESMPy.pdf ${{ github.workspace }}/esmpy_doc/docs/nightly/${{ github.ref_name }}/
 
     - name: Commit and publish docs
-      env:
-        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
       run: |
         cd ${{ github.workspace }}/esmpy_doc
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git add .
         git diff-index --quiet HEAD || git commit --message "Publish ESMPy Docs"
         git push origin
-        ssh-add -D

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -49,8 +49,8 @@ jobs:
           echo "ERROR: Missing ESMPY_WEB_DEPLOY_KEY!"
           exit 1
         fi
-        echo "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{secrets.ESMPY_WEB_DEPLOY_KEY}}'
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git clone --depth=1 git@github.com:esmf-org/esmpy_doc.git ${{ github.workspace }}/esmpy_doc
@@ -71,4 +71,4 @@ jobs:
         git add .
         git diff-index --quiet HEAD || git commit --message "Publish ESMPy Docs"
         git push origin
-        rm ~/.ssh/id_rsa
+        ssh-add -D

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -51,6 +51,7 @@ jobs:
           echo "ERROR: Missing ESMPY_WEB_DEPLOY_KEY!"
           exit 1
         fi
+        set +o history
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
         ssh-add - <<< "${{secrets.ESMPY_WEB_DEPLOY_KEY}}"
         git config --global user.name "github-actions[bot]"

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -51,8 +51,8 @@ jobs:
         fi
         echo "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
-        git config --global user.name "ESMF-Bot"
-        git config --global user.email "esmf_support@ucar.edu"
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git clone --depth=1 git@github.com:esmf-org/esmpy_doc.git ${{ github.workspace }}/esmpy_doc
     
     - name: Copy docs

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -41,13 +41,19 @@ jobs:
       with:
         name: esmpy-docs
         path: ${{ github.workspace }}/artifacts
-        
-    - name: Checkout esmpy_doc
-      uses: actions/checkout@v3
-      with:
-          repository: esmf-org/esmpy_doc
-          path: esmpy_doc
-          token: ${{ secrets.ESMF_WEB_TOKEN }}
+    
+    - name: Setup deployment
+      run: | 
+        mkdir -p ~/.ssh
+        if [ -z "${{secrets.ESMF_WEB_DEPLOY_KEY}}" ]; then
+          echo "ERROR: Missing ESMF_WEB_DEPLOY_KEY!"
+          exit 1
+        fi
+        echo "${{secrets.ESMF_WEB_DEPLOY_KEY}}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        git config --global user.name "ESMF-Bot"
+        git config --global user.email "esmf_support@ucar.edu"
+        git clone --depth=1 git@github.com:esmf-org/esmpy_doc.git ${{ github.workspace }}/esmpy_doc
     
     - name: Copy docs
       run: | 
@@ -60,10 +66,8 @@ jobs:
         cp -rf latex/ESMPy.pdf ${{ github.workspace }}/esmpy_doc/docs/nightly/${{ github.ref_name }}/
 
     - name: Commit and publish docs
-      uses: actions-js/push@master
-      with:
-        repository: esmf-org/esmpy_doc
-        directory: ${{ github.workspace }}/esmpy_doc
-        branch: master
-        github_token: ${{ secrets.ESMF_WEB_TOKEN }}
-        message: 'Publish ESMPy Docs'
+      run: |
+        cd ${{ github.workspace }}/esmpy_doc
+        git diff-index --quiet HEAD || git commit --message "Publish ESMPy Docs"
+        git push origin
+        rm ~/.ssh/id_rsa

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -53,7 +53,7 @@ jobs:
         fi
         set +o history
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        ssh-add - <<< "${{secrets.ESMPY_WEB_DEPLOY_KEY}}"
+        echo "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" | ssh-add -
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git clone --depth=1 git@github.com:esmf-org/esmpy_doc.git ${{ github.workspace }}/esmpy_doc

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -68,6 +68,7 @@ jobs:
     - name: Commit and publish docs
       run: |
         cd ${{ github.workspace }}/esmpy_doc
+        git add .
         git diff-index --quiet HEAD || git commit --message "Publish ESMPy Docs"
         git push origin
         rm ~/.ssh/id_rsa

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -43,14 +43,16 @@ jobs:
         path: ${{ github.workspace }}/artifacts
     
     - name: Setup deployment
+      env:
+        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
       run: | 
         mkdir -p ~/.ssh
         if [ -z "${{secrets.ESMPY_WEB_DEPLOY_KEY}}" ]; then
           echo "ERROR: Missing ESMPY_WEB_DEPLOY_KEY!"
           exit 1
         fi
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{secrets.ESMPY_WEB_DEPLOY_KEY}}'
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add - <<< "${{secrets.ESMPY_WEB_DEPLOY_KEY}}"
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git clone --depth=1 git@github.com:esmf-org/esmpy_doc.git ${{ github.workspace }}/esmpy_doc
@@ -66,6 +68,8 @@ jobs:
         cp -rf latex/ESMPy.pdf ${{ github.workspace }}/esmpy_doc/docs/nightly/${{ github.ref_name }}/
 
     - name: Commit and publish docs
+      env:
+        SSH_AUTH_SOCK: ${{runner.temp}}/ssh_agent.sock
       run: |
         cd ${{ github.workspace }}/esmpy_doc
         git add .


### PR DESCRIPTION
Remove 3rd party GitHub Action
Uses deploy keys instead of personal access tokens
Separate deploy keys for ESMF_WEB_DEPLOY_KEY and ESMPY_WEB_DEPLOY_KEY are required
Code is always checking out and committing to default branches of 
- esmf-org.github.io
- esmpy_doc

Please use MERGE SQUASH