### PR TITLE
Update FindESMF.cmake to make ESMF::ESMF main target

### DIFF
--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -109,7 +109,7 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
-  # Add target alias to facilitate unambiguous linking
+  # Add ESMF as an alias to ESMF::ESMF for backward compatibility
   if(NOT TARGET ESMF)
     add_library(ESMF ALIAS ESMF::ESMF)
   endif()

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -96,22 +96,22 @@ if(EXISTS ${ESMFMKFILE})
       message(WARNING "Static ESMF library (libesmf.a) not found in \
                        ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF STATIC IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF STATIC IMPORTED)
     endif()
   else()
     find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
     if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
       message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF UNKNOWN IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF UNKNOWN IMPORTED)
     endif()
   endif()
 
   # Add target alias to facilitate unambiguous linking
-  if(NOT TARGET ESMF::ESMF)
-    add_library(ESMF::ESMF ALIAS ESMF)
+  if(NOT TARGET ESMF)
+    add_library(ESMF ALIAS ESMF::ESMF)
   endif()
 
   # Add ESMF include directories
@@ -135,7 +135,7 @@ if(EXISTS ${ESMFMKFILE})
                       ESMF_F90COMPILEPATHS
         VERSION_VAR ESMF_VERSION)
 
-  set_target_properties(ESMF PROPERTIES
+  set_target_properties(ESMF::ESMF PROPERTIES
         IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
         INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
         INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")

--- a/src/addon/ESMX/Comps/ESMX_Data/cmake/FindESMF.cmake
+++ b/src/addon/ESMX/Comps/ESMX_Data/cmake/FindESMF.cmake
@@ -96,22 +96,22 @@ if(EXISTS ${ESMFMKFILE})
       message(WARNING "Static ESMF library (libesmf.a) not found in \
                        ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF STATIC IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF STATIC IMPORTED)
     endif()
   else()
     find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
     if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
       message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF UNKNOWN IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF UNKNOWN IMPORTED)
     endif()
   endif()
 
-  # Add target alias to facilitate unambiguous linking
-  if(NOT TARGET ESMF::ESMF)
-    add_library(ESMF::ESMF ALIAS ESMF)
+  # Add ESMF as an alias to ESMF::ESMF for backward compatibility
+  if(NOT TARGET ESMF)
+    add_library(ESMF ALIAS ESMF::ESMF)
   endif()
 
   # Add ESMF include directories
@@ -135,7 +135,7 @@ if(EXISTS ${ESMFMKFILE})
                       ESMF_F90COMPILEPATHS
         VERSION_VAR ESMF_VERSION)
 
-  set_target_properties(ESMF PROPERTIES
+  set_target_properties(ESMF::ESMF PROPERTIES
         IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
         INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
         INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")

--- a/src/addon/ESMX/Driver/cmake/FindESMF.cmake
+++ b/src/addon/ESMX/Driver/cmake/FindESMF.cmake
@@ -96,22 +96,22 @@ if(EXISTS ${ESMFMKFILE})
       message(WARNING "Static ESMF library (libesmf.a) not found in \
                        ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF STATIC IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF STATIC IMPORTED)
     endif()
   else()
     find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
     if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
       message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF UNKNOWN IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF UNKNOWN IMPORTED)
     endif()
   endif()
 
-  # Add target alias to facilitate unambiguous linking
-  if(NOT TARGET ESMF::ESMF)
-    add_library(ESMF::ESMF ALIAS ESMF)
+  # Add ESMF as an alias to ESMF::ESMF for backward compatibility
+  if(NOT TARGET ESMF)
+    add_library(ESMF ALIAS ESMF::ESMF)
   endif()
 
   # Add ESMF include directories
@@ -135,7 +135,7 @@ if(EXISTS ${ESMFMKFILE})
                       ESMF_F90COMPILEPATHS
         VERSION_VAR ESMF_VERSION)
 
-  set_target_properties(ESMF PROPERTIES
+  set_target_properties(ESMF::ESMF PROPERTIES
         IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
         INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
         INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")


### PR DESCRIPTION
As detailed in #225, our UFS collaborators would like MAPL to provide a `MAPL-targets.cmake` file that uses `ESMF::ESMF` as the target within. From my testing, this can only seem to work if `ESMF::ESMF` is the main target provided by `FindESMF.cmake` and not an `ALIAS`. 

So this PR does that, it essentially makes `ESMF::ESMF` the target the "main" `add_library()` call is run on and then makes `ESMF` the alias.

As far as I can tell, this works. All other needed changes are in GEOS and MAPL.