### PR TITLE
Implement the ESMX `link_options` application option

### DIFF
--- a/src/addon/ESMX/Driver/CMakeLists.txt
+++ b/src/addon/ESMX/Driver/CMakeLists.txt
@@ -157,6 +157,11 @@ foreach(ESMX_LINK_LIBRARY IN ITEMS ${ESMX_LINK_LIBRARIES})
   endif()
 endforeach()
 
+# link options
+if(DEFINED ESMX_LINK_OPTIONS)
+  target_link_options(esmx_driver PUBLIC ${ESMX_LINK_OPTIONS})
+endif()
+
 # add components
 set(CMP_OPTIONS BUILD_TYPE;
                 SOURCE_DIR;

--- a/src/addon/ESMX/Driver/esmx_app_config.py
+++ b/src/addon/ESMX/Driver/esmx_app_config.py
@@ -28,6 +28,7 @@ def create_appConf(appCfg: ESMXAppCfg, odir):
                ESMXOpt('disable_comps', None, str),
                ESMXOpt('link_paths', None, dir),
                ESMXOpt('link_libraries', None, str),
+               ESMXOpt('link_options', None, str),
                ESMXOpt('build_args', None, str),
                ESMXOpt('build_jobs', None, str),
                ESMXOpt('build_verbose', None, str),

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -126,9 +126,10 @@ These options affect the ESMX application layer. If no key/value pair is provide
 | `exe_name`            | executable name for application                                      | `esmx_app`             |
 | `disable_comps`       | scalar or list of components to disable                              | *None*                 |
 | `link_module_paths`   | scalar or list of search paths for CMake modules                     | *None*                 |
+| `link_libraries`      | scalar or list of external libraries, linked to esmx                 | *None*                 |
+| `link_options`        | scalar or list of options used during linking of esmx                | *None*                 |
 | `link_packages`       | scalar or list of cmake packages, use link_libraries to link to esmx | *None*                 |
 | `link_paths`          | scalar or list of search path for external libraries                 | *None*                 |
-| `link_libraries`      | scalar or list of external libraries, linked to esmx                 | *None*                 |
 | `build_args`          | scalar or list of arguments passed to all build_types                | *None*                 |
 | `build_jobs`          | job number used for all build_types                                  | *None*                 |
 | `build_verbose`       | verbosity setting used for all build_types                           | *None*                 |


### PR DESCRIPTION
Sometimes I have the need to specify a link option for when the ESMX executable is linked. E.g. `-check_mpi` to turn on IntelMPI check features. I can hack this into one of the components' cmake module files, but it would be cleaner if it could be specified as an esmx application option in `esmxBuild.yaml`. This PR adds this feature by adding the `link_options` application option.