### PR TITLE
Fix ESMF_FortranWordsize for 32-bit systems

### DIFF
--- a/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
@@ -73,7 +73,7 @@ module ESMF_FortranWordsizeMod
   interface
 
     subroutine esmf_pointerdifference(n, s1, s2, len)
-      integer*8 :: n
+      integer(C_SIZE_T) :: n
       type(*) :: s1
       type(*) :: s2
       integer :: len

--- a/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
+++ b/src/Infrastructure/Util/src/ESMF_FortranWordsize.cppF90
@@ -73,6 +73,7 @@ module ESMF_FortranWordsizeMod
   interface
 
     subroutine esmf_pointerdifference(n, s1, s2, len)
+      use iso_c_binding
       integer(C_SIZE_T) :: n
       type(*) :: s1
       type(*) :: s2


### PR DESCRIPTION
Pointer size is hard coded as `integer*8` in one place only, in the whole ESMF code base.  This should probably be `integer(C_SIZE_T)` to conform with incoming subroutine calls.  Please confirm, I am not very familiar with ISO_C_MODULE issues.

This may fix an error on 32-bit PPC.  A MacPorts developer is testing ESMF on 32-bit PPC.  Downstream issue has error messages and other details:

https://trac.macports.org/ticket/72424