### PR TITLE
Fix compiling on Cray with CCE 19.0.0

### DIFF
--- a/src/Infrastructure/Mesh/tests/ESMCI_MeshCapRegridUTest.C
+++ b/src/Infrastructure/Mesh/tests/ESMCI_MeshCapRegridUTest.C
@@ -35,6 +35,7 @@
 #include <algorithm> //find_if
 #include <fstream>
 #include <ctime>
+#include <array>
 
 struct FindAnyPair {
     FindAnyPair (std::string a, std::string b, std::string c, std::string d, 


### PR DESCRIPTION
Compiling on Cray with the 19.0.0 compilers raises this error:

```
ESMCI_MeshCapRegridUTest.C:94:26: error: implicit instantiation of undefined template 'std::array<char, 64>'
   94 |     std::array<char, 64> buffer;
      |                          ^
```

This is resolved by adding "#include <array>".