### PR TITLE
Minor documentation tweak for ESMF_Info section (Infrastructure/Base)

### DIFF
--- a/src/Infrastructure/Base/doc/Info_desc.tex
+++ b/src/Infrastructure/Base/doc/Info_desc.tex
@@ -69,8 +69,6 @@ Notice again that the {\tt ESMF\_Attribute} API automatically prepends "/ESMF/Ge
 \label{info_key_format}
 A key in the \texttt{ESMF\_Info} interface provides the location of a value to retrieve from the key-value storage. Keys in the \texttt{ESMF\_Info} class use the JSON Pointer syntax \cite{json_for_modern_cpp_json_pointer}. A forward slash is prepended to string keys if it does not exist. Hence, \texttt{"aKey"} and \texttt{"/aKey"} are equivalent. Note the indexing aspect of the JSON Pointer syntax is not supported.
 
-Every "key" argument in the \texttt{ESMF\_Info} class uses pathing following the JSON Pointer syntax [6]. A forward slash is prepended to string keys if it does not exist. Hence, "aKey" and "/aKey" are equivalent. Note the indexing aspect of the JSON Pointer syntax is not supported (i.e. "/my\_list~1").
-
 Some examples for valid "key" arguments:
 \begin{itemize}
     \item \texttt{altitude} :: A simple key argument with no nesting.


### PR DESCRIPTION
This is a totally minor PR, but I was reading the ESMF_Info section and noticed this duplication in the documentation.  In short, two paragraphs said mostly the same thing, just slightly differently.  The first one seemed to be more clear, so I kept that.

It was also just an opportunity to do a very simple PR.  :-)