### PR TITLE
DEV: Change python git version plugin to setuptools_scm.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
-src/doc		export-ignore
-.gitattributes	export-ignore
-.gitignore	export-ignore
-
-*.C linguist-language=C++
+.git_archival.txt         export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
-.git_archival.txt         export-subst
+src/doc		export-ignore
+.gitattributes	export-ignore
+.gitignore	export-ignore
+
+*.C linguist-language=C++
+
+.git_archival.txt export-subst

--- a/src/addon/esmpy/.git_archival.txt
+++ b/src/addon/esmpy/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/src/addon/esmpy/pyproject.toml
+++ b/src/addon/esmpy/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools>=41", "wheel", "setuptools-git-versioning" ]
+requires = [ "setuptools>=41", "wheel", "setuptools-scm" ]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -57,12 +57,11 @@ Documentation = "https://earthsystemmodeling.org/esmpy_doc/release/latest/html/"
 sourcecode = "https://github.com/esmf-org/esmf/tree/develop/src/addon/esmpy"
 releasenotes = "https://earthsystemmodeling.org/static/releases.html"
 
-[tool.setuptools-git-versioning]
-enabled = true
-template = "{tag}"
-dev_template = "{tag}"
-dirty_template = "{tag}"
-starting_version = "8.9.0beta" # this is a backup for pip <= 22.0 where git-versioning doesn't work; it is also needed for the conda distribution of ESMPy; it is important that this does NOT include "beta" on release branches
+[tool.setuptools_scm]
+root = "../../.."
+parentdir_prefix_version = "esmf-"
+fallback_version = "8.9.0beta" # this is needed for the conda distribution of ESMPy; it is important that this does NOT include "beta" on release branches
+fallback_root = "../../.."
 
 [tool.dynamic]
 version = "placeholder" # this is a placeholder for the version pulled with git-versioning

--- a/src/addon/esmpy/pyproject.toml
+++ b/src/addon/esmpy/pyproject.toml
@@ -62,6 +62,7 @@ root = "../../.."
 parentdir_prefix_version = "esmf-"
 fallback_version = "8.9.0beta" # this is needed for the conda distribution of ESMPy; it is important that this does NOT include "beta" on release branches
 fallback_root = "../../.."
+local_scheme = "no-local-version"
 
 [tool.dynamic]
 version = "placeholder" # this is a placeholder for the version pulled with git-versioning


### PR DESCRIPTION
Hopefully this will cause fewer problems than setuptools-git-versioning on builds from tarballs (e.g. esmf-org/esmf#367).

Behavior on git tags should be identical. I think I changed the behavior on commits after tags and on working trees with changes.  

It should be able to get the version from GitHub's auto-generated release/tag archives (https://github.com/esmf-org/esmf/archive/refs/tags/v8.8.1.tar.gz), it might be able to get a version from GitHub's auto-generated branch archives (https://github.com/esmf-org/esmf/archive/refs/heads/develop.zip), it keeps the existing fallback version in case neither of those worked, and downstream users should be able to set the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_esmpy` environment variable if all of the previous attempts got borked somehow.

Descriptions of fallbacks [here](https://setuptools-scm.readthedocs.io/en/stable/usage/#builtin-mechanisms-for-obtaining-version-numbers) and [here](https://setuptools-scm.readthedocs.io/en/stable/config/).