### PR TITLE
Extend debug message for syncToRealTime() function

### DIFF
--- a/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
@@ -834,42 +834,42 @@ namespace ESMCI{
     {
         case ESMC_CALKIND_NOLEAP:
           ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
-            "; calkindflag is NOLEAP. Only GREGORIAN and JULIAN are supported.",
+            "; calkindflag is NOLEAP. Only GREGORIAN and JULIAN are supported when syncing to real time.",
             ESMC_CONTEXT, &rc);
           return(rc);
           break;
 
         case ESMC_CALKIND_360DAY:
           ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
-            "; calkindflag is 360DAY. Only GREGORIAN and JULIAN are supported.",
+            "; calkindflag is 360DAY. Only GREGORIAN and JULIAN are supported when syncing to real time.",
             ESMC_CONTEXT, &rc);
           return(rc);
           break;
 
         case ESMC_CALKIND_JULIANDAY:
           ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
-            "; calkindflag is JULIANDAY. Only GREGORIAN and JULIAN are supported.",
+            "; calkindflag is JULIANDAY. Only GREGORIAN and JULIAN are supported when syncing to real time.",
             ESMC_CONTEXT, &rc);
           return(rc);
           break;
 
         case ESMC_CALKIND_MODJULIANDAY:
           ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
-            "; calkindflag is MODJULIANDAY. Only GREGORIAN and JULIAN are supported.",
+            "; calkindflag is MODJULIANDAY. Only GREGORIAN and JULIAN are supported when syncing to real time.",
             ESMC_CONTEXT, &rc);
           return(rc);
           break;
 
         case ESMC_CALKIND_NOCALENDAR:
           ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
-            "; calkindflag is NOCALENDAR. Only GREGORIAN and JULIAN are supported.",
+            "; calkindflag is NOCALENDAR. Only GREGORIAN and JULIAN are supported when syncing to real time.",
             ESMC_CONTEXT, &rc);
           return(rc);
           break;
 
         case ESMC_CALKIND_CUSTOM:
           ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
-            "; calkindflag is CUSTOM. Only GREGORIAN and JULIAN are supported.",
+            "; calkindflag is CUSTOM. Only GREGORIAN and JULIAN are supported when syncing to real time.",
             ESMC_CONTEXT, &rc);
           return(rc);
           break;

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
@@ -830,13 +830,48 @@ namespace ESMCI{
       return(rc);
     }
 
-    if (this->calendar->calkindflag == ESMC_CALKIND_JULIANDAY ||
-        this->calendar->calkindflag == ESMC_CALKIND_MODJULIANDAY ||
-        this->calendar->calkindflag == ESMC_CALKIND_NOCALENDAR) {
-      ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
-        "; calkindflag is JULIANDAY, "
-        "MODJULIANDAY or NOCALENDAR.", ESMC_CONTEXT, &rc);
-      return(rc);
+    switch (this->calendar->calkindflag)
+    {
+        case ESMC_CALKIND_NOLEAP:
+          ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
+            "; calkindflag is NOLEAP. Only GREGORIAN and JULIAN are supported.",
+            ESMC_CONTEXT, &rc);
+          return(rc);
+          break;
+
+        case ESMC_CALKIND_360DAY:
+          ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
+            "; calkindflag is 360DAY. Only GREGORIAN and JULIAN are supported.",
+            ESMC_CONTEXT, &rc);
+          break;
+
+        case ESMC_CALKIND_JULIANDAY:
+          ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
+            "; calkindflag is JULIANDAY. Only GREGORIAN and JULIAN are supported.",
+            ESMC_CONTEXT, &rc);
+          return(rc);
+          break;
+
+        case ESMC_CALKIND_MODJULIANDAY:
+          ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
+            "; calkindflag is MODJULIANDAY. Only GREGORIAN and JULIAN are supported.",
+            ESMC_CONTEXT, &rc);
+          return(rc);
+          break;
+
+        case ESMC_CALKIND_NOCALENDAR:
+          ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
+            "; calkindflag is NOCALENDAR. Only GREGORIAN and JULIAN are supported.",
+            ESMC_CONTEXT, &rc);
+          return(rc);
+          break;
+
+        case ESMC_CALKIND_CUSTOM:
+          ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
+            "; calkindflag is CUSTOM. Only GREGORIAN and JULIAN are supported.",
+            ESMC_CONTEXT, &rc);
+          return(rc);
+          break;
     }
 
     time_t tm;

--- a/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
+++ b/src/Infrastructure/TimeMgr/src/ESMCI_Time.C
@@ -843,6 +843,7 @@ namespace ESMCI{
           ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_WRONG,
             "; calkindflag is 360DAY. Only GREGORIAN and JULIAN are supported.",
             ESMC_CONTEXT, &rc);
+          return(rc);
           break;
 
         case ESMC_CALKIND_JULIANDAY:


### PR DESCRIPTION
This PR aims to extend error messages of syncToRealTime() function for the calendars that does not support leap year. The message is also specialized for based on used calendar. For testing, `libfaketime` library is used by running test application using `srun --label -n 4 /work/noaa/nems/tufuk/ESMF/libfaketime/bin/faketime '2024-02-29 08:00:00' ./esmApp` command.

Linked issue: Fixes esmf-org/esmf-support#423