### PR TITLE
Unsure expected behavior when using ESMX from CMake based project build

### DIFF
--- a/src/addon/ESMX/CMakeLists.txt
+++ b/src/addon/ESMX/CMakeLists.txt
@@ -28,22 +28,6 @@ include(GNUInstallDirs)
 # Add ESMX driver
 add_subdirectory(Driver)
 
-if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
-  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -fbacktrace -O2")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-g -fbacktrace -O0 -fcheck=all -ffpe-trap=invalid,zero,overflow,underflow")
-elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
-  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -traceback -O2")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-g -traceback -O0 -check all -fpe0 -ftrapuv -init=snan,arrays")
-elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -fast")
-  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -traceback -O2 -fast")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-g -traceback -O0")
-else()
-  message(WARNING "${CMAKE_Fortran_COMPILER_ID} Fortran compiler will be used with default options")
-endif()
-
 # define ESMX_EXE_NAME
 if(NOT DEFINED ESMX_EXE_NAME)
   set(ESMX_EXE_NAME "esmx_app")


### PR DESCRIPTION
This PR removes the setting of custom compiler flags from the top level ESMX `CMakeLists.txt` file. Setting these flags causes unexpected behavior in projects that use CMake and leverage ESMX.