### PR TITLE
BLD: Get ESMF compiling on Cygwin

### DIFF
--- a/.github/workflows/test-build-cygwin.yml
+++ b/.github/workflows/test-build-cygwin.yml
@@ -1,0 +1,74 @@
+name: Test on Cygwin
+on: ["push", "pull_request"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  SHELLOPTS: igncr
+  CYGWIN_NOWINPATH: 1
+  CHERE_INVOKING: 1
+  ESMF_DIR: /cygdrive/d/a/esmf/esmf
+  ESMF_BOPT: O
+  ESMF_OPTLEVEL: 2
+  ESMF_COMM: mpiuni
+  ESMF_COMPILER: gfortran
+  ESMF_TESTSHAREDOBJ: ON
+  ESMF_RANLIB: ranlib
+  ESMF_LAPACK: system
+  ESMF_LAPACK_LIBPATH: /usr/lib
+  ESMF_LAPACK_LIBS: -llapack -lblas
+  NETCDF: /usr
+  ESMF_NETCDF: split
+  ESMF_NETCDF_INCLUDE: /usr/include
+  ESMF_NETCDF_LIBPATH: /usr/lib
+  ESMF_CXX: g++
+  ESMF_CXXCOMPILEOPTS: "-g -O2"
+  ESMF_F90: gfortran
+  ESMF_F90COMPILEOPTS: "-g -O2"
+  ESMF_INSTALL_PREFIX: /tmp/fakeroot/usr
+  ESMF_INSTALL_DOCDIR: share/doc/esmf
+
+jobs:
+  cygwin_build_test:
+    runs-on: windows-latest
+    steps:
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: cygwin/cygwin-install-action@v4
+        with:
+          platform: x86_64
+          install-dir: 'C:\tools\cygwin'
+          packages: >-
+            openmpi gcc-core gcc-fortran gcc-g++ libnetcdf-devel libnetcdf-fortran-devel 
+            texlive-collection-latex texlive-collection-latexextra perl make bash dash 
+            liblapack-devel
+            python39-devel python39-pip python39-numpy python39-pytest
+      - name: Set Windows PATH
+        uses: egor-tensin/cleanup-path@v3
+        with:
+          dirs: 'C:\tools\cygwin\bin;C:\tools\cygwin\lib\lapack'
+      - name: Check location
+        run: |
+          C:\tools\cygwin\bin\dash.exe -c "echo PWD; pwd; echo ESMF_DIR=${ESMF_DIR}"
+      - name: Build ESMF
+        run: |
+          C:\tools\cygwin\bin\dash.exe -c "/usr/bin/make all"
+      - name: Build ESMPy
+        run: |
+          C:\tools\cygwin\bin\dash.exe -c "cd src/addon/esmpy; python -m pip install ."
+      - name: Check ESMF
+        run: |
+          C:\tools\cygwin\bin\dash.exe -c "/usr/bin/make check"
+      - name: Check ESMPy
+        run: |
+          C:\tools\cygwin\bin\dash.exe -c "cd src/addon/esmpy; /usr/bin/make download test_all"
+      - name: Build ESMF Docs
+        run: |
+          C:\tools\cygwin\bin\dash.exe -c "/usr/bin/make doc"

--- a/build/common.mk
+++ b/build/common.mk
@@ -4027,7 +4027,11 @@ $(ESMF_LOCOBJDIR)/%.o : %.cpp
 
 .F90.$(ESMF_SL_SUFFIX):
 	$(ESMF_F90COMPILEFREECPP_CMD) $(ESMF_SO_F90COMPILEOPTS) $<
-	$(ESMF_F90LINKER) $(ESMF_SO_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) -o $@ $*.o $(ESMF_F90ESMFLINKLIBS)
+	if [ ${ESMF_SL_SUFFIX} -ne "dll.a" ] ; then \
+	$(ESMF_F90LINKER) $(ESMF_SO_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) -o $@ $*.o $(ESMF_F90ESMFLINKLIBS); \
+	else \
+	$(ESMF_F90LINKER) $(ESMF_SO_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) -shared -o $(@:.dll.a=.dll) -Wl,--out-implib=$@ -Wl,--export-all-symbols -Wl,--whole-archive $*.o -Wl,--no-whole-archive $(ESMF_F90ESMFLINKLIBS); \
+	fi;
 
 .F90.$(ESMF_LIB_SUFFIX):
 	$(ESMF_F90COMPILEFREECPP_CMD) $<
@@ -4128,11 +4132,16 @@ shared:
 		    mkdir tmp_$$NEXTLIB ;\
 		    cd tmp_$$NEXTLIB  ;\
 	                $(ESMF_AREXTRACT) ../$$NEXTLIB.$(ESMF_LIB_SUFFIX) ;\
+		    if [ "${ESMF_SL_SUFFIX}" -ne "dll.a" ] ; then \
                     echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
 		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
 		    echo Converting $$NEXTLIB.$(ESMF_SL_SUFFIX) to $$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) ;\
                     echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
 		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+		    else \
+			echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/cyg$${NEXTLIB#lib}\.dll -Wl,--out-implib=$(ESMF_LDIR)/$$NEXTLIB\.dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--whole-archive *.o -Wl,--no-whole-archive $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+                        $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/cyg$${NEXTLIB#lib}\.dll -Wl,--out-implib=$(ESMF_LDIR)/$$NEXTLIB\.dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--whole-archive *.o -Wl,--no-whole-archive $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+	            fi ;\
 		    cd .. ;\
 		    $(ESMF_RM) -r tmp_$$NEXTLIB ;\
 		fi ;\

--- a/build/common.mk
+++ b/build/common.mk
@@ -4027,10 +4027,10 @@ $(ESMF_LOCOBJDIR)/%.o : %.cpp
 
 .F90.$(ESMF_SL_SUFFIX):
 	$(ESMF_F90COMPILEFREECPP_CMD) $(ESMF_SO_F90COMPILEOPTS) $<
-	if [ ${ESMF_SL_SUFFIX} -ne "dll.a" ] ; then \
-	$(ESMF_F90LINKER) $(ESMF_SO_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) -o $@ $*.o $(ESMF_F90ESMFLINKLIBS); \
+	if [ $(ESMF_SL_SUFFIX) != "dll.a" ] ; then \
+	  $(ESMF_F90LINKER) $(ESMF_SO_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) -o $@ $*.o $(ESMF_F90ESMFLINKLIBS); \
 	else \
-	$(ESMF_F90LINKER) $(ESMF_SO_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) -shared -o $(@:.dll.a=.dll) -Wl,--out-implib=$@ -Wl,--export-all-symbols -Wl,--whole-archive $*.o -Wl,--no-whole-archive $(ESMF_F90ESMFLINKLIBS); \
+	  $(ESMF_F90LINKER) $(ESMF_SO_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) -shared -o $(@:.dll.a=.dll) -Wl,--out-implib=$@ -Wl,--export-all-symbols -Wl,--whole-archive $*.o -Wl,--no-whole-archive $(ESMF_F90ESMFLINKLIBS); \
 	fi;
 
 .F90.$(ESMF_LIB_SUFFIX):
@@ -4131,17 +4131,17 @@ shared:
 		    echo Converting $$NEXTLIB.a to $$NEXTLIB.$(ESMF_SL_SUFFIX) ;\
 		    mkdir tmp_$$NEXTLIB ;\
 		    cd tmp_$$NEXTLIB  ;\
-	                $(ESMF_AREXTRACT) ../$$NEXTLIB.$(ESMF_LIB_SUFFIX) ;\
-		    if [ "${ESMF_SL_SUFFIX}" -ne "dll.a" ] ; then \
-                    echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
-		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
-		    echo Converting $$NEXTLIB.$(ESMF_SL_SUFFIX) to $$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) ;\
-                    echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
-		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+		    $(ESMF_AREXTRACT) ../$$NEXTLIB.$(ESMF_LIB_SUFFIX) ;\
+		    if [ $(ESMF_SL_SUFFIX) != "dll.a" ] ; then \
+		        echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
+		        $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
+		        echo Converting $$NEXTLIB.$(ESMF_SL_SUFFIX) to $$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) ;\
+		        echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+		        $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
 		    else \
 			echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/cyg$${NEXTLIB#lib}\.dll -Wl,--out-implib=$(ESMF_LDIR)/$$NEXTLIB\.dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--whole-archive *.o -Wl,--no-whole-archive $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
-                        $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/cyg$${NEXTLIB#lib}\.dll -Wl,--out-implib=$(ESMF_LDIR)/$$NEXTLIB\.dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--whole-archive *.o -Wl,--no-whole-archive $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
-	            fi ;\
+		        $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/cyg$${NEXTLIB#lib}\.dll -Wl,--out-implib=$(ESMF_LDIR)/$$NEXTLIB\.dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--whole-archive *.o -Wl,--no-whole-archive $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+		    fi ;\
 		    cd .. ;\
 		    $(ESMF_RM) -r tmp_$$NEXTLIB ;\
 		fi ;\

--- a/build_config/Cygwin.gfortran.default/build_rules.mk
+++ b/build_config/Cygwin.gfortran.default/build_rules.mk
@@ -9,6 +9,7 @@
 ESMF_F90DEFAULT         = gfortran
 ESMF_CXXDEFAULT         = g++
 ESMF_CDEFAULT           = gcc
+ESMF_CXXCOMPILECPPFLAGS+= -D_BSD_SOURCE -D_POSIX_C_SOURCE=199309L
 
 ############################################################
 # Default MPI setting.
@@ -115,8 +116,8 @@ ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################
 # Cygwin 1.5.24 does not yet support POSIX IPC (memory mapped files)
-#
-ESMF_CXXCOMPILECPPFLAGS += -DESMF_NO_POSIXIPC
+# Cygwin 3.4.9 might
+# ESMF_CXXCOMPILECPPFLAGS += -DESMF_NO_POSIXIPC
  
 ############################################################
 # Fortran symbol convention


### PR DESCRIPTION
I updated my ESMF build on Cygwin, and tried to generalize my changes from the last time I did this so ESMF would still compile on Linux.

I also added a CI run to ensure ESMF compilation gets checked. I think I set up the tests to run as well, but I'm less sure of that.

Might close https://github.com/esmf-org/esmf/issues/136; I'm not sure if they're after a Cygwin build of ESMF or a 64-bit MinGW/Windows build of ESMF. PR https://github.com/esmf-org/esmf/pull/149 suggests they're after a MinGW-w64 build but are trying to do it in Cygwin without cross-compilers for whatever reason.

Follow-on to #201.