### PR TITLE
Fix spack build action

### DIFF
--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -83,7 +83,7 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get -qq install tar unzip file curl gringo
         sudo apt-get -qq install build-essential binutils-dev gfortran gdb
-        sudo apt-get -qq install gfortran-12 gfortran-13
+        sudo apt-get -qq install gfortran-12 g++-13 gfortran-13
         sudo apt-get -qq install python3-dev
 
     # restore Intel oneAPI compiler installation from cache

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -80,6 +80,7 @@ jobs:
     - name: Install Core Development Tools
       run: |
         sudo apt-get -qq update
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get -qq install tar unzip file curl gringo
         sudo apt-get -qq install build-essential binutils-dev gfortran gdb
         sudo apt-get -qq install gfortran-12 gfortran-13

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   set-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       matrix: ${{ steps.list_comp_pkgs.outputs.matrix }}
@@ -66,7 +66,7 @@ jobs:
   build:
     needs: set-matrix
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
@@ -80,10 +80,9 @@ jobs:
     - name: Install Core Development Tools
       run: |
         sudo apt-get -qq update
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get -qq install tar unzip file curl gringo
         sudo apt-get -qq install build-essential binutils-dev gfortran gdb
-        sudo apt-get -qq install gfortran-12 g++-13 gfortran-13
+        sudo apt-get -qq install gfortran-12 gfortran-13
         sudo apt-get -qq install python3-dev
 
     # restore Intel oneAPI compiler installation from cache


### PR DESCRIPTION
This PR aims to fix spack build action and includes following changes. 

- The new repo for apt get is added to allow Ubuntu to find gfortran-13 package correctly.
- The g++-13 package is also added to the list of required packages explicitly since Ubuntu was not installing it by default and spack package manager had issue to find the g++13 compiler.

The chnages in action is tested under my own personal fork. The successful run can be seen in https://github.com/uturuncoglu/esmf/actions/runs/9123456143/job/25085911284.