### PR TITLE
Fix build of libesmftrace_preload.dylib on Darwin-openmpi

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -2049,6 +2049,8 @@ ESMF_TRACE_LDPRELOAD := $(ESMF_LIBDIR)/libesmftrace_preload.$(ESMF_SL_SUFFIX)
 ESMF_PRELOADSCRIPT = $(ESMF_LIBDIR)/preload.sh
 
 ESMF_SL_PRELOAD_LIBLINKER = $(ESMF_CXXCOMPILER)
+ESMF_SL_PRELOAD_LIBOPTS = $(ESMF_CXXLINKOPTS)
+ESMF_SL_PRELOAD_LIBLIBS = $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS)
 
 ifeq ($(ESMF_OS),Darwin)
 ESMF_ENV_PRELOAD          = DYLD_INSERT_LIBRARIES
@@ -2056,6 +2058,10 @@ ESMF_ENV_PRELOAD_DELIMIT  = ':'
 ifeq ($(ESMF_COMM),openmpi)
 # make sure to link in the Fortran MPI bindings
 ESMF_SL_PRELOAD_LIBLINKER = $(ESMF_F90COMPILER)
+# and since we're using the F90 compiler as the linker, make sure to use link
+# options and libs appropriate for the F90 compiler instead of the C++ compiler
+ESMF_SL_PRELOAD_LIBOPTS = $(ESMF_F90LINKOPTS)
+ESMF_SL_PRELOAD_LIBLIBS = $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90LINKLIBS)
 endif
 else
 ESMF_ENV_PRELOAD          = LD_PRELOAD

--- a/build_config/Darwin.gfortranclang.default/build_rules.mk
+++ b/build_config/Darwin.gfortranclang.default/build_rules.mk
@@ -272,8 +272,7 @@ ESMF_F90LINKLIBS += -lgfortran
 ############################################################
 # Shared library options
 ESMF_SL_LIBOPTS  += -dynamiclib
-# No need for "$(ESMF_F90LINKPATHS) $(ESMF_F90LINKLIBS)" in the following because they are identical to the CXX versions:
-ESMF_SL_LIBLIBS  += $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKLIBS)
+ESMF_SL_LIBLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKLIBS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKLIBS)
 
 ############################################################
 # Static builds on Darwin do not support trace lib due to missing linker option

--- a/src/Infrastructure/Trace/preload/makefile
+++ b/src/Infrastructure/Trace/preload/makefile
@@ -32,7 +32,7 @@ ifeq  ($(ESMF_OS),MinGW)
 endif
 
 tracelib_preload: preload.o preload_mpi.o wrappers.o wrappers_mpi.o
-	$(ESMF_SL_PRELOAD_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/libesmftrace_preload.$(ESMF_SL_SUFFIX) $^ $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) $(ESMF_TRACE_ESMFLIB)
+	$(ESMF_SL_PRELOAD_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/libesmftrace_preload.$(ESMF_SL_SUFFIX) $^ $(ESMF_SL_PRELOAD_LIBOPTS) $(ESMF_SL_PRELOAD_LIBLIBS) $(ESMF_TRACE_ESMFLIB)
 	$(MAKE) ESMF_PRELOADDIR=$(ESMF_LIBDIR) build_preload_script
 
 tracelib_static: wrappers_io.o wrappers_mpi.o wrappers.o


### PR DESCRIPTION
With Darwin-openmpi, we use a Fortran linker for libesmftrace_preload.dylib. But the link command was using flags appropriate for a C++ linker rather than a Fortran linker. This PR changes the link flags to be appropriate for a Fortran linker in this case.

I have tested this on my Mac (green, with gfortranclang+openmpi) and confirmed that this resolves the build issues I was running into.

I have also tested this on catania and derecho to ensure that this doesn't break the build / test on other systems.

@theurich I'd welcome a quick look.