### PR TITLE
Focus on Namespace handling for targeted field mirror

### DIFF
--- a/src/Infrastructure/Base/interface/ESMF_Info.F90
+++ b/src/Infrastructure/Base/interface/ESMF_Info.F90
@@ -223,6 +223,7 @@ public ESMF_InfoSetNULL
 public ESMF_InfoSetDirty
 public ESMF_InfoIsSet
 public ESMF_InfoIsPresent
+public ESMF_InfoLog
 public ESMF_InfoPrint
 public ESMF_InfoDump
 public ESMF_InfoUpdate
@@ -2492,6 +2493,71 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
   if (present(rc)) rc = ESMF_SUCCESS
 end function ESMF_InfoIsSet
+
+!------------------------------------------------------------------------------
+
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_InfoLog()"
+!BOP
+! !IROUTINE: ESMF_InfoLog - Log contents of an Info object
+!
+! !INTERFACE:
+subroutine ESMF_InfoLog(info, keywordEnforcer, prefix, logMsgFlag, rc)
+! !ARGUMENTS:
+  type(ESMF_Info), intent(in)                       :: info
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    character(len=*),       intent(in),   optional  :: prefix
+    type(ESMF_LogMsg_Flag), intent(in),   optional  :: logMsgFlag
+    integer, intent(out),                 optional  :: rc
+!
+! !DESCRIPTION:
+!   Write information about {\tt info} object to the ESMF default Log.
+!
+!   The arguments are:
+!   \begin{description}
+!   \item[info]
+!     {\tt ESMF\_Info} object logged.
+!   \item [{[prefix]}]
+!     String to prefix the log message. Default is no prefix.
+!   \item [{[logMsgFlag]}]
+!     Type of log message generated. See section \ref{const:logmsgflag} for
+!     a list of valid message types. Default is {\tt ESMF\_LOGMSG\_INFO}.
+!   \item[{[rc]}] 
+!     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
+!   \end{description}
+!
+!EOP
+!------------------------------------------------------------------------------
+  integer                   :: localrc
+  character(:), allocatable :: output, local_preString
+
+  ! initialize return code; assume routine not implemented
+  localrc = ESMF_RC_NOT_IMPL
+  if (present(rc)) rc = ESMF_RC_NOT_IMPL
+
+  !TODO: This should really be implemented on the C++ side where we could
+  !TODO: correctly deal with line breaks and prepend the prefix string on
+  !TODO: each line, much like for ESMF_HConfigLog().
+  !TODO: For now implemented quickly on the Fortran side to make available.
+
+  if (present(prefix)) then
+    local_preString = prefix
+  else
+    local_preString = ""
+  endif
+
+  output = ESMF_InfoDump(info, indent=2, rc=localrc)
+  if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+    ESMF_CONTEXT, rcToReturn=rc)) return
+
+  call ESMF_LogWrite(local_preString//output, logMsgFlag, rc=localrc)
+  if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+    ESMF_CONTEXT, rcToReturn=rc)) return
+
+  ! return successfully
+  if (present(rc)) rc = ESMF_SUCCESS
+
+end subroutine ESMF_InfoLog
 
 !------------------------------------------------------------------------------
 

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -1853,7 +1853,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
           ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
 
-#if 1
+#if 0
 !TODO: need a way to indicate from calling side that info should be logged
         block
           type(ESMF_Info) :: info

--- a/src/Superstructure/State/src/ESMF_StateAPI.cppF90
+++ b/src/Superstructure/State/src/ESMF_StateAPI.cppF90
@@ -59,6 +59,7 @@ module ESMF_StateAPIMod
       use ESMF_IOUtilMod
       use ESMF_UtilMod
       use ESMF_UtilStringMod
+      use ESMF_InfoMod
 
       implicit none
 
@@ -1851,6 +1852,21 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (ESMF_LogFoundError(localrc, &
           ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
+
+#if 1
+!TODO: need a way to indicate from calling side that info should be logged
+        block
+          type(ESMF_Info) :: info
+          call ESMF_InfoGetFromBase(stateR%statep%base, info=info, rc=localrc)
+          if (ESMF_LogFoundError(localrc, &
+            ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+          call ESMF_InfoLog(info, prefix=prefix, rc=localrc)
+          if (ESMF_LogFoundError(localrc, &
+            ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+        end block
+#endif
 
         if (itemCount > 0) then
           allocate(itemNameList(itemCount))

--- a/src/addon/NUOPC/src/NUOPC_Base.F90
+++ b/src/addon/NUOPC/src/NUOPC_Base.F90
@@ -154,12 +154,13 @@ module NUOPC_Base
 ! !IROUTINE: NUOPC_AddNamespace - Add a nested state with Namespace to a State
 ! !INTERFACE:
   subroutine NUOPC_AddNamespace(state, Namespace, nestedStateName, &
-    nestedState, rc)
+    nestedState, vm, rc)
 ! !ARGUMENTS:
     type(ESMF_State), intent(inout)         :: state
     character(len=*), intent(in)            :: Namespace
     character(len=*), intent(in),  optional :: nestedStateName
     type(ESMF_State), intent(out), optional :: nestedState
+    type(ESMF_VM),    intent(in),  optional :: vm
     integer,          intent(out), optional :: rc
 ! !DESCRIPTION:
 !   Add a Namespace to {\tt state}. Namespaces are implemented via nested 
@@ -178,6 +179,10 @@ module NUOPC_Base
 !     Name of the nested state. Defaults to {\tt Namespace}.
 !   \item[{[nestedState]}]
 !     Optional return of the newly created nested state.
+!   \item[{[vm]}]
+!     If present, the nested State created to hold the namespace is created on
+!     the specified {\tt ESMF\_VM} object. The default is to create the nested
+!     State on the VM of the current component context.
 !   \item[{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 !   \end{description}
@@ -189,9 +194,10 @@ module NUOPC_Base
     type(ESMF_State)            :: nestedS
     character(len=80)           :: nestedSName
     type(ESMF_StateIntent_Flag) :: stateIntent
-    
+    logical                     :: stateIsCreated
+
     if (present(rc)) rc = ESMF_SUCCESS
-    
+
     call ESMF_StateGet(state, stateIntent=stateIntent, rc=localrc)
     if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
@@ -201,31 +207,39 @@ module NUOPC_Base
     else
       nestedSName = trim(Namespace)
     endif
-    
+
     nestedS = ESMF_StateCreate(name=nestedSName, stateIntent=stateIntent, &
-      rc=localrc)
-    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
-      
-    call NUOPC_InitAttributes(nestedS, rc=localrc)
+      vm=vm, rc=localrc)
     if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
 
-    call NUOPC_SetAttribute(nestedS, name="Namespace", &
-      value=trim(Namespace), rc=localrc)
+    stateIsCreated = ESMF_StateIsCreated(nestedS, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
-    
-    call ESMF_StateAdd(state, (/nestedS/), rc=localrc)
-    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
+
+    if (stateIsCreated) then
+
+      call NUOPC_InitAttributes(nestedS, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
+
+      call NUOPC_SetAttribute(nestedS, name="Namespace", &
+        value=trim(Namespace), rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
+
+      call ESMF_StateAdd(state, (/nestedS/), rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=FILENAME, rcToReturn=rc)) return  ! bail out
+
+    endif
 
     if (present(nestedState)) &
       nestedState = nestedS
-    
+
   end subroutine
-  !---------------------------------------------------------------------
-  
+  !-----------------------------------------------------------------------------
+
   !-----------------------------------------------------------------------------
 !BOP
 ! !IROUTINE: NUOPC_AddNestedState - Add a nested state to a state with NUOPC attributes

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -436,7 +436,7 @@ module NUOPC_Connector
     integer                   :: i, j
     character(ESMF_MAXSTR)    :: importCplSet, exportCplSet
     character(len=240)        :: msgString
-    character(ESMF_MAXSTR)    :: importProvider, exportProvider
+    character(ESMF_MAXSTR)    :: stateName, namespace
 
     rc = ESMF_SUCCESS
 
@@ -609,25 +609,22 @@ module NUOPC_Connector
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
     elseif (trim(exportXferPolicy)=="transferAllAsNests") then
-      ! check name of provider component
-      call NUOPC_GetAttribute(importState, name="CompName", &
-        value=importProvider, rc=rc)
+      ! access importState namespace so it can be transferred to exportState
+      call NUOPC_GetAttribute(importState, name="Namespace", &
+        value=namespace, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! create nested state
-      exportNestedState = ESMF_StateCreate(name=trim(importProvider)//"-NestedState", rc=rc)
+      ! access name of exportState for nestedStateName construction for clarity
+      call ESMF_StateGet(exportState, name=stateName, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! set FieldTransferPolicy metadata for nested state
-      call NUOPC_SetAttribute(exportNestedState, "FieldTransferPolicy", "transferAll", rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! define namespace and nested state
-      call NUOPC_AddNamespace(exportState, namespace=trim(importProvider), &
+      ! set namespace on exportState, creating a nestedState
+      call NUOPC_AddNamespace(exportState, namespace=trim(namespace), &
+        nestedStateName=trim(stateName)//"-namespace:"//trim(namespace), &
         nestedState=exportNestedState, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! top level mirroring into exportState
+      ! mirror importState items into exportNestedState
       call doMirror(importState, exportNestedState, acceptorVM=vm, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
@@ -707,25 +704,20 @@ module NUOPC_Connector
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
     elseif (trim(importXferPolicy)=="transferAllAsNests") then
-      ! check name of provider component
-      call NUOPC_GetAttribute(exportState, name="CompName", &
-        value=exportProvider, rc=rc)
+      ! access exportState namespace so it can be transferred to importState
+      call NUOPC_GetAttribute(exportState, name="Namespace", &
+        value=namespace, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! create nested state
-      importNestedState = ESMF_StateCreate(name=trim(exportProvider)//"-NestedState", rc=rc)
+      ! access name of importState for nestedStateName construction for clarity
+      call ESMF_StateGet(importState, name=stateName, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! set FieldTransferPolicy metadata for nested state
-      call NUOPC_SetAttribute(importNestedState, "FieldTransferPolicy", "transferAll", rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! define namespace and nested state
-      call NUOPC_AddNamespace(importState, namespace=trim(exportProvider), &
+      ! set namespace on importState, creating a nestedState
+      call NUOPC_AddNamespace(importState, namespace=trim(namespace), &
+        nestedStateName=trim(stateName)//"-namespace:"//trim(namespace), &
         nestedState=importNestedState, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! top level mirroring into exportState
+      ! mirror exportState items into importNestedState
       call doMirror(exportState, importNestedState, acceptorVM=vm, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
@@ -839,13 +831,12 @@ module NUOPC_Connector
     recursive subroutine doMirror(providerState, acceptorState, acceptorVM, rc)
       type(ESMF_State)           :: providerState
       type(ESMF_State)           :: acceptorState
-      type(ESMF_VM), intent(in)  :: acceptorVM       
+      type(ESMF_VM), intent(in)  :: acceptorVM
       integer,       intent(out) :: rc
 
       integer                :: item, itemCount
       character(ESMF_MAXSTR) :: providerTransferOffer, acceptorTransferOffer
       character(ESMF_MAXSTR) :: acceptorStateName
-      character(ESMF_MAXSTR) :: providerCompName
       type(ESMF_State)       :: providerNestedState
       type(ESMF_State)       :: acceptorNestedState
       character(ESMF_MAXSTR) :: nestedStateName
@@ -866,7 +857,7 @@ module NUOPC_Connector
       character(ESMF_MAXSTR)      :: valueString
       type(ESMF_Pointer)          :: vmThis
       logical                     :: actualFlag
-      
+
       rc = ESMF_SUCCESS
 
       nullify(providerStandardNameList)
@@ -874,18 +865,13 @@ module NUOPC_Connector
       nullify(providerFieldList)
       nullify(providerCplSetList)
       nullify(acceptorStandardNameList)
-      
+
       actualFlag = .true.
       call ESMF_VMGetThis(acceptorVM, vmThis)
       if (vmThis == ESMF_NULL_POINTER) then
         actualFlag = .false.  ! local PET is not for an actual member
       endif
 
-      call NUOPC_GetAttribute(providerState, name="CompName", &
-        value=providerCompName, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-    
       call ESMF_StateGet(acceptorState, name=acceptorStateName, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
@@ -1062,14 +1048,9 @@ module NUOPC_Connector
               line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
           endif
 
-          ! Add extra metadata to the field in acceptor side about provider
-          call NUOPC_SetAttribute(fieldAdv, name="ProviderCompName", &
-            value=trim(providerCompName), rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
         end do
       endif
-      
+
       if (flipIntent) then
         ! Need to flip the accetorState intent back (same as providerIntent).
         call ESMF_StateSet(acceptorState, stateIntent=providerIntent, rc=rc)

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -618,10 +618,10 @@ module NUOPC_Connector
       call ESMF_StateGet(exportState, name=stateName, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! set namespace on exportState, creating a nestedState
+      ! set namespace on exportState, creating a nestedState on acceptor VM
       call NUOPC_AddNamespace(exportState, namespace=trim(namespace), &
         nestedStateName=trim(stateName)//"-namespace:"//trim(namespace), &
-        nestedState=exportNestedState, rc=rc)
+        nestedState=exportNestedState, vm=vm, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
       ! mirror importState items into exportNestedState
@@ -713,10 +713,10 @@ module NUOPC_Connector
       call ESMF_StateGet(importState, name=stateName, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=trim(name)//":"//FILENAME)) return  ! bail out
-      ! set namespace on importState, creating a nestedState
+      ! set namespace on importState, creating a nestedState on acceptor VM
       call NUOPC_AddNamespace(importState, namespace=trim(namespace), &
         nestedStateName=trim(stateName)//"-namespace:"//trim(namespace), &
-        nestedState=importNestedState, rc=rc)
+        nestedState=importNestedState, vm=vm, rc=rc)
       ! mirror exportState items into importNestedState
       call doMirror(exportState, importNestedState, acceptorVM=vm, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &


### PR DESCRIPTION
Base the implementation of the new `"transferAllAsNests"` mirror option on the existing `Namespace` concept: Fields advertised via `NUOPC_Connector` into a State that has `FieldTransferPolicy="transferAllAsNests"` set becomes indistinguishable from manually advertised Fields under the target component `Namespace`.

Also ensure the implementation is compliant with the optimized `ESMF_StateReconcile()` behavior. Specifically do not depend on top level State Info being reconciled for empty States, or constituent fields (e.g. in nested State) being reconciled if nested State is object of the reconciling VM context.