### PR TITLE
Fix ESMX module paths and library linking using packages

### DIFF
--- a/src/addon/ESMX/Driver/CMakeLists.txt
+++ b/src/addon/ESMX/Driver/CMakeLists.txt
@@ -32,6 +32,19 @@ execute_process(COMMAND ${Python_EXECUTABLE}
   ${CMAKE_CURRENT_LIST_DIR}/esmx_app_config.py --ifile ${ESMX_BUILD_FILE} --odir ${CMAKE_CURRENT_BINARY_DIR}
   RESULT_VARIABLE ret)
 esmx_check_ret(${ret} "esmx_app_config.py failed processing ${ESMX_BUILD_FILE}")
+
+include(${CMAKE_CURRENT_BINARY_DIR}/modConf.txt)
+
+# add module paths
+foreach(ESMX_CMAKE_MODULE_PATH IN ITEMS ${ESMX_LINK_MODULE_PATHS})
+  list(APPEND CMAKE_MODULE_PATH ${ESMX_CMAKE_MODULE_PATH})
+endforeach()
+
+# link packages
+foreach(ESMX_LINK_PACKAGE IN ITEMS ${ESMX_LINK_PACKAGES})
+  find_package(${ESMX_LINK_PACKAGE} REQUIRED)
+endforeach()
+
 include(${CMAKE_CURRENT_BINARY_DIR}/appConf.txt)
 
 # disabled components
@@ -121,24 +134,16 @@ add_library(esmx_driver ESMX_Driver.F90)
 target_include_directories(esmx_driver PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(esmx_driver PUBLIC ESMF)
 
-# add module paths
-foreach(ESMX_CMAKE_MODULE_PATH IN ITEMS ${ESMX_CMAKE_MODULE_PATHS})
-  list(APPEND CMAKE_MODULE_PATH ${ESMX_CMAKE_MODULE_PATH})
-endforeach()
-
-# link packages
-foreach(ESMX_LINK_PACKAGE IN ITEMS ${ESMX_LINK_PACKAGES})
-  find_package(${ESMX_LINK_PACKAGE} REQUIRED)
-endforeach()
-
 # link external libraries
 foreach(ESMX_LINK_LIBRARY IN ITEMS ${ESMX_LINK_LIBRARIES})
   if(TARGET ${ESMX_LINK_LIBRARY})
     target_link_libraries(esmx_driver PUBLIC ${ESMX_LINK_LIBRARY})
   else()
+    get_filename_component(FND_LIB_PATH ${ESMX_LINK_LIBRARY} DIRECTORY)
+    get_filename_component(FND_LIB_NAME ${ESMX_LINK_LIBRARY} NAME)
     find_library(FND_LINK_LIBRARY
-      NAMES ${ESMX_LINK_LIBRARY}
-      HINTS ${ESMX_LINK_PATHS}
+      NAMES ${FND_LIB_NAME}
+      HINTS ${ESMX_LINK_PATHS} ${FND_LIB_PATH}
       PATH_SUFFIXES "." "lib" "lib64"
       NO_CACHE
     )
@@ -147,6 +152,8 @@ foreach(ESMX_LINK_LIBRARY IN ITEMS ${ESMX_LINK_LIBRARIES})
     endif()
     target_link_libraries(esmx_driver PUBLIC ${FND_LINK_LIBRARY})
     unset(FND_LINK_LIBRARY)
+    unset(FND_LIB_PATH)
+    unset(FND_LIB_NAME)
   endif()
 endforeach()
 

--- a/src/addon/ESMX/Driver/esmx_app_config.py
+++ b/src/addon/ESMX/Driver/esmx_app_config.py
@@ -3,13 +3,31 @@ import sys
 import argparse
 from esmx_tools import *
 
+def create_modConf(appCfg: ESMXAppCfg, odir):
+    options = [ESMXOpt('link_module_paths', None, dir),
+               ESMXOpt('link_packages', None, str)]
+    # open file
+    with open(os.path.join(odir, 'modConf.txt'), 'w') as f:
+        for opt in options:
+            val = appCfg.get(opt.option, opt.default)
+            if (val):
+                val = str(val)
+                val = val.replace(" ", ";")
+                val = val.replace(",", ";")
+                if (opt.ctype == dir):
+                    dirs = list(val.split(";"))
+                    for i in range(len(dirs)):
+                        dirs[i] = dirs[i].strip()
+                        if not dirs[i].startswith('$'):
+                            dirs[i] = os.path.abspath(dirs[i])
+                    val = ';'.join(dirs)
+                f.write('set(ESMX_{} {})\n'.format(opt.upper(), val))
+
 def create_appConf(appCfg: ESMXAppCfg, odir):
     options = [ESMXOpt('exe_name', None, str),
                ESMXOpt('disable_comps', None, str),
-               ESMXOpt('link_module_paths', None, dir),
                ESMXOpt('link_paths', None, dir),
                ESMXOpt('link_libraries', None, str),
-               ESMXOpt('link_packages', None, str),
                ESMXOpt('build_args', None, str),
                ESMXOpt('build_jobs', None, str),
                ESMXOpt('build_verbose', None, str),
@@ -58,6 +76,9 @@ def main(argv):
 
     # read app configuration yaml file
     appCfg = ESMXAppCfg(ifile)
+
+    # create modConf.txt for CMake
+    create_modConf(appCfg, odir)
 
     # create appConf.txt for CMake
     create_appConf(appCfg, odir)

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -121,27 +121,27 @@ There are *three* top level sections recognized in the ESMX build file. Each is 
 
 These options affect the ESMX application layer. If no key/value pair is provided then the default will be used.
 
-| Option key            | Description / Value options                           | Default                |
-| --------------------- | ----------------------------------------------------- | ---------------------- |
-| `exe_name`            | executable name for application                       | `esmx_app`             |
-| `disable_comps`       | scalar or list of components to disable               | *None*                 |
-| `link_module_paths`   | scalar or list of search paths for CMake modules      | *None*                 |
-| `link_packages`       | scalar or list of cmake packages, linked to esmx      | *None*                 |
-| `link_paths`          | scalar or list of search path for external libraries  | *None*                 |
-| `link_libraries`      | scalar or list of external libraries, linked to esmx  | *None*                 |
-| `build_args`          | scalar or list of arguments passed to all build_types | *None*                 |
-| `build_jobs`          | job number used for all build_types                   | *None*                 |
-| `build_verbose`       | verbosity setting used for all build_types            | *None*                 |
-| `cmake_build_args`    | scalar or list of argumens passed to all cmake builds | *None*                 |
-| `cmake_build_jobs`    | job number used for all cmake builds                  | *None*                 |
-| `cmake_build_verbose` | verbosity setting used for all cmake builds           | *None*                 |
-| `make_build_args`     | scalar or list of argumens passed to all make builds  | *None*                 |
-| `make_build_jobs`     | job number used for all make builds                   | *None*                 |
-| `script_build_args`   | scalar or list of argumens passed to all script builds| *None*                 |
-| `test`                | (beta) add test cases: `on` or `off`                  | `off`                  |
-| `test_exe`            | (beta) executable used to launch test cases           | ESMF_INTERNAL_MPIRUN   |
-| `test_dir`            | (beta) output directory for test cases                | CMAKE_BINARY_DIR-tests |
-| `test_tasks`          | (beta) number of tasks used to run test cases         | `4`                    |
+| Option key            | Description / Value options                                          | Default                |
+| --------------------- | -------------------------------------------------------------------- | ---------------------- |
+| `exe_name`            | executable name for application                                      | `esmx_app`             |
+| `disable_comps`       | scalar or list of components to disable                              | *None*                 |
+| `link_module_paths`   | scalar or list of search paths for CMake modules                     | *None*                 |
+| `link_packages`       | scalar or list of cmake packages, use link_libraries to link to esmx | *None*                 |
+| `link_paths`          | scalar or list of search path for external libraries                 | *None*                 |
+| `link_libraries`      | scalar or list of external libraries, linked to esmx                 | *None*                 |
+| `build_args`          | scalar or list of arguments passed to all build_types                | *None*                 |
+| `build_jobs`          | job number used for all build_types                                  | *None*                 |
+| `build_verbose`       | verbosity setting used for all build_types                           | *None*                 |
+| `cmake_build_args`    | scalar or list of argumens passed to all cmake builds                | *None*                 |
+| `cmake_build_jobs`    | job number used for all cmake builds                                 | *None*                 |
+| `cmake_build_verbose` | verbosity setting used for all cmake builds                          | *None*                 |
+| `make_build_args`     | scalar or list of argumens passed to all make builds                 | *None*                 |
+| `make_build_jobs`     | job number used for all make builds                                  | *None*                 |
+| `script_build_args`   | scalar or list of argumens passed to all script builds               | *None*                 |
+| `test`                | (beta) add test cases: `on` or `off`                                 | `off`                  |
+| `test_exe`            | (beta) executable used to launch test cases                          | ESMF_INTERNAL_MPIRUN   |
+| `test_dir`            | (beta) output directory for test cases                               | CMAKE_BINARY_DIR-tests |
+| `test_tasks`          | (beta) number of tasks used to run test cases                        | `4`                    |
 
 #### Component Options (`components` key)
 


### PR DESCRIPTION
* fix bug in variable name for ESMX_LINK_MODULE_PATHS
* add capability to find packages before expanding variables, which allows you to pick up variables from find_package calls
* add capability to provide a full path to link library

Needs Attention: Do we want to rename configurations options

- link_module_paths -> append_module_paths
- link_packages -> find_packages

Resolves: https://github.com/esmf-org/esmf/issues/281