### PR TITLE
Fix Fujitsu build failure

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -1134,7 +1134,8 @@ endif
 
 ifeq ($(ESMF_COMPILER),fujitsu)
 # under Fujitsu the Fortran link libs are not compatible with C linker
-ESMF_CLINKLIBS     += $(ESMF_CXXLINKLIBS)
+# explicitly set here
+ESMF_CLINKLIBS     += $(ESMF_CXXLINKLIBS) -lstdc++
 else
 # but for other compilers the Fortran link libs are often needed by C linker
 ESMF_CLINKLIBS     += $(ESMF_CXXLINKLIBS) $(ESMF_F90LINKLIBS)

--- a/build/common.mk
+++ b/build/common.mk
@@ -1131,7 +1131,14 @@ endif
 ifeq ($(origin ESMF_CLINKLIBS_ENV), environment)
 ESMF_CLINKLIBS = $(ESMF_CLINKLIBS_ENV)
 endif
+
+ifeq ($(ESMF_COMPILER),fujitsu)
+# under Fujitsu the Fortran link libs are not compatible with C linker
+ESMF_CLINKLIBS     += $(ESMF_CXXLINKLIBS)
+else
+# but for other compilers the Fortran link libs are often needed by C linker
 ESMF_CLINKLIBS     += $(ESMF_CXXLINKLIBS) $(ESMF_F90LINKLIBS)
+endif
 ESMF_CESMFLINKLIBS += -lesmf $(ESMF_CLINKLIBS)
 
 # - tools: AR + RANLIB + ...

--- a/build_config/Linux.fujitsu.default/build_rules.mk
+++ b/build_config/Linux.fujitsu.default/build_rules.mk
@@ -61,8 +61,8 @@ ESMF_CXXCOMPILECPPFLAGS += -DESMF_NO_F2018ASSUMEDTYPE
 ############################################################
 # Special debug flags
 #
-ESMF_F90OPTFLAG_G       += -Nquickdbg 
-ESMF_CXXOPTFLAG_G       += -Nquickdbg
+ESMF_F90OPTFLAG_G       += -Nquickdbg
+ESMF_CXXOPTFLAG_G       +=
 
 ############################################################
 # Enable TR15581/F2003 Allocatable array resizing
@@ -133,7 +133,7 @@ ESMF_F90LINKLIBS += --linkstl=libstdc++
 ESMF_CXXLINKLIBS += --linkfortran
 
 ############################################################
-# Linker option that ensures that the specified libraries are 
+# Linker option that ensures that the specified libraries are
 # used to also resolve symbols needed by other libraries.
 #
 ESMF_F90LINKOPTS          += -Wl,--no-as-needed


### PR DESCRIPTION
This PR resolves #417:

- Do not use Fortran link libs when linking with C front end.
- Do not use `-Nquickdbg` with Clang. Also do not want to use sanitizer flags by default for debug mode because of outstanding issues, see #414.
