### PR TITLE
Add `grid_to_field_map` argument to Field API in ESMPY

### DIFF
--- a/src/addon/esmpy/src/esmpy/api/field.py
+++ b/src/addon/esmpy/src/esmpy/api/field.py
@@ -64,10 +64,11 @@ class Field(object):
         single value, a list or a tuple containing the number of entries for
         each desired extra dimension of the :class:`~esmpy.api.field.Field`. The
         time dimension must be last, following Fortran indexing conventions.
-    :param list grid_to_field_map: Controls mapping of the grid dimension 
-        :class:`~esmpy.api.field.Field` index to the field dimension index. 
-        if ``None``, defaults to maping grid indices to the first available
-        field indices. List must be equal size to the grid rank
+    :param ndarray grid_to_field_map: numpy array mapping the grid dimension 
+        :class:`~esmpy.api.field.Field` index to the field dimension index.
+        Array length must be equal to the grid rank; uses 1-based indexing.
+        If ``None``, defaults to mapping grid indices to the first available
+        field indices.
     """
 
     @initialize

--- a/src/addon/esmpy/src/esmpy/api/field.py
+++ b/src/addon/esmpy/src/esmpy/api/field.py
@@ -64,6 +64,10 @@ class Field(object):
         single value, a list or a tuple containing the number of entries for
         each desired extra dimension of the :class:`~esmpy.api.field.Field`. The
         time dimension must be last, following Fortran indexing conventions.
+    :param list grid_to_field_map: Controls mapping of the grid dimension 
+        :class:`~esmpy.api.field.Field` index to the field dimension index. 
+        if ``None``, defaults to maping grid indices to the first available
+        field indices. List must be equal size to the grid rank
     """
 
     @initialize
@@ -71,7 +75,8 @@ class Field(object):
                 typekind=None,
                 staggerloc=None,
                 meshloc=None,
-                ndbounds=None):
+                ndbounds=None,
+                grid_to_field_map=None):
         # optional arguments
         if isinstance(staggerloc, type(None)):
             staggerloc = StaggerLoc.CENTER
@@ -81,7 +86,6 @@ class Field(object):
             meshloc = MeshLoc.NODE
 
         # extra levels?
-        grid_to_field_map = None
         ungridded_lower_bound = None
         ungridded_upper_bound = None
         rank = grid.rank
@@ -94,6 +98,9 @@ class Field(object):
 
         # TODO: flip ndbounds
         #     also, will have to verify that everything is switched back
+        if isinstance(grid_to_field_map, type(None)):
+            # set this to put gridded dimension in the first available dimensions of the field, dependent on grid rank
+           grid_to_field_map = np.array([i+1 for i in range(grid.rank)], dtype=np.int32)
 
         xd = 0
         if local_ndbounds:
@@ -101,8 +108,6 @@ class Field(object):
             lb = [1 for a in range(len(local_ndbounds))]
             ungridded_lower_bound = np.array(lb, dtype=np.int32)
             ungridded_upper_bound = np.array(local_ndbounds, dtype=np.int32)
-            # set this to put gridded dimension in the first available dimensions of the field, dependent on grid rank
-            grid_to_field_map = np.array([i+1 for i in range(grid.rank)], dtype=np.int32)
             rank += len(local_ndbounds)
 
         if isinstance(grid, Grid):

--- a/src/addon/esmpy/src/esmpy/test/test_api/test_field.py
+++ b/src/addon/esmpy/src/esmpy/test/test_api/test_field.py
@@ -552,3 +552,12 @@ class TestField(TestBase):
         assert type(field2) == np.ndarray
         assert field2.shape == (5,20)
         # self.examine_field_attributes(field2)
+
+    @pytest.mark.skipif(pet_count()!=1, reason="test must be run in serial")
+    def test_field_grid_to_field_map(self):
+        grid = Grid(np.array([8,10]), coord_sys=CoordSys.CART, staggerloc=StaggerLoc.CENTER)
+        field1 = Field(grid, ndbounds=[3,2])
+        g2fm = np.array([3,4],dtype=np.int32)
+        field2 = Field(grid, ndbounds=[3,2], grid_to_field_map=g2fm)
+        assert field1.data.shape == (8,10,3,2)
+        assert field2.data.shape == (3,2,8,10)


### PR DESCRIPTION
This adds a `grid_to_field_map` arguement to the Field API in ESMPY. This is needed so that the ungridded dimensions can be mapped to the field index that will be usable with dynamic masking which will be a separate PR.