### PR TITLE
BLD: Do not try to recurse into nonexistent directories.

### DIFF
--- a/src/Infrastructure/GridUtil/makefile
+++ b/src/Infrastructure/GridUtil/makefile
@@ -12,7 +12,7 @@ include ${ESMF_DIR}/makefile
 # The DIRS line needs to contain all subdirectories which exist 
 # directly below this directory, and have either library,
 # example/test code, or documents which need to be generated.
-DIRS	  = src interface tests examples doc
+DIRS	  = src interface tests
 
 CLEANDIRS   =
 CLEANFILES  =

--- a/src/Superstructure/InfoAPI/makefile
+++ b/src/Superstructure/InfoAPI/makefile
@@ -13,9 +13,4 @@ include ${ESMF_DIR}/makefile
 # the DIRS line needs to contain all subdirectories which exist 
 #  directly below this directory, and have either library,
 #  example/test code, or documents which need to be generated.
-DIRS      = src interface examples tests doc
-
-
-
-
-
+DIRS      = src interface tests doc


### PR DESCRIPTION
Infrastructure/Mesh/src/Legacy also has no subdirectories, but tries to recurse into five or so.  I just skipped that directory, since I wasn't sure if it would attempt to download those projects.

Found while trying to create a script to convert the build system to CMake.