### PR TITLE
Fix for Spack build action

### DIFF
--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -82,7 +82,7 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get -qq install tar unzip file curl gringo
         sudo apt-get -qq install build-essential binutils-dev gfortran gdb
-        sudo apt-get -qq install libgfortran-12 libgfortran-13
+        sudo apt-get -qq install gfortran-12 gfortran-13
         sudo apt-get -qq install python3-dev
 
     # restore Intel oneAPI compiler installation from cache

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -82,6 +82,7 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get -qq install tar unzip file curl gringo
         sudo apt-get -qq install build-essential binutils-dev gfortran gdb
+        sudo apt-get -qq install libgfortran-12 libgfortran-13
         sudo apt-get -qq install python3-dev
 
     # restore Intel oneAPI compiler installation from cache


### PR DESCRIPTION
This PR fixes issue with the automated Spack build. The actions tarted to fail due to missing gfortran (version 12 and 13) packages. This changes add extra code to install those packages explicitly. 