### PR TITLE
Fix non-monotonic time on Mac OS GH Runner

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -75,6 +75,8 @@ jobs:
           sudo apt-get -qq update
           sudo apt install -qq -y autoconf automake libtool
         elif [[ "${{matrix.config.osys}}" == "macos-"* ]]; then
+          sudo systemsetup -setusingnetworktime off
+          sudo rm -rf /etc/ntp.conf
           brew install autoconf automake libtool
           brew unlink libevent || true
         fi


### PR DESCRIPTION
Disable network synchronization on Mac OS GH Runner
Workaround noted here: https://github.com/actions/runner-images/issues/820