### PR TITLE
Adjust to the LLVM 21 update

### DIFF
--- a/build_config/Linux.llvm.default/build_rules.mk
+++ b/build_config/Linux.llvm.default/build_rules.mk
@@ -239,7 +239,7 @@ ESMF_F90LINKLIBS += -lrt -lstdc++ -ldl
 ############################################################
 # Link against libesmf.a using the C++ linker front-end
 #
-ESMF_CXXLINKLIBS += -lrt -lFortranDecimal -lstdc++ -lm -ldl
+ESMF_CXXLINKLIBS += -lrt -lFortranDecimal -lflang_rt.runtime -lstdc++ -lm -ldl
 
 ############################################################
 # Linker option that ensures that the specified libraries are 

--- a/build_config/Linux.llvm.default/build_rules.mk
+++ b/build_config/Linux.llvm.default/build_rules.mk
@@ -6,7 +6,7 @@
 ############################################################
 # Default compiler setting.
 #
-ESMF_F90DEFAULT         = flang-new
+ESMF_F90DEFAULT         = flang
 ESMF_CXXDEFAULT         = clang++
 ESMF_CDEFAULT           = clang
 ESMF_CPPDEFAULT		= clang -E -P -x c
@@ -239,7 +239,7 @@ ESMF_F90LINKLIBS += -lrt -lstdc++ -ldl
 ############################################################
 # Link against libesmf.a using the C++ linker front-end
 #
-ESMF_CXXLINKLIBS += -lrt -lFortranRuntime -lFortranDecimal -lstdc++ -lm -ldl
+ESMF_CXXLINKLIBS += -lrt -lFortranDecimal -lstdc++ -lm -ldl
 
 ############################################################
 # Linker option that ensures that the specified libraries are 


### PR DESCRIPTION
This PR adjusts the ESMF `build_config/Linux.llvm.default` to LLVM 21.
- flang-new -> flang
- The libFortranRuntime is gone under the LLVM installation -> assume no longer needed when linking with C/C++.