### PR TITLE
Add Runtime Options for logMsgAbort and abort

### DIFF
--- a/src/Infrastructure/Util/src/ESMF_LogErr.F90
+++ b/src/Infrastructure/Util/src/ESMF_LogErr.F90
@@ -1730,11 +1730,68 @@ end subroutine ESMF_LogGet
 !      \end{description}
 !
 !EOPI
+
+    integer                        :: localrc
+    integer                        :: msgAbortCnt
+    type(ESMF_LogMsg_Flag)         :: msgAbortLst(6)
+    character(ESMF_MAXSTR)         :: envRtAbort
+    integer                        :: idxRtAbort
+
     ! Initialize return code; assume routine not implemented
     if (present(rc)) rc = ESMF_RC_NOT_IMPL
 
     call ESMF_LogOpen(ESMF_LogDefault, filename,  &
-        appendflag=logappendflag, logkindflag=logkindflag, rc=rc)
+      appendflag=logappendflag, logkindflag=logkindflag, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+
+    call c_ESMC_VMGetEnv("ESMF_RUNTIME_ABORT_LOGMSG_TYPES", envRtAbort, localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    msgAbortCnt = 0
+    idxRtAbort = index (envRtAbort, "ESMF_LOGMSG_DEBUG")
+    if (idxRtAbort > 0) then
+      msgAbortCnt = msgAbortCnt + 1
+      msgAbortLst(msgAbortCnt) = ESMF_LOGMSG_DEBUG
+    endif
+    idxRtAbort = index (envRtAbort, "ESMF_LOGMSG_ERROR")
+    if (idxRtAbort > 0) then
+      msgAbortCnt = msgAbortCnt + 1
+      msgAbortLst(msgAbortCnt) = ESMF_LOGMSG_ERROR
+    endif
+    idxRtAbort = index (envRtAbort, "ESMF_LOGMSG_INFO")
+    if (idxRtAbort > 0) then
+      msgAbortCnt = msgAbortCnt + 1
+      msgAbortLst(msgAbortCnt) = ESMF_LOGMSG_INFO
+    endif
+    idxRtAbort = index (envRtAbort, "ESMF_LOGMSG_JSON")
+    if (idxRtAbort > 0) then
+      msgAbortCnt = msgAbortCnt + 1
+      msgAbortLst(msgAbortCnt) = ESMF_LOGMSG_JSON
+    endif
+    idxRtAbort = index (envRtAbort, "ESMF_LOGMSG_TRACE")
+    if (idxRtAbort > 0) then
+      msgAbortCnt = msgAbortCnt + 1
+      msgAbortLst(msgAbortCnt) = ESMF_LOGMSG_TRACE
+    endif
+    idxRtAbort = index (envRtAbort, "ESMF_LOGMSG_WARNING")
+    if (idxRtAbort > 0) then
+      msgAbortCnt = msgAbortCnt + 1
+      msgAbortLst(msgAbortCnt) = ESMF_LOGMSG_WARNING
+    endif
+    if (msgAbortCnt > 6) then
+      call ESMF_LogSetError(ESMF_RC_BUFFER_SHORT, &
+        msg="msgAbortLst overflow - ESMF_RUNTIME_ABORT_LOGMSG_TYPES", &
+        ESMF_CONTEXT, rcToReturn=rc)
+      return
+    elseif (msgAbortCnt > 0) then
+      call ESMF_LogSet(ESMF_LogDefault, &
+        logmsgAbort=msgAbortLst(1:msgAbortCnt), rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    endif
+
+    if (present(rc)) rc=ESMF_SUCCESS
 
 end subroutine ESMF_LogInitialize
 

--- a/src/Infrastructure/VM/interface/ESMCI_VM_F.C
+++ b/src/Infrastructure/VM/interface/ESMCI_VM_F.C
@@ -1205,6 +1205,39 @@ extern "C" {
     if (rc!=NULL) *rc = ESMF_SUCCESS;
   }
 
+  void FTN_X(c_esmc_vmgetenv)(char *name, char *value, int *rc,
+    ESMCI_FortranStrLenArg name_l, ESMCI_FortranStrLenArg value_l){
+#undef  ESMC_METHOD
+#define ESMC_METHOD "c_esmc_vmgetenv()"
+    // Initialize return code; assume routine not implemented
+    if (rc!=NULL) *rc = ESMC_RC_NOT_IMPL;
+    try{
+      std::string nameStr(name, ESMC_F90lentrim(name, name_l));
+      std::string envVarStr;
+      char const *envVar = ESMCI::VM::getenv(nameStr.c_str());
+      if (envVar != NULL && strlen(envVar) > 0) {
+        envVarStr.assign(envVar);
+      }else{
+        envVarStr.assign("");
+      }
+      std::strncpy (value, envVarStr.c_str(), value_l);
+    }catch(int localrc){
+      if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU,
+        ESMC_CONTEXT, rc))
+        return; // bail out
+    }catch(std::exception &x){
+      ESMC_LogDefault.MsgFoundError(ESMC_RC_INTNRL_BAD, x.what(), ESMC_CONTEXT,
+        rc);
+      return; // bail out
+    }catch(...){
+      ESMC_LogDefault.MsgFoundError(ESMC_RC_INTNRL_BAD, "- Caught exception",
+        ESMC_CONTEXT, rc);
+      return;
+    }
+    // return successfully
+    if (rc!=NULL) *rc = ESMF_SUCCESS;
+  }
+
   void FTN_X(c_esmc_vmsetenv)(char *name, char *value, int *rc,
     ESMCI_FortranStrLenArg name_l, ESMCI_FortranStrLenArg value_l){
 #undef  ESMC_METHOD
@@ -1212,8 +1245,8 @@ extern "C" {
     // Initialize return code; assume routine not implemented
     if (rc!=NULL) *rc = ESMC_RC_NOT_IMPL;
     try{
-      std::string nameStr(name, name_l);
-      std::string valueStr(value, value_l);
+      std::string nameStr(name, ESMC_F90lentrim(name, name_l));
+      std::string valueStr(value, ESMC_F90lentrim(value, value_l));
       ESMCI::VM::setenv(nameStr.c_str(), valueStr.c_str());
     }catch(int localrc){
       if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU,

--- a/src/Infrastructure/VM/interface/ESMF_VM.F90
+++ b/src/Infrastructure/VM/interface/ESMF_VM.F90
@@ -458,6 +458,7 @@ module ESMF_VMMod
   public ESMF_VMInitializePreMPI
   public ESMF_VMInitialize
   public ESMF_VMSet
+  public ESMF_VMGetEnv
   public ESMF_VMSetEnv
   public ESMF_VMFinalize
   public ESMF_VMAbort
@@ -9396,6 +9397,49 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present(rc)) rc = ESMF_SUCCESS
 
   end subroutine ESMF_VMSet
+!------------------------------------------------------------------------------
+
+
+! -------------------------- ESMF-internal method -----------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_VMGetEnv()"
+!BOPI
+! !IROUTINE: ESMF_VMGetEnv - Get environment variable cached in the Global VM
+
+! !INTERFACE:
+  subroutine ESMF_VMGetEnv(name, value, rc)
+!
+! !ARGUMENTS:
+    character(*), intent(in)            :: name
+    character(*), intent(out)           :: value
+    integer,      intent(out), optional :: rc
+!
+! !DESCRIPTION:
+!   Get environment variable cached in the Global VM.
+!
+!   The arguments are:
+!   \begin{description}
+!     \item [name]
+!        The name of the environment variable.
+!     \item [value]
+!        The value of the environment variable.
+!   \item[{[rc]}]
+!        Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
+!   \end{description}
+!
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc      ! local return code
+
+    ! Call into the C++ interface.
+    call c_ESMC_VMGetEnv(name, value, localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+
+    ! return successfully
+    if (present(rc)) rc = ESMF_SUCCESS
+
+  end subroutine ESMF_VMGetEnv
 !------------------------------------------------------------------------------
 
 

--- a/src/Infrastructure/VM/src/ESMCI_VM.C
+++ b/src/Infrastructure/VM/src/ESMCI_VM.C
@@ -3400,8 +3400,20 @@ VM *VM::initialize(
 
   // obtain ESMF runtime environment
   if (GlobalVM->getLocalPet() == 0){
-    char const *esmfRuntimeVarName = "ESMF_RUNTIME_COMPLIANCECHECK";
+    char const *esmfRuntimeVarName = "ESMF_RUNTIME_ABORT_ACTION";
     char const *esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
+    if (esmfRuntimeVarValue){
+      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
+      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
+    }
+    esmfRuntimeVarName = "ESMF_RUNTIME_ABORT_LOGMSG_TYPES";
+    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
+    if (esmfRuntimeVarValue){
+      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
+      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
+    }
+    esmfRuntimeVarName = "ESMF_RUNTIME_COMPLIANCECHECK";
+    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
     if (esmfRuntimeVarValue){
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);

--- a/src/Infrastructure/VM/src/ESMCI_VMKernel.C
+++ b/src/Infrastructure/VM/src/ESMCI_VMKernel.C
@@ -901,6 +901,28 @@ struct SpawnArg{
 void VMK::abort(){
   // abort default (all MPI) virtual machine
   int finalized;
+
+  char const *envRTabort = VM::getenv("ESMF_RUNTIME_ABORT_ACTION");
+  if (envRTabort != NULL && strlen(envRTabort) > 0) {
+    std::string RTabort(envRTabort);
+    transform(RTabort.begin(), RTabort.end(), RTabort.begin(), ::toupper);
+    if (RTabort == "MPI_ABORT") {
+      ; // no-op, do not raise signal
+    } else if (RTabort == "SIGABRT") {
+      raise (SIGABRT);
+    } else if (RTabort == "SIGQUIT") {
+#ifdef SIGQUIT
+      raise (SIGQUIT);
+#else
+      fprintf(stderr, "SIGQUIT not defined for ESMF_RUNTIME_ABORT_ACTION\n"
+        "-> default to MPI_Abort.\n");
+#endif
+    } else {
+      fprintf(stderr, "Invalid ESMF_RUNTIME_ABORT_ACTION setting - %s\n"
+        "-> default to MPI_Abort.\n", RTabort.c_str());
+    }
+  }
+  // signal may be caught therefore call MPI_Abort if code gets here
   MPI_Finalized(&finalized);
   if (!finalized)
     MPI_Abort(default_mpi_c, EXIT_FAILURE);

--- a/src/Superstructure/ESMFMod/src/ESMF_Init.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF_Init.F90
@@ -296,6 +296,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !           value is set, potentially overriding the value defined within the
 !           user environment for the same variable.
 !           \begin{itemize}
+!              \item {\tt ESMF\_RUNTIME\_ABORT\_ACTION}
+!              \item {\tt ESMF\_RUNTIME\_ABORT\_LOGMSG\_TYPES}
 !              \item {\tt ESMF\_RUNTIME\_COMPLIANCECHECK}
 !              \item {\tt ESMF\_RUNTIME\_GARBAGE}
 !              \item {\tt ESMF\_RUNTIME\_GARBAGE\_LOG}
@@ -1119,6 +1121,10 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
               ESMF_CONTEXT, rcToReturn=rc)) return
           endif
         endif
+
+        ! Ingest ESMF_RUNTIME_* log variables before initializing the log
+        call ingest_environment_variable("ESMF_RUNTIME_ABORT_ACTION")
+        call ingest_environment_variable("ESMF_RUNTIME_ABORT_LOGMSG_TYPES")
 
       endif ! have a default Config
 

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -51,27 +51,29 @@ program ESMX_App
 
   ! Validate hconfigNode against ESMX/App controlled key vocabulary
   isFlag = ESMF_HConfigValidateMapKeys(hconfigNode, &
-    vocabulary=["defaultLogFilename          ", & ! ESMF_Initialize option
-                "logAppendFlag               ", & ! ESMF_Initialize option
-                "logKindFlag                 ", & ! ESMF_Initialize option
-                "defaultCalKind              ", & ! ESMF_Initialize option
-                "globalResourceControl       ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_COMPLIANCECHECK", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_GARBAGE        ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_GARBAGE_LOG    ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_PROFILE        ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_PROFILE_OUTPUT ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_PROFILE_PETLIST", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_PROFILE_REGRID ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_TRACE          ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_TRACE_CLOCK    ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_TRACE_COMPONENT", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_TRACE_FLUSH    ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_TRACE_PETLIST  ", & ! ESMF_Initialize option
-                "startTime                   ", & ! ESMX_App option
-                "stopTime                    ", & ! ESMX_App option
-                "logFlush                    ", & ! ESMX_App option
-                "fieldDictionary             "  & ! ESMX_App option
+    vocabulary=["defaultLogFilename             ", & ! ESMF_Initialize option
+                "logAppendFlag                  ", & ! ESMF_Initialize option
+                "logKindFlag                    ", & ! ESMF_Initialize option
+                "defaultCalKind                 ", & ! ESMF_Initialize option
+                "globalResourceControl          ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_ABORT_ACTION      ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_ABORT_LOGMSG_TYPES", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_COMPLIANCECHECK   ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_GARBAGE           ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_GARBAGE_LOG       ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE           ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE_OUTPUT    ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE_PETLIST   ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE_REGRID    ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE             ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_CLOCK       ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_COMPONENT   ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_FLUSH       ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_PETLIST     ", & ! ESMF_Initialize option
+                "startTime                      ", & ! ESMX_App option
+                "stopTime                       ", & ! ESMX_App option
+                "logFlush                       ", & ! ESMX_App option
+                "fieldDictionary                "  & ! ESMX_App option
                 ], badKey=valueString, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -344,6 +344,8 @@ This section affects the application level.
 | `defaultCalKind`          | ESMF calendar kind used by default, see ESMF RefDoc for options | `ESMF_CALKIND_GREGORIAN`|
 | `logFlush`                | enable/disable log flush for each write: `true` or `false`| `false`         |
 | `fieldDictionary`         | name of the NUOPC field dictionary file to be loaded      | *None*          |
+| `ESMF_RUNTIME_ABORT_ACTION`| set ESMF abort action: `MPI_ABORT` `SIGABRT` or `SIGQUIT`| `MPI_ABORT`     |
+| `ESMF_RUNTIME_ABORT_LOGMSG_TYPES`| type(s) of log messages causing abort (e.g. `ESMF_LOGMSG_ERROR,ESMF_LOGMSG_WARNING`) | *None* |
 | `ESMF_RUNTIME_COMPLIANCECHECK`| enable/disable NUOPC compliance checking: `ON` or `OFF` with `DEPTH` | `OFF`|
 | `ESMF_RUNTIME_GARBAGE`    | ESMF garbage collection setting: `NONE`, `FULL`,`SAFE`     | `SAFE`          |
 | `ESMF_RUNTIME_GARBAGE_LOG`| enable/disable logging of ESMF garbage collection: `ON` or `OFF`         | `OFF`|

--- a/src/doc/ESMF_debug.tex
+++ b/src/doc/ESMF_debug.tex
@@ -155,3 +155,27 @@ is a problem in the library code. In this example user code is visible at the
 very top of the stack {\tt esmApp.F90}, and at the very bottom {\tt ocn.F90}.
 In fact the location of the division by zero is correctly identified by the
 runtime library at line 149 in file {\tt ocn.F90}.
+
+It is possible to force a hard crash within the ESMF library while logging
+ERRORS or WARNINGS to the {\tt PET<nnn>.ESMF\_LogFile}. Doing so can be
+advantageous because it may produce a code dump and/or backtrace at the
+initial point of error without ESMF return code handling. There are two
+settings controlling log message error handling. The first setting,
+{\tt ESMF\_RUNTIME\_ABORT\_LOGMSG\_TYPES}, configures the ESMF library to abort
+during specified log message types, such as {\tt ESMF\_LOGMSG\_ERROR}. When
+setting {\tt ESMF\_RUNTIME\_ABORT\_LOGMSG\_TYPES}, multiple log message types
+can be listed, such as {\tt ESMF\_LOGMSG\_ERROR,ESMF\_LOGMSG\_WARNING}. The
+second setting, {\tt ESMF\_RUNTIME\_ABORT\_ACTION}, configures the ESMF library
+abort action. By default, the ESMF library abort handler will call
+{\tt MPI\_Abort}. This can be changed to {\tt SIGABRT} or {\tt SIGQUIT}, which
+will raise their respective exceptions. These two settings can be configured in
+the user environment before initializing ESMF or set in the configuration file
+passed to {\tt ESMF\_Initialize}.
+
+An example configuration file configuring ESMF to raise {\tt SIGABRT} during
+{\tt ESMF\_LOGMSG\_ERROR} or {\tt ESMF\_LOGMSG\_WARNING}.
+
+\begin{verbatim}
+ESMF_RUNTIME_ABORT_ACTION: "SIGABRT"
+ESMF_RUNTIME_ABORT_LOGMSG_TYPES: "ESMF_LOGMSG_ERROR,ESMF_LOGMSG_WARNING"
+\end{verbatim}


### PR DESCRIPTION
* use ESMF_RUNTIME_ABORT_LOGMSG_TYPES to set logMsgAbort for ESMF logs
* use ESMF_RUNTIME_ABORT_ACTION to call sigquit for ESMF_Abort

Closes #296 

### Testing Option 1 (uses an ESMF_Initialize configuration file)
Initialize ESMF
```fortran
call ESMF_Initialize(configFilenameFromArgNum=1, configFileName="esmf.cfg", &
  defaultDefaultCalKind=ESMF_CALKIND_GREGORIAN, rc=rc)
```

esmf.cfg
```yaml
ESMF_RUNTIME_ABORT_LOGMSG_TYPES: "ESMF_LOGMSG_ERROR" # calls ESMF_Abort if ERROR is reported to ESMF logs
ESMF_RUNTIME_ABORT_ACTION: "SIGABRT" # signals abort if ESMF_Abort is called
```

### Testing Option 2 (uses environment variables)
set environment variables
```bash
export ESMF_RUNTIME_ABORT_LOGMSG_TYPES="ESMF_LOGMSG_ERROR"
export ESMF_RUNTIME_ABORT_ACTION="SIGABRT" # or "SIGQUIT"
```

### Test Application
[esmf_abort.tar.gz](https://github.com/user-attachments/files/19097557/esmf_abort.tar.gz)
