### PR TITLE
Determine LLVM Flang runtime libs dynamically for backward compatibility

### DIFF
--- a/build_config/Linux.llvm.default/build_rules.mk
+++ b/build_config/Linux.llvm.default/build_rules.mk
@@ -239,7 +239,7 @@ ESMF_F90LINKLIBS += -lrt -lstdc++ -ldl
 ############################################################
 # Link against libesmf.a using the C++ linker front-end
 #
-ESMF_CXXLINKLIBS += -lrt -lFortranDecimal -lflang_rt.runtime -lstdc++ -lm -ldl
+ESMF_CXXLINKLIBS += $(shell $(ESMF_DIR)/scripts/libs.llvm $(ESMF_F90COMPILER) $(ESMF_F90COMPILEOPTS)) -lrt -lstdc++ -lm -ldl
 
 ############################################################
 # Linker option that ensures that the specified libraries are 

--- a/scripts/libs.llvm
+++ b/scripts/libs.llvm
@@ -1,0 +1,5 @@
+#!/bin/sh
+# this script expects the LLVM flang command (or a wrapper, e.g. mpif90)
+# and returns the LLVM flang runtime libraries that need to be linked explicitly when using clang as linker
+$* -v $ESMF_DIR/scripts/hello.f90 2>&1 | grep "\-L" | awk 'BEGIN { RS=" "}; /^-l/ ' | xargs
+rm -f hello.o a.out


### PR DESCRIPTION
Resolves #411 by using a script to determine the LLVM flang runtime libraries from `flang` itself. This is needed while LLVM flang runtime libs are still in flux due to active development, e.g. between LLVM versions 20 and 21.