### PR TITLE
Add artifacts to Spack build action for debugging

### DIFF
--- a/.github/workflows/scripts/run_nuopc_app_proto.sh
+++ b/.github/workflows/scripts/run_nuopc_app_proto.sh
@@ -89,8 +89,10 @@ echo "-------------"
 echo "PASSED TESTS:"
 echo "-------------"
 cat testProtos_summary.log | grep "PASS"
-if [[ ! -z "$result_fail" ]]; then
-  echo "Some of NUOPC app prototypes are failed! Exiting ..."
-  exit 1
-fi
 echo "::endgroup::"
+
+if [[ ! -z "$result_fail" ]]; then
+  echo "NUOPC_APP_PROTO_PASS=$(echo 'false')" >> $GITHUB_ENV
+else
+  echo "NUOPC_APP_PROTO_PASS=$(echo 'true')" >> $GITHUB_ENV
+fi

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -119,7 +119,7 @@ jobs:
           -r ${{ github.workspace }}
 
     # checkout NUOPC app prototypes
-    - name: Checkout NUOPC app prototypes
+    - name: Checkout NUOPC App Prototypes
       uses: actions/checkout@v3
       with:
         repository: esmf-org/nuopc-app-prototypes
@@ -127,7 +127,7 @@ jobs:
         ref: ${{ needs.set-matrix.outputs.nuopc_app_version }}
 
     # test installation using NUOPC app prototypes
-    - name: Run NUOPC app prototypes
+    - name: Run NUOPC App Prototypes
       run: |
         ${{ github.workspace }}/.github/workflows/scripts/run_nuopc_app_proto.sh \
           -c ${{ matrix.compiler }} \
@@ -135,7 +135,7 @@ jobs:
           -s ~/.spack-ci
 
     # compress run directory of NUOPC app prototypes
-    - name: Compress Run Directory
+    - name: Compress NUOPC App Prototypes Run Directory
       run: |
         cd ${{ github.workspace }}
         tar -cvf nuopc-app-prototypes.tar nuopc-app-prototypes/
@@ -150,7 +150,7 @@ jobs:
         retention-days: 5
 
     # force to fail if there is any failed nuopc app prototypes
-    - name: Result of Baseline Check
+    - name: Check Result of NUOPC App Prototypes 
       run: |
         if [[ "${{ env.NUOPC_APP_PROTO_PASS }}" == "false" ]]; then
           echo "Some of NUOPC app prototypes are failed! Exiting ..."

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -103,20 +103,20 @@ jobs:
         scripts/install_oneapi.sh -c ${{ matrix.compiler }}
 
     # concretize test environment 
-    #- name: Concretize Spack Environment Using YAML Specification
-    #  run: |
-    #    ${{ github.workspace }}/.github/workflows/scripts/spack_concretize.sh \
-    #      -a x86_64 \
-    #      -c ${{ matrix.compiler }} \
-    #      -d ${{ matrix.esmf }} \
-    #      -i ~/.spack-ci \
-    #      -r ${{ github.workspace }} 
+    - name: Concretize Spack Environment Using YAML Specification
+      run: |
+        ${{ github.workspace }}/.github/workflows/scripts/spack_concretize.sh \
+          -a x86_64 \
+          -c ${{ matrix.compiler }} \
+          -d ${{ matrix.esmf }} \
+          -i ~/.spack-ci \
+          -r ${{ github.workspace }} 
 
     # install test environment
-    #- name: Install ESMF with Spack 
-    #  run: |
-    #    ${{ github.workspace }}/.github/workflows/scripts/spack_install.sh \
-    #      -r ${{ github.workspace }}
+    - name: Install ESMF with Spack 
+      run: |
+        ${{ github.workspace }}/.github/workflows/scripts/spack_install.sh \
+          -r ${{ github.workspace }}
 
     # checkout NUOPC app prototypes
     - name: Checkout NUOPC app prototypes
@@ -145,7 +145,7 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: Artifacts for ${{ matrix.compiler }} ${{ matrix.esmf_version }} ${{ matrix.nuopc_app_version }} 
+        name: Artifacts for ${{ matrix.compiler }} ${{ matrix.esmf }}
         path: ${{ github.workspace }}/nuopc-app-prototypes.tar.gz
         retention-days: 5
 

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -103,20 +103,20 @@ jobs:
         scripts/install_oneapi.sh -c ${{ matrix.compiler }}
 
     # concretize test environment 
-    - name: Concretize Spack Environment Using YAML Specification
-      run: |
-        ${{ github.workspace }}/.github/workflows/scripts/spack_concretize.sh \
-          -a x86_64 \
-          -c ${{ matrix.compiler }} \
-          -d ${{ matrix.esmf }} \
-          -i ~/.spack-ci \
-          -r ${{ github.workspace }} 
+    #- name: Concretize Spack Environment Using YAML Specification
+    #  run: |
+    #    ${{ github.workspace }}/.github/workflows/scripts/spack_concretize.sh \
+    #      -a x86_64 \
+    #      -c ${{ matrix.compiler }} \
+    #      -d ${{ matrix.esmf }} \
+    #      -i ~/.spack-ci \
+    #      -r ${{ github.workspace }} 
 
     # install test environment
-    - name: Install ESMF with Spack 
-      run: |
-        ${{ github.workspace }}/.github/workflows/scripts/spack_install.sh \
-          -r ${{ github.workspace }}
+    #- name: Install ESMF with Spack 
+    #  run: |
+    #    ${{ github.workspace }}/.github/workflows/scripts/spack_install.sh \
+    #      -r ${{ github.workspace }}
 
     # checkout NUOPC app prototypes
     - name: Checkout NUOPC app prototypes
@@ -133,3 +133,29 @@ jobs:
           -c ${{ matrix.compiler }} \
           -r ${{ github.workspace }}/nuopc-app-prototypes \
           -s ~/.spack-ci
+
+    # compress run directory of NUOPC app prototypes
+    - name: Compress Run Directory
+      run: |
+        tar -cvf nuopc-app-prototypes.tar ${{ github.workspace }}/nuopc-app-prototypes
+        gzip nuopc-app-prototypes.tar
+
+    # push test results to artifacts
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: nuopc-app-prototypes.tar.gz 
+        path: ${{ github.workspace }}
+        retention-days: 5
+
+    # force to fail if there is any failed nuopc app prototypes
+    - name: Result of Baseline Check
+      run: |
+        if [[ "${{ env.NUOPC_APP_PROTO_PASS }}" == "false" ]]; then
+          echo "Some of NUOPC app prototypes are failed! Exiting ..."
+          exit 1
+        else
+          echo "All tests are passed."
+          exit 0
+        fi
+      shell: bash

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -137,15 +137,16 @@ jobs:
     # compress run directory of NUOPC app prototypes
     - name: Compress Run Directory
       run: |
-        tar -cvf nuopc-app-prototypes.tar ${{ github.workspace }}/nuopc-app-prototypes
+        cd ${{ github.workspace }}
+        tar -cvf nuopc-app-prototypes.tar nuopc-app-prototypes/
         gzip nuopc-app-prototypes.tar
 
     # push test results to artifacts
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: nuopc-app-prototypes.tar.gz 
-        path: ${{ github.workspace }}
+        name: Artifacts for ${{ matrix.compiler }} ${{ matrix.esmf_version }} ${{ matrix.nuopc_app_version }} 
+        path: ${{ github.workspace }}/nuopc-app-prototypes.tar.gz
         retention-days: 5
 
     # force to fail if there is any failed nuopc app prototypes


### PR DESCRIPTION
This PR aims to add new feature to Spack build action to store run directory of NUOPC App Prototypes as artifacts. @theurich this is replacement of https://github.com/esmf-org/esmf/pull/194. GitHub did not allow me to create PR with the previous branch. So, I created new one.