### PR TITLE
Simplify uploaded artifacts

### DIFF
--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -134,12 +134,19 @@ jobs:
           -r ${{ github.workspace }}/nuopc-app-prototypes \
           -s ~/.spack-ci
 
-    # push test results to artifacts
+    # compress run directory of NUOPC app prototypes
+    - name: Prepare NUOPC App Prototypes Artifacts Directory
+      run: |
+        cd ${{ github.workspace }}/nuopc-app-prototypes
+        mkdir Artifacts
+        mv NUOPC-PROTO-RESULTS Artifacts/
+
+   # push test results to artifacts
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Artifacts for ${{ matrix.compiler }} ${{ matrix.esmf }}
-        path: ${{ github.workspace }}/nuopc-app-prototypes/NUOPC-PROTO-RESULTS
+        path: ${{ github.workspace }}/nuopc-app-prototypes/Artifacts
         retention-days: 5
 
     # force to fail if there is any failed nuopc app prototypes

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -134,19 +134,12 @@ jobs:
           -r ${{ github.workspace }}/nuopc-app-prototypes \
           -s ~/.spack-ci
 
-    # compress run directory of NUOPC app prototypes
-    - name: Compress NUOPC App Prototypes Run Directory
-      run: |
-        cd ${{ github.workspace }}
-        tar -cvf nuopc-app-prototypes.tar nuopc-app-prototypes/
-        gzip nuopc-app-prototypes.tar
-
     # push test results to artifacts
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Artifacts for ${{ matrix.compiler }} ${{ matrix.esmf }}
-        path: ${{ github.workspace }}/nuopc-app-prototypes.tar.gz
+        path: ${{ github.workspace }}/nuopc-app-prototypes/NUOPC-PROTO-RESULTS
         retention-days: 5
 
     # force to fail if there is any failed nuopc app prototypes


### PR DESCRIPTION
Simplifications:
- Only capture what is collected under the `NUOPC-PROTO-RESULTS` directory when running the NUOPC protos.
- Rely exclusively on the `actions/upload-artifact@v3` compression (zip), rather than tar and gzip. This simplifies artifacts usage.