### PR TITLE
Use v4 of the upload-artifact action

### DIFF
--- a/.github/workflows/api-change.yml
+++ b/.github/workflows/api-change.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers

--- a/.github/workflows/api-change.yml
+++ b/.github/workflows/api-change.yml
@@ -41,7 +41,7 @@ jobs:
         docker rm ${CID}
             
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: api-change
         path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers
@@ -43,7 +43,7 @@ jobs:
         path: ${{ github.workspace }}/artifacts
        
     - name: Checkout esmf-org.github.io
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           repository: esmf-org/esmf-org.github.io
           path: ${{github.workspace}}/esmf-org.github.io

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -37,7 +37,7 @@ jobs:
         docker rm ${CID}        
             
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: esmf-docs
         path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers
@@ -43,7 +43,7 @@ jobs:
         path: ${{ github.workspace }}/artifacts
     
     - name: Checkout esmpy_doc
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           repository: esmf-org/esmpy_doc
           path: ${{github.workspace}}/esmpy_doc

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -37,7 +37,7 @@ jobs:
         docker rm ${CID}
             
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: esmpy-docs
         path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -87,7 +87,7 @@ jobs:
 
     # restore Intel oneAPI compiler installation from cache
     - name: Restore Intel oneAPI Compiler Installation
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: ${{ startsWith(matrix.compiler, 'oneapi') }}
       with:
         path: /opt/intel/oneapi

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
     # check out base repo
     - name: Checkout Base Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # prepare core environment
     - name: Install Core Development Tools
@@ -120,7 +120,7 @@ jobs:
 
     # checkout NUOPC app prototypes
     - name: Checkout NUOPC App Prototypes
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: esmf-org/nuopc-app-prototypes
         path: ${{ github.workspace }}/nuopc-app-prototypes

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -143,7 +143,7 @@ jobs:
 
    # push test results to artifacts
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Artifacts for ${{ matrix.compiler }} ${{ matrix.esmf }}
         path: ${{ github.workspace }}/nuopc-app-prototypes/Artifacts

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -32,7 +32,7 @@ jobs:
         docker rm ${CID}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-coverage
         path: ${{ github.workspace }}/artifacts


### PR DESCRIPTION
The v3 upload-artifact action is deprecated and will be removed in the future (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This PR updates the action to use v4.

Note possibly breaking changes given in
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md. I haven't reviewed these carefully, but at a glance I don't see use of these patterns. But @danrosen25 and @uturuncoglu you might have a better sense of this than I do.