### PR TITLE
Build ESMF and ESMPy docs from ESMF forks

### DIFF
--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -26,7 +26,10 @@ jobs:
     - name: Build Docker image  
       run: | 
         cd ${{ github.workspace }}/esmf-containers/build-esmf-docs/esmf
-        docker build . --tag esmf/build-esmf-docs --build-arg ESMF_BRANCH="${{ github.ref_name }}" --no-cache
+        docker build . --tag esmf/build-esmf-docs \
+          --build-arg "ESMF_REPOSITORY=${{github.server_url}}/${{github.repository}}" \
+          --build-arg "ESMF_BRANCH=${{github.ref_name}}" \
+          --no-cache
         
     - name: Extract artifacts
       run: |
@@ -43,6 +46,7 @@ jobs:
         path: ${{ github.workspace }}/artifacts
        
     - name: Checkout esmf-org.github.io
+      if: github.repository_owner == 'esmf-org'
       uses: actions/checkout@v4
       with:
           repository: esmf-org/esmf-org.github.io
@@ -50,6 +54,7 @@ jobs:
           ssh-key: ${{secrets.ESMF_WEB_DEPLOY_KEY}}
 
     - name: Copy docs
+      if: github.repository_owner == 'esmf-org'
       run: | 
         cd ${{ github.workspace }}/esmf-org.github.io        
         mkdir -p docs/nightly/${{ github.ref_name }}/dev_guide
@@ -66,6 +71,7 @@ jobs:
         cp -rf ./dev_guide/dev_guide/* ${{ github.workspace }}/esmf-org.github.io/docs/nightly/${{ github.ref_name }}/dev_guide/
         
     - name: Commit and publish docs
+      if: github.repository_owner == 'esmf-org'
       run: | 
         cd ${{ github.workspace }}/esmf-org.github.io
         git config user.name "github-actions[bot]"

--- a/.github/workflows/build-esmpy-docs.yml
+++ b/.github/workflows/build-esmpy-docs.yml
@@ -26,7 +26,10 @@ jobs:
     - name: Build Docker image  
       run: | 
         cd ${{ github.workspace }}/esmf-containers/build-esmf-docs/esmpy
-        docker build . --tag esmf/build-esmpy-docs --build-arg ESMF_BRANCH="${{ github.ref_name }}" --no-cache
+        docker build . --tag esmf/build-esmpy-docs \
+          --build-arg "ESMF_REPOSITORY=${{github.server_url}}/${{github.repository}}" \
+          --build-arg "ESMF_BRANCH=${{github.ref_name}}" \
+          --no-cache
         
     - name: Copy artifacts
       run: |
@@ -43,6 +46,7 @@ jobs:
         path: ${{ github.workspace }}/artifacts
     
     - name: Checkout esmpy_doc
+      if: github.repository_owner == 'esmf-org'
       uses: actions/checkout@v4
       with:
           repository: esmf-org/esmpy_doc
@@ -50,6 +54,7 @@ jobs:
           ssh-key: ${{secrets.ESMPY_WEB_DEPLOY_KEY}}
     
     - name: Copy docs
+      if: github.repository_owner == 'esmf-org'
       run: | 
         cd ${{ github.workspace }}/esmpy_doc
         mkdir -p docs/nightly/${{ github.ref_name }}
@@ -60,6 +65,7 @@ jobs:
         cp -rf latex/ESMPy.pdf ${{ github.workspace }}/esmpy_doc/docs/nightly/${{ github.ref_name }}/
 
     - name: Commit and publish docs
+      if: github.repository_owner == 'esmf-org'
       run: |
         cd ${{ github.workspace }}/esmpy_doc
         git config user.name "github-actions[bot]"


### PR DESCRIPTION
This PR along with changes to Dockerfiles for esmf-containers/build-esmf-docs/esmf and esmf-containers/build-esmf-docs/esmpy fix the process of building ESMF and ESMPy documentation from an ESMF fork.

I tried to clean up the workflow further but struggled to successfully run GitHub actions, which require Node.js, from within the existing images. The images will need more significant rework/cleanup.

Requested by NASA for testing documentation changes

### Changes
* add ESMF_REPOSITORY to build-esmf-docs
* publish if repository owner is esmf-org