### PR TITLE
Control of ESMF garbage collection via ESMF_RUNTIME_ environment vars

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -845,9 +845,11 @@ ifneq ($(origin ESMF_F90OPTFLAG), environment)
 ESMF_F90OPTFLAG = $(ESMF_F90OPTFLAG_X)
 ifeq ($(ESMF_BOPT),g)
 ESMF_F90OPTFLAG = $(ESMF_F90OPTFLAG_G)
+ESMF_F90OPTFLAG += $(ESMF_OPTFLAG_G)
 endif
 ifeq ($(ESMF_BOPT),O)
 ESMF_F90OPTFLAG = $(ESMF_F90OPTFLAG_O)
+ESMF_F90OPTFLAG += $(ESMF_OPTFLAG_O)
 endif
 endif
 # - make sure environment variable gets prepended _once_
@@ -892,9 +894,11 @@ ifneq ($(origin ESMF_CXXOPTFLAG), environment)
 ESMF_CXXOPTFLAG = $(ESMF_CXXOPTFLAG_X)
 ifeq ($(ESMF_BOPT),g)
 ESMF_CXXOPTFLAG = $(ESMF_CXXOPTFLAG_G)
+ESMF_CXXOPTFLAG += $(ESMF_OPTFLAG_G)
 endif
 ifeq ($(ESMF_BOPT),O)
 ESMF_CXXOPTFLAG = $(ESMF_CXXOPTFLAG_O)
+ESMF_CXXOPTFLAG += $(ESMF_OPTFLAG_O)
 endif
 endif
 # - make sure environment variable gets prepended _once_
@@ -936,9 +940,11 @@ ifneq ($(origin ESMF_COPTFLAG), environment)
 ESMF_COPTFLAG = $(ESMF_COPTFLAG_X)
 ifeq ($(ESMF_BOPT),g)
 ESMF_COPTFLAG = $(ESMF_COPTFLAG_G)
+ESMF_COPTFLAG += $(ESMF_OPTFLAG_G)
 endif
 ifeq ($(ESMF_BOPT),O)
 ESMF_COPTFLAG = $(ESMF_COPTFLAG_O)
+ESMF_COPTFLAG += $(ESMF_OPTFLAG_O)
 endif
 endif
 # - make sure environment variable gets prepended _once_

--- a/build_config/Linux.gfortran.default/build_rules.mk
+++ b/build_config/Linux.gfortran.default/build_rules.mk
@@ -132,13 +132,24 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version
 ############################################################
 # Special debug flags
 #
-# Activate to turn on UBSan:
-#ESMF_LINKOPTFLAG_G      += -fsanitize=undefined
-# Also set environment variable UBSAN_OPTIONS="print_stacktrace=1"
-# for stacktrace at runtime.
-#
 ESMF_F90OPTFLAG_G       += -Wall -Wextra -Wconversion -Wno-unused -Wno-unused-dummy-argument -fbacktrace -fimplicit-none -fcheck=all,no-pointer
-ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused $(ESMF_LINKOPTFLAG_G)
+ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
+
+############################################################
+# Special sanitizer flags
+#
+# Activate to turn on UBSan:
+#ESMF_OPTFLAG_G          += -fsanitize=undefined
+#ESMF_LINKOPTFLAG_G      += -fsanitize=undefined
+# Also set environment variable UBSAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+# Activate to turn on ASan:
+#ESMF_OPTFLAG_G          += -fsanitize=address
+#ESMF_LINKOPTFLAG_G      += -fsanitize=address
+# Also set environment variable ASAN_OPTIONS="help=1" to see available
+# run-time options.
+#
 
 ############################################################
 # Fortran symbol convention

--- a/build_config/Linux.nag.default/build_rules.mk
+++ b/build_config/Linux.nag.default/build_rules.mk
@@ -104,13 +104,8 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} --version
 ############################################################
 # Special debug flags
 #
-# Activate to turn on UBSan:
-#ESMF_LINKOPTFLAG_G      += -fsanitize=undefined
-# Also set environment variable UBSAN_OPTIONS="print_stacktrace=1"
-# for stacktrace at runtime.
-#
 ESMF_F90OPTFLAG_G       += -C=array
-ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused $(ESMF_LINKOPTFLAG_G)
+ESMF_CXXOPTFLAG_G       += -Wall -Wextra -Wno-unused
 
 ############################################################
 # Set NAG unix modules when certain non-Standard system calls

--- a/src/Infrastructure/Array/src/ESMCI_Array.C
+++ b/src/Infrastructure/Array/src/ESMCI_Array.C
@@ -2694,7 +2694,7 @@ int Array::destroy(
   }
 
   // optionally delete the complete object and remove from garbage collection
-  if (noGarbage){
+  if (noGarbage || VM::getCurrent()->isGarbageNone()){
     VM::rmObject(*array); // remove object from garbage collection
     delete (*array);      // completely delete the object, free heap
   }

--- a/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
+++ b/src/Infrastructure/ArrayBundle/src/ESMCI_ArrayBundle.C
@@ -274,16 +274,16 @@ int ArrayBundle::destroy(
   localrc = (*arraybundle)->destruct();
   if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU, ESMC_CONTEXT,
     &rc)) return rc;
-  
+
   // mark as invalid object
   (*arraybundle)->ESMC_BaseSetStatus(ESMF_STATUS_INVALID);
-  
+
   // optionally delete the complete object and remove from garbage collection
-  if (noGarbage){
+  if (noGarbage || VM::getCurrent()->isGarbageNone()){
     VM::rmObject(*arraybundle); // remove object from garbage collection
     delete (*arraybundle);      // completely delete the object, free heap
   }
-  
+
   // return successfully
   rc = ESMF_SUCCESS;
   return rc;

--- a/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
+++ b/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
@@ -456,7 +456,7 @@ int DELayout::destroy(
   }
 
   // optionally delete the complete object and remove from garbage collection
-  if (noGarbage){
+  if (noGarbage || VM::getCurrent()->isGarbageNone()){
     VM::rmObject(*delayout); // remove object from garbage collection
     delete (*delayout);      // completely delete the object, free heap
   }

--- a/src/Infrastructure/DistGrid/src/ESMCI_DistGrid.C
+++ b/src/Infrastructure/DistGrid/src/ESMCI_DistGrid.C
@@ -3207,7 +3207,7 @@ int DistGrid::destroy(
   }
   
   // optionally delete the complete object and remove from garbage collection
-  if (noGarbage){
+  if (noGarbage || VM::getCurrent()->isGarbageNone()){
     VM::rmObject(*distgrid); // remove object from garbage collection
     delete (*distgrid);      // completely delete the object, free heap
   }

--- a/src/Infrastructure/VM/include/ESMCI_VM.h
+++ b/src/Infrastructure/VM/include/ESMCI_VM.h
@@ -110,8 +110,10 @@ class VMTimer {
 // class definition
 class VM : public VMK {   // inherits from ESMCI::VMK class
   // This is the ESMF derived virtual machine class.
-    // performance timers
-    std::map<std::string, VMTimer> timers;
+  private:
+    enum GarbageMode{garbageNone, garbageFull, garbageSafe};
+    GarbageMode garbageMode = garbageSafe;  // default use safe garbage mode
+    std::map<std::string, VMTimer> timers;  // performance timers
   public:
     // initialize(), finalize() and abort() of global VM
     static VM *initialize(MPI_Comm mpiCommunicator, bool globalResourceControl,

--- a/src/Infrastructure/VM/include/ESMCI_VM.h
+++ b/src/Infrastructure/VM/include/ESMCI_VM.h
@@ -138,6 +138,9 @@ class VM : public VMK {   // inherits from ESMCI::VMK class
     static bool isThreadKnown(int *rc=NULL);  // is thread known under any VM
     static VMId *getCurrentID(int *rc=NULL);  // VMId of current VM
     static void getCurrentGarbageInfo(int *, int *); // garbage info current VM
+    bool isGarbageNone() const{
+      return (garbageMode==garbageNone);
+    }
     static void logGarbageInfo(std::string prefix, bool current=false,
       ESMC_LogMsgType_Flag msgType=ESMC_LOGMSG_INFO); // garbage log current VM
     static void getMemInfo(int *virtMemPet, int *physMemPet);   // memory info

--- a/src/Infrastructure/VM/src/ESMCI_VM.C
+++ b/src/Infrastructure/VM/src/ESMCI_VM.C
@@ -3436,13 +3436,13 @@ VM *VM::initialize(
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
     }
-    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_PETLIST";
+    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_OUTPUT";
     esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
     if (esmfRuntimeVarValue){
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
     }
-    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_OUTPUT";
+    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_PETLIST";
     esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
     if (esmfRuntimeVarValue){
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
@@ -3460,7 +3460,7 @@ VM *VM::initialize(
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
     }
-    esmfRuntimeVarName = "ESMF_RUNTIME_TRACE_PETLIST";
+    esmfRuntimeVarName = "ESMF_RUNTIME_TRACE_CLOCK";
     esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
     if (esmfRuntimeVarValue){
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
@@ -3472,13 +3472,13 @@ VM *VM::initialize(
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
     }
-    esmfRuntimeVarName = "ESMF_RUNTIME_TRACE_CLOCK";
+    esmfRuntimeVarName = "ESMF_RUNTIME_TRACE_FLUSH";
     esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
     if (esmfRuntimeVarValue){
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
     }
-    esmfRuntimeVarName = "ESMF_RUNTIME_TRACE_FLUSH";
+    esmfRuntimeVarName = "ESMF_RUNTIME_TRACE_PETLIST";
     esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
     if (esmfRuntimeVarValue){
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);

--- a/src/Infrastructure/VM/src/ESMCI_VM.C
+++ b/src/Infrastructure/VM/src/ESMCI_VM.C
@@ -3339,6 +3339,36 @@ VM *VM::initialize(
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
     }
+    esmfRuntimeVarName = "ESMF_RUNTIME_GARBAGE";
+    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
+    if (esmfRuntimeVarValue){
+      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
+      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
+    }
+    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE";
+    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
+    if (esmfRuntimeVarValue){
+      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
+      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
+    }
+    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_PETLIST";
+    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
+    if (esmfRuntimeVarValue){
+      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
+      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
+    }
+    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_OUTPUT";
+    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
+    if (esmfRuntimeVarValue){
+      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
+      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
+    }
+    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_REGRID";
+    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
+    if (esmfRuntimeVarValue){
+      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
+      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
+    }
     esmfRuntimeVarName = "ESMF_RUNTIME_TRACE";
     esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
     if (esmfRuntimeVarValue){
@@ -3369,32 +3399,7 @@ VM *VM::initialize(
       esmfRuntimeEnv.push_back(esmfRuntimeVarName);
       esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
     }
-    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE";
-    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
-    if (esmfRuntimeVarValue){
-      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
-      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
-    }
-    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_PETLIST";
-    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
-    if (esmfRuntimeVarValue){
-      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
-      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
-    }
-    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_OUTPUT";
-    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
-    if (esmfRuntimeVarValue){
-      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
-      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
-    }
-    esmfRuntimeVarName = "ESMF_RUNTIME_PROFILE_REGRID";
-    esmfRuntimeVarValue = std::getenv(esmfRuntimeVarName);
-    if (esmfRuntimeVarValue){
-      esmfRuntimeEnv.push_back(esmfRuntimeVarName);
-      esmfRuntimeEnvValue.push_back(esmfRuntimeVarValue);
-    }
 
-    
     int count = esmfRuntimeEnv.size();
     GlobalVM->broadcast(&count, sizeof(int), 0);
     int *length = new int[2];

--- a/src/Superstructure/ESMFMod/src/ESMF_Init.F90
+++ b/src/Superstructure/ESMFMod/src/ESMF_Init.F90
@@ -296,15 +296,18 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !           value is set, potentially overriding the value defined within the
 !           user environment for the same variable.
 !           \begin{itemize}
+!              \item {\tt ESMF\_RUNTIME\_COMPLIANCECHECK}
+!              \item {\tt ESMF\_RUNTIME\_GARBAGE}
+!              \item {\tt ESMF\_RUNTIME\_GARBAGE\_LOG}
 !              \item {\tt ESMF\_RUNTIME\_PROFILE}
 !              \item {\tt ESMF\_RUNTIME\_PROFILE\_OUTPUT}
 !              \item {\tt ESMF\_RUNTIME\_PROFILE\_PETLIST}
+!              \item {\tt ESMF\_RUNTIME\_PROFILE\_REGRID}
 !              \item {\tt ESMF\_RUNTIME\_TRACE}
 !              \item {\tt ESMF\_RUNTIME\_TRACE\_CLOCK}
-!              \item {\tt ESMF\_RUNTIME\_TRACE\_PETLIST}
-!              \item {\tt ESMF\_RUNTIME\_TRACE\_COMPONENT}
 !              \item {\tt ESMF\_RUNTIME\_TRACE\_FLUSH}
-!              \item {\tt ESMF\_RUNTIME\_COMPLIANCECHECK}
+!              \item {\tt ESMF\_RUNTIME\_TRACE\_COMPONENT}
+!              \item {\tt ESMF\_RUNTIME\_TRACE\_PETLIST}
 !           \end{itemize}
 !     \item [{[configKey]}]
 !           If present, use {\tt configKey} to find the map of predefined
@@ -1326,15 +1329,18 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
       if (haveConfig) then
         ! Ingest ESMF_RUNTIME_* settings from config -> possibly override environment
+        call ingest_environment_variable("ESMF_RUNTIME_COMPLIANCECHECK")
+        call ingest_environment_variable("ESMF_RUNTIME_GARBAGE")
+        call ingest_environment_variable("ESMF_RUNTIME_GARBAGE_LOG")
         call ingest_environment_variable("ESMF_RUNTIME_PROFILE")
         call ingest_environment_variable("ESMF_RUNTIME_PROFILE_OUTPUT")
         call ingest_environment_variable("ESMF_RUNTIME_PROFILE_PETLIST")
+        call ingest_environment_variable("ESMF_RUNTIME_PROFILE_REGRID")
         call ingest_environment_variable("ESMF_RUNTIME_TRACE")
         call ingest_environment_variable("ESMF_RUNTIME_TRACE_CLOCK")
-        call ingest_environment_variable("ESMF_RUNTIME_TRACE_PETLIST")
-        call ingest_environment_variable("ESMF_RUNTIME_TRACE_COMPONENT")
         call ingest_environment_variable("ESMF_RUNTIME_TRACE_FLUSH")
-        call ingest_environment_variable("ESMF_RUNTIME_COMPLIANCECHECK")
+        call ingest_environment_variable("ESMF_RUNTIME_TRACE_COMPONENT")
+        call ingest_environment_variable("ESMF_RUNTIME_TRACE_PETLIST")
         ! optionally destroy the HConfigNode
         if (validHConfigNode) then
           call ESMF_HConfigDestroy(hconfigNode, rc=localrc)

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -58,6 +58,7 @@ program ESMX_App
                 "globalResourceControl       ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_COMPLIANCECHECK", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_GARBAGE        ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_GARBAGE_LOG    ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_PROFILE        ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_PROFILE_OUTPUT ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_PROFILE_PETLIST", & ! ESMF_Initialize option

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -65,9 +65,9 @@ program ESMX_App
                 "ESMF_RUNTIME_PROFILE_REGRID ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE          ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE_CLOCK    ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_TRACE_PETLIST  ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE_COMPONENT", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE_FLUSH    ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_TRACE_PETLIST  ", & ! ESMF_Initialize option
                 "startTime                   ", & ! ESMX_App option
                 "stopTime                    ", & ! ESMX_App option
                 "logFlush                    ", & ! ESMX_App option

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -56,15 +56,17 @@ program ESMX_App
                 "logKindFlag                 ", & ! ESMF_Initialize option
                 "defaultCalKind              ", & ! ESMF_Initialize option
                 "globalResourceControl       ", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_COMPLIANCECHECK", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_GARBAGE        ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_PROFILE        ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_PROFILE_OUTPUT ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_PROFILE_PETLIST", & ! ESMF_Initialize option
+                "ESMF_RUNTIME_PROFILE_REGRID ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE          ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE_CLOCK    ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE_PETLIST  ", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE_COMPONENT", & ! ESMF_Initialize option
                 "ESMF_RUNTIME_TRACE_FLUSH    ", & ! ESMF_Initialize option
-                "ESMF_RUNTIME_COMPLIANCECHECK", & ! ESMF_Initialize option
                 "startTime                   ", & ! ESMX_App option
                 "stopTime                    ", & ! ESMX_App option
                 "logFlush                    ", & ! ESMX_App option

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -344,15 +344,17 @@ This section affects the application level.
 | `defaultCalKind`          | ESMF calendar kind used by default, see ESMF RefDoc for options | `ESMF_CALKIND_GREGORIAN` |
 | `logFlush`                | enable/disable log flush for each write: `true` or `false`| `false`         |
 | `fieldDictionary`         | name of the NUOPC field dictionary file to be loaded      | *None*          |
+| `ESMF_RUNTIME_COMPLIANCECHECK`| enable/disable NUOPC compliance checking: `ON` or `OFF` with `DEPTH` | `OFF`|
+| `ESMF_RUNTIME_GARBAGE`    | ESMF garbage collection setting: `NONE`, `FULL`,`SAFE`     | `SAFE`          |
 | `ESMF_RUNTIME_PROFILE`    | enable/disable all profiling functions: `ON` or `OFF`     | `OFF`           |
 | `ESMF_RUNTIME_PROFILE_OUTPUT` | output format; multiple can be selected: `TEXT` `SUMMARY` `BINARY` | `TEXT`      |
 | `ESMF_RUNTIME_PROFILE_PETLIST`| limit profiling to an explicit list of PETs           | *all PETs*      |
+| `ESMF_RUNTIME_PROFILE_REGRID` | enable/disable regrid profiling                       | `OFF`           |
 | `ESMF_RUNTIME_TRACE`      | enable/disable all tracing functions: `ON` or `OFF`       | `OFF`           |
 | `ESMF_RUNTIME_TRACE_CLOCK`| type of clock for events: `REALTIME` or `MONOTONIC` or `MONOTONIC_SYNC`  | `REALTIME`|
 | `ESMF_RUNTIME_TRACE_PETLIST`| limit tracing to an explicit list of PETs               | *all PETs*      |
 | `ESMF_RUNTIME_TRACE_COMPONENT`| enable/disable tracing of component events: `ON` or `OFF` | `ON`        |
 | `ESMF_RUNTIME_TRACE_FLUSH`| frequency of event stream flushing to file: `DEFAULT` or `EAGER` | `DEFAULT`|
-| `ESMF_RUNTIME_COMPLIANCECHECK`| enable/disable NUOPC compliance checking: `ON` or `OFF` with `DEPTH` | `OFF`|
 
 #### ESMX/Driver Options
 

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -346,10 +346,11 @@ This section affects the application level.
 | `fieldDictionary`         | name of the NUOPC field dictionary file to be loaded      | *None*          |
 | `ESMF_RUNTIME_COMPLIANCECHECK`| enable/disable NUOPC compliance checking: `ON` or `OFF` with `DEPTH` | `OFF`|
 | `ESMF_RUNTIME_GARBAGE`    | ESMF garbage collection setting: `NONE`, `FULL`,`SAFE`     | `SAFE`          |
+| `ESMF_RUNTIME_GARBAGE_LOG`| enable/disable logging of ESMF garbage collection: `ON` or `OFF`         | `OFF`|
 | `ESMF_RUNTIME_PROFILE`    | enable/disable all profiling functions: `ON` or `OFF`     | `OFF`           |
 | `ESMF_RUNTIME_PROFILE_OUTPUT` | output format; multiple can be selected: `TEXT` `SUMMARY` `BINARY` | `TEXT`      |
 | `ESMF_RUNTIME_PROFILE_PETLIST`| limit profiling to an explicit list of PETs           | *all PETs*      |
-| `ESMF_RUNTIME_PROFILE_REGRID` | enable/disable regrid profiling                       | `OFF`           |
+| `ESMF_RUNTIME_PROFILE_REGRID` | enable/disable regrid profiling: `ON` or `OFF`        | `OFF`           |
 | `ESMF_RUNTIME_TRACE`      | enable/disable all tracing functions: `ON` or `OFF`       | `OFF`           |
 | `ESMF_RUNTIME_TRACE_CLOCK`| type of clock for events: `REALTIME` or `MONOTONIC` or `MONOTONIC_SYNC`  | `REALTIME`|
 | `ESMF_RUNTIME_TRACE_PETLIST`| limit tracing to an explicit list of PETs               | *all PETs*      |

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -341,21 +341,21 @@ This section affects the application level.
 | `logKindFlag`             | ESMF logging kind, see ESMF RefDoc for options            | `ESMF_LOGKIND_Multi_On_Error`|
 | `logAppendFlag`           | enable/disable log append: `true` or `false`              | `true`          |
 | `defaultLogFilename`      | name of the default ESMF log file (suffix if multi PET)   | `ESMF_LogFile`  |
-| `defaultCalKind`          | ESMF calendar kind used by default, see ESMF RefDoc for options | `ESMF_CALKIND_GREGORIAN` |
+| `defaultCalKind`          | ESMF calendar kind used by default, see ESMF RefDoc for options | `ESMF_CALKIND_GREGORIAN`|
 | `logFlush`                | enable/disable log flush for each write: `true` or `false`| `false`         |
 | `fieldDictionary`         | name of the NUOPC field dictionary file to be loaded      | *None*          |
 | `ESMF_RUNTIME_COMPLIANCECHECK`| enable/disable NUOPC compliance checking: `ON` or `OFF` with `DEPTH` | `OFF`|
 | `ESMF_RUNTIME_GARBAGE`    | ESMF garbage collection setting: `NONE`, `FULL`,`SAFE`     | `SAFE`          |
 | `ESMF_RUNTIME_GARBAGE_LOG`| enable/disable logging of ESMF garbage collection: `ON` or `OFF`         | `OFF`|
 | `ESMF_RUNTIME_PROFILE`    | enable/disable all profiling functions: `ON` or `OFF`     | `OFF`           |
-| `ESMF_RUNTIME_PROFILE_OUTPUT` | output format; multiple can be selected: `TEXT` `SUMMARY` `BINARY` | `TEXT`      |
+| `ESMF_RUNTIME_PROFILE_OUTPUT` | output format; multiple can be selected: `TEXT` `SUMMARY` `BINARY` | `TEXT` |
 | `ESMF_RUNTIME_PROFILE_PETLIST`| limit profiling to an explicit list of PETs           | *all PETs*      |
 | `ESMF_RUNTIME_PROFILE_REGRID` | enable/disable regrid profiling: `ON` or `OFF`        | `OFF`           |
 | `ESMF_RUNTIME_TRACE`      | enable/disable all tracing functions: `ON` or `OFF`       | `OFF`           |
 | `ESMF_RUNTIME_TRACE_CLOCK`| type of clock for events: `REALTIME` or `MONOTONIC` or `MONOTONIC_SYNC`  | `REALTIME`|
-| `ESMF_RUNTIME_TRACE_PETLIST`| limit tracing to an explicit list of PETs               | *all PETs*      |
-| `ESMF_RUNTIME_TRACE_COMPONENT`| enable/disable tracing of component events: `ON` or `OFF` | `ON`        |
 | `ESMF_RUNTIME_TRACE_FLUSH`| frequency of event stream flushing to file: `DEFAULT` or `EAGER` | `DEFAULT`|
+| `ESMF_RUNTIME_TRACE_COMPONENT`| enable/disable tracing of component events: `ON` or `OFF` | `ON`        |
+| `ESMF_RUNTIME_TRACE_PETLIST`  | limit tracing to an explicit list of PETs                 | *all PETs*  |
 
 #### ESMX/Driver Options
 


### PR DESCRIPTION
This PR addresses #277 by introducing two new ESMF_RUNTIME_ environment variables that provide user level control over the ESMF garbage collection functionality:

- `ESMF_RUNTIME_GARBAGE` with supported options `NONE`, `FULL`, and `SAFE` (default).
- `ESMF_RUNTIME_GARBAGE_LOG` with supported options `ON` and `OFF` (default).

Both variables are integrated into the standard `ESMF_RUNTIME_` environment handling, i.e. can also be set via configuration file and ingested during `ESMF_Initialize()`.

The default option, `ESMF_RUNTIME_GARBAGE=SAFE`, is implemented to provide unchanged garbage collection behavior compared to before this PR. This is the recommended way for typical scenarios.

The `ESMF_RUNTIME_GARBAGE=NONE` option disables the ESMF garbage collection. In this mode, the destroy responsibility for ESMF objects lies completely with the user. This can be useful when testing for memory leaks, e.g. for simple Create()/Destroy() code patterns. Notice however that this mode cannot provide double destroy and dangling alias protection!

The `ESMF_RUNTIME_GARBAGE=FULL` option enables all of the ESMF garbage collection code, including those portions that are not operating under `SAFE` mode. This might lead to potential crashes or undefined behavior in complex applications with coupled components accessing shared objects (potentially proxy objects). 

When experimenting with the ESMF garbage collection functionality, it can be helpful to set `ESMF_RUNTIME_GARBAGE_LOG=ON`. This instructs the garbage collection code to log information to the ESMF default log.