### PR TITLE
Consistent CMake 3.5.2 version requirement under PIO

### DIFF
--- a/src/Infrastructure/IO/PIO/ParallelIO/src/clib/CMakeLists.txt
+++ b/src/Infrastructure/IO/PIO/ParallelIO/src/clib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 include (CheckFunctionExists)
 project (PIOC C)
 

--- a/src/Infrastructure/IO/PIO/ParallelIO/src/flib/CMakeLists.txt
+++ b/src/Infrastructure/IO/PIO/ParallelIO/src/flib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 project (PIOF Fortran)
 include (CheckFunctionExists)
 include (ExternalProject)

--- a/src/Infrastructure/IO/PIO/ParallelIO/src/gptl/CMakeLists.txt
+++ b/src/Infrastructure/IO/PIO/ParallelIO/src/gptl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 project (GPTL C Fortran)
 include (CheckFunctionExists)
 include (FortranCInterface)

--- a/src/Infrastructure/IO/PIO/ParallelIO/tests/CMakeLists.txt
+++ b/src/Infrastructure/IO/PIO/ParallelIO/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 project (PIOTests C Fortran)
 
 #==============================================================================


### PR DESCRIPTION
Currently the [ESMF All Tests](https://github.com/esmf-org/esmf/actions/workflows/esmf-all-tests.yml) action is failing because of the GH runners using CMake 4.0.0 as described by @danrosen25 in https://github.com/esmf-org/esmf/pull/372#issuecomment-2773603691

This PR provides a quick fix for this by moving the CMake version requirement for anything under `src/Infrastructure/IO/PIO/ParallelIO/` to consistently `cmake_minimum_required (VERSION 3.5.2)`. This is expected to not trigger an issue with CMake 4.0.0.