### PR TITLE
Append git origin to ESMF_VERSION_STRING_GIT

### DIFF
--- a/scripts/esmfversiongit
+++ b/scripts/esmfversiongit
@@ -2,5 +2,12 @@
 # return the ESMF version from Git if available, or empty string otherwise
 # test looks for .git directory or .git file (when esmf is a submodule)
 if [ -d $ESMF_DIR/.git ] || [ -s $ESMF_DIR/.git ] ; then \
-git describe --tags 2>&1 | grep -v fatal
+TAG=`git describe --tags 2>&1 | grep -v fatal`
+ORIG=`git config --get remote.origin.url 2>&1`
+if [ -z "$TAG" ] ; then TAG="no tag found" ; fi
+if [ -z "$ORIG" ] ; then ORIG="no origin found" ; fi
+case "$ORIG" in
+  *"esmf-org/esmf.git"*) echo $TAG ;;
+  *) echo $TAG "($ORIG)" ;;
+esac
 fi


### PR DESCRIPTION
Appends the git remote origin to ESMF_VERSION_STRING_GIT
If no origin is found then reports no origin found
Also fixes an issue where if no tag is found then ESMF assumes it is not a git repository. This is common when using GitHub actions/checkout because the fetch depth is zero.

Previous make info results
```
--------------------------------------------------------------
ESMF_VERSION_STRING:      8.9.0 beta snapshot
Not a Git repository
--------------------------------------------------------------
```

New make info results
```
--------------------------------------------------------------
ESMF_VERSION_STRING:      8.9.0 beta snapshot
ESMF_VERSION_STRING_GIT: no tag found (https://github.com/danrosen25/esmf)
--------------------------------------------------------------
On branch version_string_git
Your branch is up to date with 'origin/version_string_git'.

nothing to commit, working tree clean
--------------------------------------------------------------
```