### PR TITLE
Minor fix for spack build

### DIFF
--- a/.github/workflows/scripts/spack_concretize.sh
+++ b/.github/workflows/scripts/spack_concretize.sh
@@ -138,7 +138,7 @@ fi
 if [[ "$comp" == *"gcc"* ]]; then
   echo "::group::Check gcc compiler"
   str=`echo $comp | awk -F\@ '{print $1}'`
-  comp_ver=`spack compiler list | grep "${str}@" | tr -d "${str}@" | sort -n | tail -n 1`
+  comp_ver=`spack compiler list | grep "${str}@" | tr -d "${str}@" | awk '{print $2}' | sort -n | tail -n 1`
 
   use_latest=0
   if [[ "$comp" == *"gcc@latest"* ]]; then


### PR DESCRIPTION
It seems that there are some changes in spack side and `spack compiler list` command output format slightly changed and now includes extra information like `[e]` at the beginning. 

```
root@af01e8d67ed4:/opt# spack compiler list
==> Available compilers
-- gcc ubuntu24.04-aarch64 --------------------------------------
[e]  gcc@13.3.0
```

So, this PR modifies script to accommodate to the recent format change. 