### PR TITLE
Fix for spack CI/CD testing

### DIFF
--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -98,9 +98,9 @@ spack compiler find
 cat ~/.spack/packages.yaml
 echo "::endgroup::"
 
-# find external tools
+# find external tools, excluding cmake since runner uses 4.0 which is not compatible with some libraries
 echo "::group::Find Externals"
-spack external find
+spack external find --exclude cmake
 echo "::endgroup::"
 
 # create config file (to fix FetchError issue)

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -137,15 +137,14 @@ fi
 # check given gcc compiler is found or not? If not, use newer version
 if [[ "$comp" == *"gcc"* ]]; then
   echo "::group::Check gcc compiler"
-  comp_str=${comp/@/@=}
-  str=`echo $comp_str | awk -F\@ '{print $1}'`
-  comp_ver=`grep -ir "${str}@=" ~/.spack/packages.yaml | tr -d "spec: ${str}@=" | sort -n | tail -n 1`
+  str=`echo $comp | awk -F\@ '{print $1}'`
+  comp_ver=`grep -ir "${str}@" packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@" | sort -n | tail -n 1`
 
   use_latest=0
   if [[ "$comp" == *"gcc@latest"* ]]; then
      echo "The gcc@latest is set. Trying to find latest available gcc compiler ..."
      use_latest=1
-  elif [ -z "$(cat ~/.spack/packages.yaml | grep $comp_str)" ]; then
+  elif [ -z "$(cat ~/.spack/packages.yaml | grep $comp)" ]; then
      echo "Given compiler ($comp) is not found! Exiting ..."
      exit 1
   fi

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -138,13 +138,20 @@ fi
 if [[ "$comp" == *"gcc"* ]]; then
   echo "::group::Check gcc compiler"
   str=`echo $comp | awk -F\@ '{print $1}'`
-  echo "str = $str"
-  comp_ver=`grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@" | sort -n | tail -n 1`
-  echo "comp_ver = $comp_ver"
-  echo `grep -ir "${str}@" ~/.spack/packages.yaml`
-  echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}'`
-  echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}'`
-  echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@"`
+  echo "A"
+  spack compiler list
+  echo "B"
+  spack compiler list | grep "${str}@"
+  echo "C"
+  spack compiler list | grep "${str}@" | tr -d "${str}@" | sort -n | tail -n 1
+  
+  #echo "str = $str"
+  #comp_ver=`grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@" | sort -n | tail -n 1`
+  #echo "comp_ver = $comp_ver"
+  #echo `grep -ir "${str}@" ~/.spack/packages.yaml`
+  #echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}'`
+  #echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}'`
+  #echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@"`
 
   use_latest=0
   if [[ "$comp" == *"gcc@latest"* ]]; then

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -138,7 +138,7 @@ fi
 if [[ "$comp" == *"gcc"* ]]; then
   echo "::group::Check gcc compiler"
   str=`echo $comp | awk -F\@ '{print $1}'`
-  comp_ver=`grep -ir "${str}@" packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@" | sort -n | tail -n 1`
+  comp_ver=`grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@" | sort -n | tail -n 1`
 
   use_latest=0
   if [[ "$comp" == *"gcc@latest"* ]]; then

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -138,7 +138,13 @@ fi
 if [[ "$comp" == *"gcc"* ]]; then
   echo "::group::Check gcc compiler"
   str=`echo $comp | awk -F\@ '{print $1}'`
+  echo "str = $str"
   comp_ver=`grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@" | sort -n | tail -n 1`
+  echo "comp_ver = $comp_ver"
+  echo `grep -ir "${str}@" ~/.spack/packages.yaml`
+  echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}'`
+  echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}'`
+  echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@"`
 
   use_latest=0
   if [[ "$comp" == *"gcc@latest"* ]]; then

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -167,12 +167,11 @@ echo "  specs:" >> spack.yaml
 IFS=', ' read -r -a array <<< "$deps"
 for d in "${array[@]}"
 do
-  echo "  - $d %$comp target=$arch" >> spack.yaml
+  echo "  - $d target=$arch %$comp" >> spack.yaml
 done
 echo "  packages:" >> spack.yaml
 echo "    all:" >> spack.yaml
 echo "      target: ['$arch']" >> spack.yaml
-echo "      compiler: [$comp]" >> spack.yaml
 echo "      providers:" >> spack.yaml
 if [[ "$comp" == *"oneapi"* ]]; then
 echo "        mpi: [intel-${mpi}]" >> spack.yaml

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -95,7 +95,7 @@ fi
 # find compilers
 . spack/share/spack/setup-env.sh
 spack compiler find
-cat ~/.spack/linux/compilers.yaml
+cat ~/.spack/packages.yaml
 echo "::endgroup::"
 
 # find external tools
@@ -139,13 +139,13 @@ if [[ "$comp" == *"gcc"* ]]; then
   echo "::group::Check gcc compiler"
   comp_str=${comp/@/@=}
   str=`echo $comp_str | awk -F\@ '{print $1}'`
-  comp_ver=`grep -ir "${str}@=" ~/.spack/linux/compilers.yaml | tr -d "spec: ${str}@=" | sort -n | tail -n 1`
+  comp_ver=`grep -ir "${str}@=" ~/.spack/packages.yaml | tr -d "spec: ${str}@=" | sort -n | tail -n 1`
 
   use_latest=0
   if [[ "$comp" == *"gcc@latest"* ]]; then
      echo "The gcc@latest is set. Trying to find latest available gcc compiler ..."
      use_latest=1
-  elif [ -z "$(cat ~/.spack/linux/compilers.yaml | grep $comp_str)" ]; then
+  elif [ -z "$(cat ~/.spack/packages.yaml | grep $comp_str)" ]; then
      echo "Given compiler ($comp) is not found! Exiting ..."
      exit 1
   fi

--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -138,20 +138,7 @@ fi
 if [[ "$comp" == *"gcc"* ]]; then
   echo "::group::Check gcc compiler"
   str=`echo $comp | awk -F\@ '{print $1}'`
-  echo "A"
-  spack compiler list
-  echo "B"
-  spack compiler list | grep "${str}@"
-  echo "C"
-  spack compiler list | grep "${str}@" | tr -d "${str}@" | sort -n | tail -n 1
-  
-  #echo "str = $str"
-  #comp_ver=`grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@" | sort -n | tail -n 1`
-  #echo "comp_ver = $comp_ver"
-  #echo `grep -ir "${str}@" ~/.spack/packages.yaml`
-  #echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}'`
-  #echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}'`
-  #echo `grep -ir "${str}@" ~/.spack/packages.yaml | awk -F: '{print $3}' | awk '{print $1}' | tr -d "${str}@"`
+  comp_ver=`spack compiler list | grep "${str}@" | tr -d "${str}@" | sort -n | tail -n 1`
 
   use_latest=0
   if [[ "$comp" == *"gcc@latest"* ]]; then

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -84,6 +84,7 @@ jobs:
         sudo apt-get -qq install build-essential binutils-dev gfortran gdb
         sudo apt-get -qq install gfortran-12 gfortran-13
         sudo apt-get -qq install python3-dev
+        sudo apt-get -qq install curl libcurl4-openssl-dev
 
     # restore Intel oneAPI compiler installation from cache
     - name: Restore Intel oneAPI Compiler Installation


### PR DESCRIPTION
This PR  fixes Spack installation GitHub action. It was failing because of changed some conventions like compilers.yaml -> packages.yaml to keep list of available compilers in the spack side.