### PR TITLE
Fix FindPython settings for ESMX

### DIFF
--- a/src/addon/ESMX/Driver/CMakeLists.txt
+++ b/src/addon/ESMX/Driver/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 
 # load packages and modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+set(Python_FIND_UNVERSIONED_NAMES "FIRST")
+set(Python_FIND_FRAMEWORK "LAST")
+set(Python_FIND_REGISTRY  "LAST")
 find_package(Python 3.5 REQUIRED COMPONENTS Interpreter)
 find_package(ESMF 8.6.0 MODULE REQUIRED)
 include(FetchContent)

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -41,6 +41,7 @@ options:
   [--disable-comps=DISABLE_COMPS]
   [--build-type=BUILD_TYPE] or [-g]
   [--build-args=BUILD_ARGS]
+  [--cmake-args=CMAKE_ARGS]
   [--build-jobs=JOBS]
   [--load-modulefile=MODULEFILE]
   [--load-bashenv=BASHENV]
@@ -68,7 +69,10 @@ where:
   --build-type=BUILD_TYPE  build type; valid options are 'debug', 'release', 'relWithDebInfo'
   -g                       (default: release) (-g sets BUILD_TYPE to debug)
 
-  --build-args=BUILD_ARGS  global cmake arguments (e.g. -DVAR=val)
+  --build-args=BUILD_ARGS  build arguments passed to every component (e.g. -DVAR=val)
+
+  --cmake-args=CMAKE_ARGS  cmake arguments are used to configure cmake while building ESMX
+                           (e.g. -DVAR=val)
 
   --build-jobs=BUILD_JOBS  number of jobs used for building esmx and components
 

--- a/src/apps/ESMX_Builder/ESMX_Builder.sh
+++ b/src/apps/ESMX_Builder/ESMX_Builder.sh
@@ -29,7 +29,14 @@ usage () {
   printf "  -g\n"
   printf "      set --build-type=debug\n"
   printf "  --build-args=BUILD_ARGS\n"
-  printf "      cmake arguments (e.g. -DARG=VAL)\n"
+  printf "      build args are passed to each component\n"
+  printf "      arguments are not used to configure ESMX (see --cmake-args)\n"
+  printf "      (e.g. --build-args=\"-DFOO=BAR\")\n"
+  printf "      note: build_args in ESMX_BUILD_FILE supersedes --build-args\n"
+  printf "  --cmake-args=CMAKE_ARGS\n"
+  printf "      cmake args are used to configure cmake while building ESMX\n"
+  printf "      arguments are not passed to components (see --build-args)\n"
+  printf "      (e.g. --cmake-args=\"-DFOO=BAR\")\n"
   printf "  --disable-comps=DISABLE_COMPS\n"
   printf "      disable components\n"
   printf "  --build-jobs=BUILD_JOBS\n"
@@ -63,6 +70,12 @@ settings () {
   printf "  INSTALL_PREFIX=${INSTALL_PREFIX}\n"
   printf "  BUILD_TYPE=${BUILD_TYPE}\n"
   printf "  BUILD_ARGS=${BUILD_ARGS}\n"
+  printf "  CMAKE_ARGS=\n"
+  if [ ${#CMAKE_ARGS[@]} -gt 0 ]; then
+    for arg in "${CMAKE_ARGS[@]}"; do
+      printf "    ${arg}\n"
+    done
+  fi
   printf "  DISABLE_COMPS=${DISABLE_COMPS}\n"
   printf "  BUILD_JOBS=${BUILD_JOBS}\n"
   printf "  MODULEFILE=${MODULEFILE}\n"
@@ -80,6 +93,7 @@ BUILD_FILE="esmxBuild.yaml"
 ESMF_ESMXDIR=""
 BUILD_TYPE="release"
 BUILD_ARGS=""
+CMAKE_ARGS=()
 DISABLE_COMPS=""
 BUILD_JOBS=""
 BUILD_DIR="${CWD}/build"
@@ -125,6 +139,9 @@ while [[ $# -gt 0 ]]; do
     --build-jobs=?*) BUILD_JOBS=${1#*=} ;;
     --build-jobs)  usage_error "$1" "requires an argument" ;;
     --build-jobs=) usage_error "$1" "requires an argument" ;;
+    --cmake-args=?*) CMAKE_ARGS+=(${1#*=}) ;;
+    --cmake-args)  usage_error "$1" "requires an argument" ;;
+    --cmake-args=) usage_error "$1" "requires an argument" ;;
     --disable-comps=?*) DISABLE_COMPS=${1#*=} 
       DISABLE_COMPS=${DISABLE_COMPS/' '/','} 
       DISABLE_COMPS=${DISABLE_COMPS/';'/','} ;;
@@ -231,6 +248,11 @@ if [ ! -z "${BUILD_JOBS}" ]; then
 fi
 if [ ! -z "${BUILD_ARGS}" ]; then
   CMAKE_SETTINGS+=("-DESMX_BUILD_ARGS=${BUILD_ARGS}")
+fi
+if [ ${#CMAKE_ARGS[@]} -gt 0 ]; then
+  for arg in "${CMAKE_ARGS[@]}"; do
+    CMAKE_SETTINGS+=("${arg}")
+  done
 fi
 
 # make settings


### PR DESCRIPTION
Fixes #305
Find the most generic Python interpreter in standard paths

* skip frameworks
* use unversioned Python interpreter names