### PR TITLE
Fix in yaml-cpp for GCC 15

### DIFF
--- a/src/prologue/yaml-cpp/src/emitterutils.cpp
+++ b/src/prologue/yaml-cpp/src/emitterutils.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 


### PR DESCRIPTION
Closes #392 

This is the "simple" fix for ESMF and GCC 15.1. Based on https://github.com/jbeder/yaml-cpp/pull/1310 we add an explicit include for `cstdint`.

This let's things build for me. Of course, testing is needed for all other compilers to be good.