### PR TITLE
Add 'ESMF::ESMF' CMake target alias to support unambiguous linking

### DIFF
--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -109,6 +109,9 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
+  # Add target alias to facilitate unambiguous linking
+  add_library(ESMF::ESMF ALIAS ESMF)
+
   # Add ESMF include directories
   set(ESMF_INCLUDE_DIRECTORIES "")
   separate_arguments(_ESMF_F90COMPILEPATHS UNIX_COMMAND ${ESMF_F90COMPILEPATHS})

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -110,7 +110,9 @@ if(EXISTS ${ESMFMKFILE})
   endif()
 
   # Add target alias to facilitate unambiguous linking
-  add_library(ESMF::ESMF ALIAS ESMF)
+  if(NOT TARGET ESMF::ESMF)
+    add_library(ESMF::ESMF ALIAS ESMF)
+  endif()
 
   # Add ESMF include directories
   set(ESMF_INCLUDE_DIRECTORIES "")

--- a/src/addon/ESMX/Comps/ESMX_Data/cmake/FindESMF.cmake
+++ b/src/addon/ESMX/Comps/ESMX_Data/cmake/FindESMF.cmake
@@ -109,6 +109,11 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
+  # Add target alias to facilitate unambiguous linking
+  if(NOT TARGET ESMF::ESMF)
+    add_library(ESMF::ESMF ALIAS ESMF)
+  endif()
+
   # Add ESMF include directories
   set(ESMF_INCLUDE_DIRECTORIES "")
   separate_arguments(_ESMF_F90COMPILEPATHS UNIX_COMMAND ${ESMF_F90COMPILEPATHS})

--- a/src/addon/ESMX/Driver/cmake/FindESMF.cmake
+++ b/src/addon/ESMX/Driver/cmake/FindESMF.cmake
@@ -109,6 +109,11 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
+  # Add target alias to facilitate unambiguous linking
+  if(NOT TARGET ESMF::ESMF)
+    add_library(ESMF::ESMF ALIAS ESMF)
+  endif()
+
   # Add ESMF include directories
   set(ESMF_INCLUDE_DIRECTORIES "")
   separate_arguments(_ESMF_F90COMPILEPATHS UNIX_COMMAND ${ESMF_F90COMPILEPATHS})


### PR DESCRIPTION
This PR adds an alias to the CMake target `ESMF` called `ESMF::ESMF`. This way, when a downstream package calls `target_link_libraries(ESMF::ESMF)` it will fail if the target isn't found, rather than generating a spurious and unwanted `-lESMF` flag. Using the alias leaves the `ESMF` target itself untouched, so no adverse consequences are anticipated.