### PR TITLE
Suggestions for pure C STest support

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -2806,6 +2806,10 @@ $(ESMF_TESTDIR)/ESMF_%STest : ESMF_%STest.o $(SYSTEM_TESTS_OBJ) $(addsuffix .$(E
 	$(ESMF_F90LINKER) $(ESMF_EXE_F90LINKOPTS) $(ESMF_F90LINKOPTS) $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_EXEOUT_OPTION) $(SYSTEM_TESTS_OBJ) $< $(ESMF_F90ESMFLINKLIBS)
 	$(ESMF_RM) -f *.o *.mod
 
+$(ESMF_TESTDIR)/ESMC_%STest : ESMC_%STest.o $(SYSTEM_TESTS_OBJ) $(addsuffix .$(ESMF_SL_SUFFIX), $(SYSTEM_TESTS_SHOBJ)) $(ESMFLIB)
+	$(MAKE) chkdir_tests
+	$(ESMF_CLINKER) $(ESMF_EXE_CLINKOPTS) $(ESMF_CLINKOPTS) $(ESMF_CLINKPATHS) $(ESMF_CLINKRPATHS) $(ESMF_EXEOUT_OPTION) $(SYSTEM_TESTS_OBJ) $< $(ESMF_CESMFLINKLIBS)
+	$(ESMF_RM) -f *.o *.mod
 
 # debugging aid:  link the executable, standard output, and log file to
 # temporary names in the current directory (they are built in the test
@@ -2962,6 +2966,19 @@ stest:
 	  $(ESMF_MPIRUN) -np $(NP) $(ESMF_TOOLRUN) ./ESMF_$(TNAME)STest 1> ./ESMF_$(TNAME)STest.stdout 2>&1 ; \
 	fi ; \
 	cat ./PET*$(TNAME)STest.Log> ./ESMF_$(TNAME)STest.Log ; \
+	$(ESMF_RM) ./PET*$(TNAME)STest.Log
+
+sctest:
+	-@cd $(ESMF_TESTDIR) ; \
+	$(ESMF_RM) ./PET*$(TNAME)STest.Log ; \
+	if [ $(ESMF_BATCHDEPRECATED) = "true" ] ; then \
+	  echo $(ESMF_MPIRUN) -np $(NP) $(ESMF_TOOLRUN) ./ESMC_$(TNAME)STest ; \
+	  $(ESMF_MPIRUN) -np $(NP) $(ESMF_TOOLRUN) ./ESMC_$(TNAME)STest ; \
+	else \
+	  echo $(ESMF_MPIRUN) -np $(NP) $(ESMF_TOOLRUN) ./ESMC_$(TNAME)STest 1\> ./ESMC_$(TNAME)STest.stdout 2\>\&1 ; \
+	  $(ESMF_MPIRUN) -np $(NP) $(ESMF_TOOLRUN) ./ESMC_$(TNAME)STest 1> ./ESMC_$(TNAME)STest.stdout 2>&1 ; \
+	fi ; \
+	cat ./PET*$(TNAME)STest.Log> ./ESMC_$(TNAME)STest.Log ; \
 	$(ESMF_RM) ./PET*$(TNAME)STest.Log
 
 #

--- a/scripts/test_scripts/sys_tests_results.pl
+++ b/scripts/test_scripts/sys_tests_results.pl
@@ -192,6 +192,9 @@ use File::Find
                 s/ESMF//;# Break first ESMF string
                 s/ESMF/ ESMF/;# Break it into 2 fields
                 s/([^ ]*) ([^ ]*)/$2/; # Get rid of the 1st field
+                s/ESMC//;# Break first ESMC string
+                s/ESMC/ ESMC/;# Break it into 2 fields
+                s/([^ ]*) ([^ ]*)/$2/; # Get rid of the 1st field
                 s/\./ /; # Break it into 2 fields
                 s/([^ ]*) ([^ ]*)/$1.Log\n/; # Get rid of the 2nd field
         }
@@ -225,7 +228,7 @@ use File::Find
                 @Log_files=grep (/STest/, @tmp_Log_files);
                 #Sort the list of Log files.
                 @Log_files = sort (@Log_files);
-                # Find the Log fles that are in the st_ex_files
+                # Find the Log fles that are in the st_st_files
                 foreach $file ( @st_st_files) {
                                 push @Log_st_files, grep (/$file/, @Log_files);
                 }
@@ -280,7 +283,10 @@ use File::Find
                                 push @pass_st_files, grep (/$file.F90/, @act_st_files);
                         }
                         foreach $file ( @pass_tests) {
-                            push @pass_st_files, grep (/$file.C/, @act_st_files);
+                                push @pass_st_files, grep (/$file.C/, @act_st_files);
+                        }
+                        foreach $file ( @pass_tests) {
+                                push @pass_st_files, grep (/$file.c/, @act_st_files);
                         }
 			if (!$SUMMARY) { # Print only if full output requested
                 		print "\n\n";
@@ -348,7 +354,7 @@ use File::Find
                                 s/\.stdout//; # Delete stdout
                         }
 
-                        # Find the system test executable files that are in the st_ex_files
+                        # Find the system test executable files that are in the st_x_files
                         foreach $file ( @st_st_files) {
                                         push @stdout_st_files, grep (/$file/, @st_x_files);
                         }

--- a/src/Infrastructure/FieldBundle/tests/makefile
+++ b/src/Infrastructure/FieldBundle/tests/makefile
@@ -7,12 +7,12 @@ run_uni:  run_unit_tests_uni
 LOCDIR	  = src/Infrastructure/FieldBundle/tests
 
 .NOTPARALLEL:
-TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldBundleUTest \
-                $(ESMC_TESTDIR)/ESMF_FieldBundleCrGetUTest \
-                $(ESMC_TESTDIR)/ESMF_FieldBundleRedistUTest \
-                $(ESMC_TESTDIR)/ESMF_FieldBundleSMMUTest \
-                $(ESMC_TESTDIR)/ESMF_FieldBundleIOUTest \
-                $(ESMC_TESTDIR)/ESMF_FieldBundleRegridUTest
+TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldBundleUTest \
+                $(ESMF_TESTDIR)/ESMF_FieldBundleCrGetUTest \
+                $(ESMF_TESTDIR)/ESMF_FieldBundleRedistUTest \
+                $(ESMF_TESTDIR)/ESMF_FieldBundleSMMUTest \
+                $(ESMF_TESTDIR)/ESMF_FieldBundleIOUTest \
+                $(ESMF_TESTDIR)/ESMF_FieldBundleRegridUTest
 
 TESTS_RUN     = RUN_ESMF_FieldBundleUTest \
                 RUN_ESMF_FieldBundleCrGetUTest \

--- a/src/system_tests/ESMC_FieldRegrid/ESMC_FieldRegridSTest.c
+++ b/src/system_tests/ESMC_FieldRegrid/ESMC_FieldRegridSTest.c
@@ -6,7 +6,7 @@
 
 //-------------------------------------------------------------------------
 // //DESCRIPTION:
-// System test CFieldRegrid
+// System test ESMC_FieldRegrid
 // This system test is a basic check of the C-API when used for regridding.
 // It creates two Grids, two Field on the two Grids, and then does bilinear
 // regridding between the Fields. After the regridding, it does a simple check
@@ -27,7 +27,6 @@
 #include "ESMC_Test.h"
 
 int main(void) {
-#define ESMC_METHOD "CFieldRegridSTest"  
   char name[ESMF_MAXSTR];
   char failMsg[ESMF_MAXSTR];
   char msg[ESMF_MAXSTR];
@@ -39,11 +38,11 @@ int main(void) {
 
   //-------------------------------------------------------------------------
   //-------------------------------------------------------------------------
-  strcpy(name, "System Test ESMF_CFieldRegrid");
+  strcpy(name, "System Test ESMC_FieldRegridSTest");
   strcpy(failMsg, "System Test failure");
 
   // Initialize
-  localrc = ESMC_Initialize(NULL, ESMC_InitArgLogFilename("CFieldRegridSTest.Log"),
+  localrc = ESMC_Initialize(NULL, ESMC_InitArgLogFilename("ESMC_FieldRegridSTest.Log"),
                        ESMC_ArgLast);
   if (localrc != ESMF_SUCCESS) ESMC_FinalizeWithFlag(ESMC_END_ABORT);
 

--- a/src/system_tests/ESMC_FieldRegrid/makefile
+++ b/src/system_tests/ESMC_FieldRegrid/makefile
@@ -6,10 +6,10 @@ ALL: tree_build_system_tests
 run: tree_run_system_tests
 run_uni: tree_run_system_tests_uni
 
-LOCDIR	  = src/system_tests/ESMF_CFieldRegrid
+LOCDIR	  = src/system_tests/ESMC_FieldRegrid
 
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_CFieldRegridSTest
+SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMC_FieldRegridSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.
@@ -17,9 +17,9 @@ SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_CFieldRegridSTest
 # are to be compiled/created.
 SYSTEM_TESTS_OBJ     = 
 
-SYSTEM_TESTS_RUN     = RUN_CFieldRegrid
+SYSTEM_TESTS_RUN     = RUN_ESMC_FieldRegrid
 
-SYSTEM_TESTS_RUN_UNI = RUN_CFieldRegridUNI
+SYSTEM_TESTS_RUN_UNI = RUN_ESMC_FieldRegridUNI
 
 include $(ESMF_DIR)/makefile
 
@@ -29,9 +29,9 @@ CLEANDIRS   =
 CLEANFILES  = $(SYSTEM_TESTS_BUILD)
 CLOBBERDIRS =
 
-RUN_CFieldRegrid:
-	$(MAKE) TNAME=CFieldRegrid NP=4 stest
+RUN_ESMC_FieldRegrid:
+	$(MAKE) TNAME=FieldRegrid NP=4 sctest
 
-RUN_CFieldRegridUNI:
-	$(MAKE) TNAME=CFieldRegrid NP=1 stest
+RUN_ESMC_FieldRegridUNI:
+	$(MAKE) TNAME=FieldRegrid NP=1 sctest
 

--- a/src/system_tests/ESMC_FieldRegrid/makefile
+++ b/src/system_tests/ESMC_FieldRegrid/makefile
@@ -9,7 +9,7 @@ run_uni: tree_run_system_tests_uni
 LOCDIR	  = src/system_tests/ESMC_FieldRegrid
 
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMC_FieldRegridSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMC_FieldRegridSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArrayBundleRedist/makefile
+++ b/src/system_tests/ESMF_ArrayBundleRedist/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ArrayBundleRedist
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayBundleRedistSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayBundleRedistSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArrayBundleSparseMatMul/makefile
+++ b/src/system_tests/ESMF_ArrayBundleSparseMatMul/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ArrayBundleSparseMatMul
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayBundleSparseMatMulSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayBundleSparseMatMulSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArrayRedist/makefile
+++ b/src/system_tests/ESMF_ArrayRedist/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ArrayRedist
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayRedistSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayRedistSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArrayRedist3D/makefile
+++ b/src/system_tests/ESMF_ArrayRedist3D/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ArrayRedist3D
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayRedist3DSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayRedist3DSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArrayRedistMPMD/makefile
+++ b/src/system_tests/ESMF_ArrayRedistMPMD/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ArrayRedistMPMD
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayRedistSTestA $(ESMC_TESTDIR)/ESMF_ArrayRedistSTestB
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayRedistSTestA $(ESMF_TESTDIR)/ESMF_ArrayRedistSTestB
 
 # Object files other than STest%.o that the system tests executable will depend
 # on. List objects files in the order that they are to be compiled/created.

--- a/src/system_tests/ESMF_ArrayRedistOpenACC/makefile
+++ b/src/system_tests/ESMF_ArrayRedistOpenACC/makefile
@@ -6,7 +6,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_ArrayRedistOpenACC
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayRedistOpenACCSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayRedistOpenACCSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArrayRedistOpenMP/makefile
+++ b/src/system_tests/ESMF_ArrayRedistOpenMP/makefile
@@ -6,7 +6,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_ArrayRedistOpenMP
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayRedistOpenMPSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayRedistOpenMPSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArrayScatterGather/makefile
+++ b/src/system_tests/ESMF_ArrayScatterGather/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ArrayScatterGather
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArrayScatterGatherSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArrayScatterGatherSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArraySharedDeSSI/makefile
+++ b/src/system_tests/ESMF_ArraySharedDeSSI/makefile
@@ -6,7 +6,7 @@ run_uni:  tree_run_system_tests_uni
 
 LOCDIR	  = src/system_tests/ESMF_ArraySharedDeSSI
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArraySharedDeSSISTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArraySharedDeSSISTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ArraySparseMatMul/makefile
+++ b/src/system_tests/ESMF_ArraySparseMatMul/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ArraySparseMatMul
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ArraySparseMatMulSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ArraySparseMatMulSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_Attribute/makefile
+++ b/src/system_tests/ESMF_Attribute/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_Attribute
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_AttributeSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_AttributeSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_CompCreate/makefile
+++ b/src/system_tests/ESMF_CompCreate/makefile
@@ -8,7 +8,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_CompCreate
 
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_CompCreateSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_CompCreateSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_CompFortranAndC/makefile
+++ b/src/system_tests/ESMF_CompFortranAndC/makefile
@@ -9,7 +9,7 @@ run_uni: tree_run_system_tests_uni
 LOCDIR	  = src/system_tests/ESMF_CompFortranAndC
 
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_CompFortranAndCSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_CompFortranAndCSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_CompFortranAndC/user_CComponent.c
+++ b/src/system_tests/ESMF_CompFortranAndC/user_CComponent.c
@@ -73,11 +73,11 @@ void myInitInC(ESMC_GridComp gcomp, ESMC_State importState,
   printf("local ptr[0] = %g\n", ptr[0]);
   
   // Create a Mesh from VTK file
-  ESMC_CoordSys_Flag local_coordSys=ESMC_COORDSYS_CART;
+  enum ESMC_CoordSys_Flag local_coordSys=ESMC_COORDSYS_CART;
   mesh = ESMC_MeshCreate(pdim, sdim, &local_coordSys, rc);
   if (*rc!=ESMF_SUCCESS) return;  // bail out
 
-  // Hold this to be deleted later, because getting a C mesh from a C field broken  
+  // Hold to be deleted later, because getting a C mesh from a C field is broken
   tmp_mesh=mesh;
 
   // Read input files' header data
@@ -195,7 +195,7 @@ void myRunInC(ESMC_GridComp gcomp, ESMC_State importState,
   for (j=0; j<2; j++){
     for (i=0; i<5; i++){
       ij= j*5 +i;
-      if ( fabs(ptr[ij]-float((j+1)*10+i+1)) > 1.e-8 ){
+      if ( fabs(ptr[ij]-(float)((j+1)*10+i+1)) > 1.e-8 ){
         printf("Array has wrong values at i=%d, j=%d, ij=%d\n", i, j, ij);
         *rc = ESMF_FAILURE; // indicate failure in return code
         return; // bail out
@@ -250,29 +250,27 @@ void myFinalInC(ESMC_GridComp gcomp, ESMC_State importState,
 //-------------------------------------------------------------------------
 //-------------------------------------------------------------------------
 
-extern "C" {
-  // The SetServices entry point must ensure to have external C linkage,
-  // so it can be called from Fortran.
-  
-  void FTN_X(my_setservicesinc)(ESMC_GridComp gcomp, int *rc){
-    // set entry points for standard Component methods Init(), Run(), Finalize()
-    
-    // initialize return code
-    *rc = ESMF_SUCCESS;
-    
-    printf("In mySetServicesInC()\n");
-    
-    *rc = ESMC_GridCompPrint(gcomp);
-    if (*rc!=ESMF_SUCCESS) return;  // bail out
+// Public entry point into this component written in C
+// Use Fortran name mangling to make it accessible from Fortran during linking.
 
-    *rc = ESMC_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE,myInitInC,1);
-    if (*rc!=ESMF_SUCCESS) return;  // bail out
-    *rc = ESMC_GridCompSetEntryPoint(gcomp, ESMF_METHOD_RUN, myRunInC, 1);
-    if (*rc!=ESMF_SUCCESS) return;  // bail out
-    *rc = ESMC_GridCompSetEntryPoint(gcomp, ESMF_METHOD_FINALIZE,myFinalInC, 1);
-    if (*rc!=ESMF_SUCCESS) return;  // bail out
-  }
-} //extern "C"
+void FTN_X(my_setservicesinc)(ESMC_GridComp gcomp, int *rc){
+  // set entry points for standard Component methods Init(), Run(), Finalize()
+  
+  // initialize return code
+  *rc = ESMF_SUCCESS;
+  
+  printf("In mySetServicesInC()\n");
+  
+  *rc = ESMC_GridCompPrint(gcomp);
+  if (*rc!=ESMF_SUCCESS) return;  // bail out
+
+  *rc = ESMC_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE,myInitInC,1);
+  if (*rc!=ESMF_SUCCESS) return;  // bail out
+  *rc = ESMC_GridCompSetEntryPoint(gcomp, ESMF_METHOD_RUN, myRunInC, 1);
+  if (*rc!=ESMF_SUCCESS) return;  // bail out
+  *rc = ESMC_GridCompSetEntryPoint(gcomp, ESMF_METHOD_FINALIZE,myFinalInC, 1);
+  if (*rc!=ESMF_SUCCESS) return;  // bail out
+}
 
 //-------------------------------------------------------------------------
 //-------------------------------------------------------------------------

--- a/src/system_tests/ESMF_ComplianceChecker/makefile
+++ b/src/system_tests/ESMF_ComplianceChecker/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ComplianceChecker
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ComplianceCheckerSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ComplianceCheckerSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ConcurrentComponent/makefile
+++ b/src/system_tests/ESMF_ConcurrentComponent/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ConcurrentComponent
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ConcurrentCompSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ConcurrentCompSTest
 
 # Object files other than *STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_ConcurrentEnsemble/makefile
+++ b/src/system_tests/ESMF_ConcurrentEnsemble/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_ConcurrentEnsemble
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_ConcurrentEnsembleSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_ConcurrentEnsembleSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_DirectCoupling/makefile
+++ b/src/system_tests/ESMF_DirectCoupling/makefile
@@ -7,7 +7,7 @@ run_uni:  tree_run_system_tests_uni
 LOCDIR	  = src/system_tests/ESMF_DirectCoupling
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_DirectCouplingSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_DirectCouplingSTest
 
 # Object files other than STest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FaultTolerance/makefile
+++ b/src/system_tests/ESMF_FaultTolerance/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FaultTolerance
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FaultToleranceSTest $(ESMC_TESTDIR)/ESMF_FaultToleranceCompASTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FaultToleranceSTest $(ESMF_TESTDIR)/ESMF_FaultToleranceCompASTest
 
 # Object files other than STest%.o that the system tests executable will depend
 # on. List objects files in the order that they are to be compiled/created.

--- a/src/system_tests/ESMF_FieldBundleLSRedistArb2Arb/makefile
+++ b/src/system_tests/ESMF_FieldBundleLSRedistArb2Arb/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldBundleLSRedistArb2Arb
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldBundleLSRedistArb2ArbSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldBundleLSRedistArb2ArbSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleLSRedistArb2ArbUngrdDim/makefile
+++ b/src/system_tests/ESMF_FieldBundleLSRedistArb2ArbUngrdDim/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldBundleLSRedistArb2ArbUngrdDim
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldBundleLSRedistArb2ArbUngrdDimSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldBundleLSRedistArb2ArbUngrdDimSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleRedistArb2Arb/makefile
+++ b/src/system_tests/ESMF_FieldBundleRedistArb2Arb/makefile
@@ -4,7 +4,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_FieldBundleRedistArb2Arb
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldBundleRedistArb2ArbSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldBundleRedistArb2ArbSTest
 
 # Object files other than %STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleRedistBlk2Arb/makefile
+++ b/src/system_tests/ESMF_FieldBundleRedistBlk2Arb/makefile
@@ -4,7 +4,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_FieldBundleRedistBlk2Arb
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldBundleRedistBlk2ArbSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldBundleRedistBlk2ArbSTest
 
 # Object files other than %STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleRedistBlk2Blk/makefile
+++ b/src/system_tests/ESMF_FieldBundleRedistBlk2Blk/makefile
@@ -4,7 +4,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_FieldBundleRedistBlk2Blk
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldBundleRedistBlk2BlkSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldBundleRedistBlk2BlkSTest
 
 # Object files other than %STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleRedistPacked/makefile
+++ b/src/system_tests/ESMF_FieldBundleRedistPacked/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldBundleRedistPacked
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldBundleRedistPackedSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldBundleRedistPackedSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleRegridPacked/makefile
+++ b/src/system_tests/ESMF_FieldBundleRegridPacked/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldBundleRegridPacked
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldBundleRegridPackedSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldBundleRegridPackedSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleSMM/makefile
+++ b/src/system_tests/ESMF_FieldBundleSMM/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldBundleSMM
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldBundleSMMSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldBundleSMMSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldBundleSMMPacked/makefile
+++ b/src/system_tests/ESMF_FieldBundleSMMPacked/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldBundleSMMPacked
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldBundleSMMPackedSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldBundleSMMPackedSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldConcurrentComp/makefile
+++ b/src/system_tests/ESMF_FieldConcurrentComp/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldConcurrentComp
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldConCompSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldConCompSTest
 
 # Object files other than *STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldLSRedistArb2Arb/makefile
+++ b/src/system_tests/ESMF_FieldLSRedistArb2Arb/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldLSRedistArb2Arb
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldLSRedistArb2ArbSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldLSRedistArb2ArbSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldLSRedistArb2ArbUngrdDim/makefile
+++ b/src/system_tests/ESMF_FieldLSRedistArb2ArbUngrdDim/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldLSRedistArb2ArbUngrdDim
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldLSRedistArb2ArbUngrdDimSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldLSRedistArb2ArbUngrdDimSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldLSSMM/makefile
+++ b/src/system_tests/ESMF_FieldLSSMM/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldLSSMM
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldLSSMMSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldLSSMMSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldMeshSMM/makefile
+++ b/src/system_tests/ESMF_FieldMeshSMM/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldMeshSMM
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldMeshSMMSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldMeshSMMSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRedist/makefile
+++ b/src/system_tests/ESMF_FieldRedist/makefile
@@ -6,7 +6,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_FieldRedist
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldRedistSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldRedistSTest
 
 # Object files other than %STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRedistArb2Arb/makefile
+++ b/src/system_tests/ESMF_FieldRedistArb2Arb/makefile
@@ -6,7 +6,7 @@ run_uni:  tree_run_system_tests_uni
 
 LOCDIR	  = src/system_tests/ESMF_FieldRedistArb2Arb/
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldRedistArb2ArbSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldRedistArb2ArbSTest
 
 # Object files other than %STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRedistBlk2Arb/makefile
+++ b/src/system_tests/ESMF_FieldRedistBlk2Arb/makefile
@@ -4,7 +4,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_FieldRedistBlk2Arb
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldRedistBlk2ArbSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldRedistBlk2ArbSTest
 
 # Object files other than %STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRedistBlk2Blk/makefile
+++ b/src/system_tests/ESMF_FieldRedistBlk2Blk/makefile
@@ -4,7 +4,7 @@ run: tree_run_system_tests
 
 LOCDIR	  = src/system_tests/ESMF_FieldRedistBlk2Blk
 
-SYSTEM_TESTS_BUILD   = $(ESMC_TESTDIR)/ESMF_FieldRedistBlk2BlkSTest
+SYSTEM_TESTS_BUILD   = $(ESMF_TESTDIR)/ESMF_FieldRedistBlk2BlkSTest
 
 # Object files other than %STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegrid/makefile
+++ b/src/system_tests/ESMF_FieldRegrid/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegrid
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridConserv/makefile
+++ b/src/system_tests/ESMF_FieldRegridConserv/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridConserv
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridConsrvSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridConsrvSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridDisjoint/makefile
+++ b/src/system_tests/ESMF_FieldRegridDisjoint/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridDisjoint
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridDisjointSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridDisjointSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridLS/makefile
+++ b/src/system_tests/ESMF_FieldRegridLS/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridLS
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridLSSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridLSSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridMesh/makefile
+++ b/src/system_tests/ESMF_FieldRegridMesh/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridMesh
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridMeshSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridMeshSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridMeshToMesh/makefile
+++ b/src/system_tests/ESMF_FieldRegridMeshToMesh/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridMeshToMesh
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridMeshToMeshSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridMeshToMeshSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridMulti/makefile
+++ b/src/system_tests/ESMF_FieldRegridMulti/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridMulti
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridMultiSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridMultiSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridOrder/makefile
+++ b/src/system_tests/ESMF_FieldRegridOrder/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridOrder
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridOrderSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridOrderSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridOverlap/makefile
+++ b/src/system_tests/ESMF_FieldRegridOverlap/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridOverlap
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridOverlapSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridOverlapSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldRegridPatchDisjoint/makefile
+++ b/src/system_tests/ESMF_FieldRegridPatchDisjoint/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldRegridPatchDisjoint
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldRegridPatchDisjointSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldRegridPatchDisjointSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldSharedDeSSI/makefile
+++ b/src/system_tests/ESMF_FieldSharedDeSSI/makefile
@@ -6,7 +6,7 @@ run_uni:  tree_run_system_tests_uni
 
 LOCDIR	  = src/system_tests/ESMF_FieldSharedDeSSI
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldSharedDeSSISTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldSharedDeSSISTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_FieldSparseMatMul/makefile
+++ b/src/system_tests/ESMF_FieldSparseMatMul/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_FieldSparseMatMul
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_FieldSparseMatMulSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_FieldSparseMatMulSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_MapperSimpleTwoConcurrentComps/makefile
+++ b/src/system_tests/ESMF_MapperSimpleTwoConcurrentComps/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_MapperSimpleTwoConcurrentComps
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_MapperSimpleTwoConcurrentCompsSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_MapperSimpleTwoConcurrentCompsSTest
 
 # Object files other than *STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_MapperTwoConcurrentComps/makefile
+++ b/src/system_tests/ESMF_MapperTwoConcurrentComps/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_MapperTwoConcurrentComps
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_MapperTwoConcurrentCompsSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_MapperTwoConcurrentCompsSTest
 
 # Object files other than *STest.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_RecursiveComponent/makefile
+++ b/src/system_tests/ESMF_RecursiveComponent/makefile
@@ -7,7 +7,7 @@ run_uni:  tree_run_system_tests_uni
 LOCDIR	  = src/system_tests/ESMF_RecursiveComponent
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_RecursiveComponentSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_RecursiveComponentSTest
 
 # Object files other than STest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_SequentialEnsemble/makefile
+++ b/src/system_tests/ESMF_SequentialEnsemble/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_SequentialEnsemble
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_SequentialEnsembleSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_SequentialEnsembleSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_Trace/makefile
+++ b/src/system_tests/ESMF_Trace/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_Trace
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_TraceSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_TraceSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.
@@ -26,11 +26,11 @@ include $(ESMF_DIR)/makefile
 DIRS = 
 
 CLEANDIRS   =
-CLEANFILES  = $(SYSTEM_TESTS_BUILD) $(ESMC_TESTDIR)/traceout
+CLEANFILES  = $(SYSTEM_TESTS_BUILD) $(ESMF_TESTDIR)/traceout
 CLOBBERDIRS =
 
 
 RUN_Trace:
-	rm -rf $(ESMC_TESTDIR)/traceout
+	rm -rf $(ESMF_TESTDIR)/traceout
 	env ESMF_RUNTIME_TRACE=ON $(MAKE) TNAME=Trace NP=8 stest
 

--- a/src/system_tests/ESMF_TransferGrid/makefile
+++ b/src/system_tests/ESMF_TransferGrid/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_TransferGrid
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_TransferGridSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_TransferGridSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_TransferMesh/makefile
+++ b/src/system_tests/ESMF_TransferMesh/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_TransferMesh
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_TransferMeshSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_TransferMeshSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_WebServices/makefile
+++ b/src/system_tests/ESMF_WebServices/makefile
@@ -7,8 +7,8 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_WebServices
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_WebServicesSTest \
-                        $(ESMC_TESTDIR)/ESMF_WebServicesClientSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_WebServicesSTest \
+                        $(ESMF_TESTDIR)/ESMF_WebServicesClientSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_XGridConcurrent/makefile
+++ b/src/system_tests/ESMF_XGridConcurrent/makefile
@@ -7,7 +7,7 @@ run: tree_run_system_tests
 LOCDIR	  = src/system_tests/ESMF_XGridConcurrent
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_XGridConcurrentSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_XGridConcurrentSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/ESMF_XGridSerial/makefile
+++ b/src/system_tests/ESMF_XGridSerial/makefile
@@ -8,7 +8,7 @@ run_uni: tree_run_system_tests_uni
 LOCDIR	  = src/system_tests/ESMF_XGridSerial
 
 
-SYSTEM_TESTS_BUILD    = $(ESMC_TESTDIR)/ESMF_XGridSerialSTest
+SYSTEM_TESTS_BUILD    = $(ESMF_TESTDIR)/ESMF_XGridSerialSTest
 
 # Object files other than SysTest%.o that the
 # system tests executable will depend on.

--- a/src/system_tests/makefile
+++ b/src/system_tests/makefile
@@ -23,7 +23,7 @@ DIRS      = ESMF_CompCreate \
             ESMF_ArrayRedistOpenMP \
             ESMF_ArrayRedistOpenACC \
             ESMF_ArraySharedDeSSI \
-            ESMF_CFieldRegrid \
+            ESMC_FieldRegrid \
             ESMF_ConcurrentComponent \
             ESMF_FieldConcurrentComp \
             ESMF_FieldBundleSMM \


### PR DESCRIPTION
This PR makes a few suggestions for the pure C STest support in ESMF:

- Consistently use the ESMC prefix (in STest dir name as well as source file name) to refer to pure C ESMF API usage.
- Consistently use the lower case `.c` suffix to indicate pure C code.
- Align build system and test scripts.
- Minor cleanup around the usage of `ESMC_TESTDIR` which seems to have come in a long time ago, and was inconsistent and confusing.