### PR TITLE
Fix FieldGet() index space info arguments to work for all staggers

### DIFF
--- a/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldGet.cppF90
@@ -374,11 +374,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     type(ESMF_FieldType), pointer :: ftype
     integer :: localrc, fieldrank
-    type(ESMF_GridDecompType) :: decompType
-    type(ESMF_GeomType_Flag) :: localGeomType
     type(ESMF_Status) :: fieldstatus
-    type(ESMF_Grid)             :: l_grid
-    type(ESMF_Mesh)             :: l_mesh
     type(ESMF_DistGrid)         :: distgrid
 
     ! Initialize
@@ -407,16 +403,12 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       status = ftype%status
     endif
 
-    ! set default decomp type to non-arb.
-    decompType = ESMF_GRID_NONARBITRARY
-
     ! Get the geometry type
     if (present(geomtype)) then
-        call ESMF_GeomGet(ftype%geom, geomtype=localGeomType, rc=localrc)
+        call ESMF_GeomGet(ftype%geom, geomtype=geomtype, rc=localrc)
         if (ESMF_LogFoundError(localrc, &
           ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-        geomtype = localGeomType
     endif
 
     if (present(geom)) then
@@ -651,40 +643,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if(present(minIndex) .or. present(maxIndex) .or. present(elementCount) .or. &
          present(localMinIndex) .or. present(localMaxIndex) .or. present(localElementCount)) then
 
-       call ESMF_GeomGet(ftype%geom, geomtype=localGeomType, rc=localrc)
-       if (ESMF_LogFoundError(localrc, &
-            ESMF_ERR_PASSTHRU, &
-            ESMF_CONTEXT, rcToReturn=rc)) return
-
-       if (localGeomType == ESMF_GEOMTYPE_GRID) then
-          call ESMF_GeomGet(ftype%geom, &
-               grid=l_grid, rc=localrc)
-          if (ESMF_LogFoundError(localrc, &
-               ESMF_ERR_PASSTHRU, &
-               ESMF_CONTEXT, rcToReturn=rc)) return
-          call ESMF_GridGet(l_grid, distgrid=distgrid, rc=localrc)
-          if (ESMF_LogFoundError(localrc, &
-               ESMF_ERR_PASSTHRU, &
-               ESMF_CONTEXT, rcToReturn=rc)) return
-       else if (localGeomType == ESMF_GEOMTYPE_MESH) then
-          call ESMF_GeomGet(ftype%geom, &
-               mesh=l_mesh, rc=localrc)
-          if (ESMF_LogFoundError(localrc, &
-               ESMF_ERR_PASSTHRU, &
-               ESMF_CONTEXT, rcToReturn=rc)) return
-          call ESMF_MeshGet(l_mesh, nodaldistgrid=distgrid, rc=localrc)
-          if (ESMF_LogFoundError(localrc, &
-               ESMF_ERR_PASSTHRU, &
-               ESMF_CONTEXT, rcToReturn=rc)) return
-       else
-          call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
-               msg="Only implemented for Grid and Mesh.", &
-               ESMF_CONTEXT, rcToReturn=rc)
-          return
-       endif
-
        call ESMF_ArrayGet(ftype%array, rank=fieldrank, &
-            rc=localrc)
+            distgrid=distgrid, rc=localrc)
        if (localrc .ne. ESMF_SUCCESS) then
           call ESMF_LogSetError(rcToCheck=ESMF_RC_OBJ_BAD, &
                msg="Cannot retrieve fieldrank from ftypep%array", &


### PR DESCRIPTION
The asynchronous write component under NEPTUNE uses `ESMF_Field` objects on `ESMF_STAGGERLOC_CORNER` for the output options that require regridding. I noticed that the index space info returned by `ESMF_FieldGet()`, e.g. `elementCount`, etc. were incorrect under this situation. Looking at the code I found that it seems it was coded only to work for `ESMF_STAGGERLOC_CENTER` when using Grid, and nodedistrid when using Mesh. This PR attempts to fix this problem, and should support all cases generally by simply using the `DistGrid` of the underlying `Array`.