### PR TITLE
ESMF_FieldEmpty.cppF90: Fix bogus CPP warnings

### DIFF
--- a/src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90
+++ b/src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90
@@ -4403,14 +4403,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
   ! Get pointer to internal Field
   ftypep => field%ftypep
 
-  ! Get field's current status
+  ! Get current status of field
   currStatus=ftypep%status
 
   ! Change Field based on current status and new status
   if (currStatus == ESMF_FIELDSTATUS_EMPTY) then
 
      if (setStatus == ESMF_FIELDSTATUS_EMPTY) then
-         ! Don't do anything, since no change in status
+         ! Do not do anything, since no change in status
      else if (setStatus == ESMF_FIELDSTATUS_GRIDSET) then
         call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_WRONG, &
              msg="a Field can't be reset to be more complete than its current status.", &
@@ -4437,11 +4437,11 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
              ESMF_CONTEXT, rcToReturn=rc)) return
 
-        ! Set flag back to it's inital setting
+        ! Set flag back to its inital setting
         ftypep%geomb_internal = .false.
 
      else if (setStatus == ESMF_FIELDSTATUS_GRIDSET) then
-         ! Don't do anything, since no change in status
+         ! Do not do anything, since no change in status
      else if (setStatus == ESMF_FIELDSTATUS_COMPLETE) then
         call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_WRONG, &
              msg="a Field can't be reset to be more complete than its current status.", &
@@ -4463,7 +4463,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
              ESMF_CONTEXT, rcToReturn=rc)) return
 
-        ! Set Array internal flag back to it's inital setting
+        ! Set Array internal flag back to its inital setting
         ftypep%array_internal = .false.
 
         ! Destroy Geometry
@@ -4471,7 +4471,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
              ESMF_CONTEXT, rcToReturn=rc)) return
 
-        ! Set geom internal flag back to it's inital setting
+        ! Set geom internal flag back to its inital setting
         ftypep%geomb_internal = .false.
 
      else if (setStatus == ESMF_FIELDSTATUS_GRIDSET) then
@@ -4481,11 +4481,11 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
              ESMF_CONTEXT, rcToReturn=rc)) return
 
-        ! Set Array internal flag back to it's inital setting
+        ! Set Array internal flag back to its inital setting
         ftypep%array_internal = .false.
 
      else if (setStatus == ESMF_FIELDSTATUS_COMPLETE) then
-         ! Don't do anything, since no change in status
+         ! Do not do anything, since no change in status
      else
         call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_WRONG, &
              msg="unknown status type", &


### PR DESCRIPTION
* Modify 8 fortran comments in one file, prevent bogus CPP warning messages from Clang compiler.
* Fixes `error: missing terminating ' character`
* Fixes broken builds with older Clang versions.
* Fixes: https://github.com/orgs/esmf-org/discussions/400
* This is the only cppF90 file in ESMF 8.8.1 exhibiting this problem.