### PR TITLE
Address issues flagged by AddressSanitizer - low hanging fruit

### DIFF
--- a/src/Infrastructure/IO/interface/ESMCI_IO_YAML_F.C
+++ b/src/Infrastructure/IO/interface/ESMCI_IO_YAML_F.C
@@ -216,7 +216,7 @@ namespace ESMCI {
     }
 
     //--------------------------------------------------------------------
-    void FTN_X(c_esmc_io_yamlcget)(IO_YAML **ptr, char *data, int *rc) {
+    void FTN_X(c_esmc_io_yamlcget)(IO_YAML **ptr, char *data, int *dataLen, int *rc) {
 #undef  ESMC_METHOD
 #define ESMC_METHOD "c_esmc_io_yamlcget()"
       // Initialize return code; assume routine not implemented
@@ -228,7 +228,7 @@ namespace ESMCI {
       if (data) {
         const std::string buffer = (*ptr)->cget();
         if (!buffer.empty()) {
-          size_t len = buffer.copy(data, std::strlen(data));
+          size_t len = buffer.copy(data, *dataLen);
           data[len] = '\0';
         }
       }

--- a/src/Infrastructure/IO/interface/ESMF_IO_YAML.F90
+++ b/src/Infrastructure/IO/interface/ESMF_IO_YAML.F90
@@ -560,7 +560,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer :: localrc, stat
     ! local variables
     integer :: i, j, k
-    integer :: contentLineCount, contentStringLen
+    integer :: contentLineCount, contentStringLen, contentLen
     character(len=1), allocatable :: buffer(:)
 !
 !   ! Assume failure until success
@@ -583,8 +583,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       ! setup receiving buffer for parsed content
       contentStringLen = len(content(1))
       contentLineCount = size(content)
-      allocate(buffer(contentStringLen * contentLineCount), &
-        stat=stat)
+      contentLen = contentStringLen * contentLineCount
+      allocate(buffer(contentLen), stat=stat)
       if (ESMF_LogFoundAllocError(statusToCheck=stat, &
         msg="Allocation of string buffer.", &
         ESMF_CONTEXT, rcToReturn=rc)) return
@@ -592,7 +592,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       ! initialize buffer
       buffer = ""
 
-      call c_ESMC_IO_YAMLCGet(yaml, buffer, localrc)
+      call c_ESMC_IO_YAMLCGet(yaml, buffer, contentLen, localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
 

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Alarm_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Alarm_F.C
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 // INCLUDES
 //------------------------------------------------------------------------------
+#include <string>
 #include <cstdio>
 
 #include "ESMCI_F90Interface.h"
@@ -229,10 +230,11 @@ extern "C" {
                                          const char *name,
                                          int *status,
                                          ESMCI_FortranStrLenArg name_l) {
+          std::string nameStr(name, ESMC_F90lentrim(name, name_l));
           *ptr = ESMCI_alarmReadRestart(
                                            *nameLen,  // always present
                                                       //   internal argument.
-                                            name,     // required.
+                                            nameStr.c_str(),    // required.
                     ESMC_NOT_PRESENT_FILTER(status) );
        }
 
@@ -247,8 +249,8 @@ extern "C" {
                                       int *status,
                                       ESMCI_FortranStrLenArg options_l) {
           ESMF_CHECK_POINTER(*ptr, status)
-          int rc = (*ptr)->Alarm::validate(
-                      ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (*ptr)->Alarm::validate(optionsStr.c_str());
           if (ESMC_PRESENT(status)) *status = rc;
        }
 
@@ -256,8 +258,8 @@ extern "C" {
                                       int *status,
                                       ESMCI_FortranStrLenArg options_l) {
           ESMF_CHECK_POINTER(*ptr, status)
-          int rc = (*ptr)->Alarm::print(
-                   ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (*ptr)->Alarm::print(optionsStr.c_str());
           fflush (stdout);
           if (ESMC_PRESENT(status)) *status = rc;
        }

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Calendar_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Calendar_F.C
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 // INCLUDES
 //------------------------------------------------------------------------------
+#include <string>
 #include <cstdio>
 
 #include "ESMCI_F90Interface.h"
@@ -374,10 +375,11 @@ extern "C" {
                                             const char *name,
                                             int *status,
                                             ESMCI_FortranStrLenArg name_l) {
+           std::string nameStr(name, ESMC_F90lentrim(name, name_l));
            *ptr = ESMCI_CalendarReadRestart(
                                           *nameLen,  // always present
                                                     //   internal argument.
-                                           name,     // required.
+                                           nameStr.c_str(),    // required.
                    ESMC_NOT_PRESENT_FILTER(status) );
        }
 
@@ -393,8 +395,8 @@ extern "C" {
                                          int *status,
                                          ESMCI_FortranStrLenArg options_l) {
            ESMF_CHECK_POINTER(*ptr, status)
-           int rc = (*ptr)->Calendar::validate(
-                          ESMC_NOT_PRESENT_FILTER(options) );
+           std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+           int rc = (*ptr)->Calendar::validate(optionsStr.c_str());
            if (ESMC_PRESENT(status)) *status = rc;
        }
 
@@ -402,8 +404,8 @@ extern "C" {
                                       int *status,
                                       ESMCI_FortranStrLenArg options_l) {
            ESMF_CHECK_POINTER(*ptr, status)
-           int rc = (*ptr)->Calendar::print(
-                       ESMC_NOT_PRESENT_FILTER(options) );
+           std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+           int rc = (*ptr)->Calendar::print(optionsStr.c_str());
            fflush (stdout);
            if (ESMC_PRESENT(status)) *status = rc;
        }

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Clock_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Clock_F.C
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 // INCLUDES
 //------------------------------------------------------------------------------
+#include <string>
 #include <cstdio>
 
 #include "ESMCI_F90Interface.h"
@@ -362,10 +363,11 @@ extern "C" {
                                          const char *name,
                                          int *status,
                                          ESMCI_FortranStrLenArg name_l) {
+          std::string nameStr(name, ESMC_F90lentrim(name, name_l));
           *ptr = ESMCI_ClockReadRestart(
                                            *nameLen,  // always present
                                                       //   internal argument.
-                                            name,     // required.
+                                            nameStr.c_str(),    // required.
                     ESMC_NOT_PRESENT_FILTER(status) );
        }
 
@@ -380,8 +382,8 @@ extern "C" {
                                       int *status,
                                       ESMCI_FortranStrLenArg options_l) {
           ESMF_CHECK_POINTER(*ptr, status)
-          int rc = (*ptr)->Clock::validate(
-                      ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (*ptr)->Clock::validate(optionsStr.c_str());
           if (ESMC_PRESENT(status)) *status = rc;
        }
 
@@ -389,8 +391,8 @@ extern "C" {
                                    int *status,
                                    ESMCI_FortranStrLenArg options_l) {
           ESMF_CHECK_POINTER(*ptr, status)
-          int rc = (*ptr)->Clock::print(
-                   ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (*ptr)->Clock::print(optionsStr.c_str());
           fflush (stdout);
           if (ESMC_PRESENT(status)) *status = rc;
        }

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_TimeInterval_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_TimeInterval_F.C
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 // INCLUDES
 //------------------------------------------------------------------------------
+#include <string>
 #include <cstdio>
 
 #include "ESMCI_F90Interface.h"
@@ -641,10 +642,11 @@ extern "C" {
                                                 const char *name,
                                                 int *status,
                                                 ESMCI_FortranStrLenArg name_l) {
+          std::string nameStr(name, ESMC_F90lentrim(name, name_l));
           int rc = (ptr)->TimeInterval::readRestart(
                                         *nameLen,  // always present
                                                    //   internal argument.
-                                         name);    // required.
+                                         nameStr.c_str());    // required.
 
           if (ESMC_PRESENT(status)) *status = rc;
        }
@@ -659,8 +661,8 @@ extern "C" {
        void FTN_X(c_esmc_timeintervalvalidate)(TimeInterval *ptr,
                                              const char *options, int *status,
                                              ESMCI_FortranStrLenArg options_l) {
-          int rc = (ptr)->TimeInterval::validate(
-                            ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (ptr)->TimeInterval::validate(optionsStr.c_str());
 
           if (ESMC_PRESENT(status)) *status = rc;
        }
@@ -668,8 +670,8 @@ extern "C" {
        void FTN_X(c_esmc_timeintervalprint)(TimeInterval *ptr,
                                           const char *options, int *status,
                                           ESMCI_FortranStrLenArg options_l) {
-          int rc = (ptr)->TimeInterval::print(
-                         ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (ptr)->TimeInterval::print(optionsStr.c_str());
 
           fflush (stdout);
           if (ESMC_PRESENT(status)) *status = rc;

--- a/src/Infrastructure/TimeMgr/interface/ESMCI_Time_F.C
+++ b/src/Infrastructure/TimeMgr/interface/ESMCI_Time_F.C
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 // INCLUDES
 //------------------------------------------------------------------------------
+#include <string>
 #include <cstdio>
 
 #include "ESMCI_F90Interface.h"
@@ -205,10 +206,11 @@ extern "C" {
                                         const char *name,
                                         int *status,
                                         ESMCI_FortranStrLenArg name_l) {
+          std::string nameStr(name, ESMC_F90lentrim(name, name_l));
           int rc = (ptr)->Time::readRestart(
                                                *nameLen,  // always present 
                                                           //  internal argument.
-                                                name);    // required.
+                                                nameStr.c_str());    // required.
           if (ESMC_PRESENT(status)) *status = rc;
        }
 
@@ -221,16 +223,16 @@ extern "C" {
        void FTN_X(c_esmc_timevalidate)(Time *ptr, const char *options,
                                      int *status,
                                      ESMCI_FortranStrLenArg options_l) {
-          int rc = (ptr)->Time::validate(
-                    ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (ptr)->Time::validate(optionsStr.c_str());
           if (ESMC_PRESENT(status)) *status = rc;
        }
 
        void FTN_X(c_esmc_timeprint)(Time *ptr, const char *options,
                                   int *status,
                                   ESMCI_FortranStrLenArg options_l) {
-          int rc = (ptr)->Time::print(
-                 ESMC_NOT_PRESENT_FILTER(options) );
+          std::string optionsStr(options, ESMC_F90lentrim(options, options_l));
+          int rc = (ptr)->Time::print(optionsStr.c_str());
           fflush (stdout);
           if (ESMC_PRESENT(status)) *status = rc;
        }

--- a/src/Infrastructure/VM/src/ESMCI_VM.C
+++ b/src/Infrastructure/VM/src/ESMCI_VM.C
@@ -2811,25 +2811,28 @@ void VM::logMemInfo(
   stderr = stderrOrig;  // restore original stderr
   fflush(fp);
   fclose(fp); // must close before free(buf), b/c buf may re-alloc!
-  std::string malloc_stats_output;
   if (buf){
-    malloc_stats_output = string(buf, buf+len);
+    if (len){
+      std::string malloc_stats_output = string(buf, buf+len);
+      size_t pos = malloc_stats_output.rfind("system bytes     =");
+      pos += 18;
+      long system = strtol(malloc_stats_output.c_str()+pos, NULL, 10);
+      info.str(""); // clear info
+      info << "[malloc] Total space held (mmap + non-mmap): " << setw(16)
+        << system;
+      sprintf(msg, "%s - MemInfo: %s Byte", prefix.c_str(), info.str().c_str());
+      log->Write(msg, msgType);
+      pos = malloc_stats_output.rfind("in use bytes     =");
+      pos += 18;
+      long in_use = strtol(malloc_stats_output.c_str()+pos, NULL, 10);
+      info.str(""); // clear info
+      info << "[malloc] Total space used (mmap + non-mmap): " << setw(16)
+        << in_use;
+      sprintf(msg, "%s - MemInfo: %s Byte", prefix.c_str(), info.str().c_str());
+      log->Write(msg, msgType);
+    }
     free(buf);
   }
-  size_t pos = malloc_stats_output.rfind("system bytes     =");
-  pos += 18;
-  long system = strtol(malloc_stats_output.c_str()+pos, NULL, 10);
-  info.str(""); // clear info
-  info << "[malloc] Total space held (mmap + non-mmap): " <<setw(16)<< system;
-  sprintf(msg, "%s - MemInfo: %s Byte", prefix.c_str(), info.str().c_str());
-  log->Write(msg, msgType);
-  pos = malloc_stats_output.rfind("in use bytes     =");
-  pos += 18;
-  long in_use = strtol(malloc_stats_output.c_str()+pos, NULL, 10);
-  info.str(""); // clear info
-  info << "[malloc] Total space used (mmap + non-mmap): " <<setw(16)<< in_use;
-  sprintf(msg, "%s - MemInfo: %s Byte", prefix.c_str(), info.str().c_str());
-  log->Write(msg, msgType);
 #elif (defined ESMF_OS_Darwin)
   // Get memory
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1090

--- a/src/Infrastructure/VM/src/ESMCI_VMKernel.C
+++ b/src/Infrastructure/VM/src/ESMCI_VMKernel.C
@@ -3544,11 +3544,11 @@ VMKPlan::~VMKPlan(){
     commfreeflag = 0;
   }
   if (stdoutName){
-    delete stdoutName;
+    delete [] stdoutName;
     stdoutName = NULL;
   }
   if (stderrName){
-    delete stderrName;
+    delete [] stderrName;
     stderrName = NULL;
   }
 }


### PR DESCRIPTION
This PR addresses some of the easy to fix issues that were flagged on my local Linux system, running with AddressSanitizer enabled (specifically this was with GCC 7.4.0 and `ESMF_OPTFLAG_G  += -fsanitize=address` + `ESMF_LINKOPTFLAG_G  += -fsanitize=address`). 
