### PR TITLE
Feature/tclune/#185 eliminate cs global array

### DIFF
--- a/src/Infrastructure/Mesh/interface/ESMF_Mesh.F90
+++ b/src/Infrastructure/Mesh/interface/ESMF_Mesh.F90
@@ -4329,11 +4329,11 @@ function ESMF_MeshCreateCubedSphere(tileSize, nx, ny, name, rc)
         ! Generate glocal edge coordinates and local center coordinates
         allocate(lonCenter(count(1,i), count(2,i)), latCenter(count(1,i), count(2,i)))
         if (i==1) then
-           call ESMF_UtilCreateCSCoords(tileSize, lonEdge=lonEdge, latEdge=latEdge, &
+           call ESMF_UtilCreateCSCoordsPar(tileSize, lonEdge=lonEdge, latEdge=latEdge, &
                 start=start(:,i), count=count(:,i), &
                 tile=tileno(i), lonCenter=lonCenter, latCenter=latCenter)
         else
-           call ESMF_UtilCreateCSCoords(tileSize, start=start(:,i), count=count(:,i), &
+           call ESMF_UtilCreateCSCoordsPar(tileSize, start=start(:,i), count=count(:,i), &
                  tile=tileno(i), lonCenter=lonCenter, latCenter=latCenter)
         endif
         !call ESMF_VMWtime(endtime, rc=rc)


### PR DESCRIPTION
This version "works".   It has a much smaller memory footprint.  Runs much faster and the results are more accurate by 3-4 digits.

But ... backward compatibility means we need to add a switch to preserve old behavior, and that will take a bit more work.

I wanted to get this in front of the core team before the gov't shutdown so that they might have advice to finish it up when I can return to work.   (Or maybe they'll take ownership from here?)

@atrayano is still in the process of verifying the memory reduction.