### PR TITLE
Support the traditional CMake build procedure with ESMX (broken for some cases)

### DIFF
--- a/src/addon/ESMX/Driver/CMakeLists.txt
+++ b/src/addon/ESMX/Driver/CMakeLists.txt
@@ -65,6 +65,11 @@ else()
   set(ESMX_EXE_NAME ${ESMX_EXE_NAME} PARENT_SCOPE)
 endif()
 
+# define ESMX_SDIR
+if(NOT DEFINED ESMX_SDIR)
+  set(ESMX_SDIR ${CMAKE_SOURCE_DIR})
+endif()
+
 # test options
 if(ESMX_TEST)
   enable_testing()
@@ -133,7 +138,7 @@ endif()
 
 # generate component config file(s)
 execute_process(COMMAND ${Python_EXECUTABLE}
-  ${CMAKE_CURRENT_LIST_DIR}/esmx_comp_config.py --ifile ${ESMX_BUILD_FILE} --odir ${CMAKE_CURRENT_BINARY_DIR} --sdir ${CMAKE_SOURCE_DIR} ${ESMX_DISABLE_COMPS}
+  ${CMAKE_CURRENT_LIST_DIR}/esmx_comp_config.py --ifile ${ESMX_BUILD_FILE} --odir ${CMAKE_CURRENT_BINARY_DIR} --sdir ${ESMX_SDIR} ${ESMX_DISABLE_COMPS}
   RESULT_VARIABLE ret)
 esmx_check_ret(${ret} "esmx_comp_config.py failed processing ${ESMX_BUILD_FILE}")
 

--- a/src/addon/ESMX/Driver/CMakeLists.txt
+++ b/src/addon/ESMX/Driver/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 
 # generate component config file(s)
 execute_process(COMMAND ${Python_EXECUTABLE}
-  ${CMAKE_CURRENT_LIST_DIR}/esmx_comp_config.py --ifile ${ESMX_BUILD_FILE} --odir ${CMAKE_CURRENT_BINARY_DIR} ${ESMX_DISABLE_COMPS}
+  ${CMAKE_CURRENT_LIST_DIR}/esmx_comp_config.py --ifile ${ESMX_BUILD_FILE} --odir ${CMAKE_CURRENT_BINARY_DIR} --sdir ${CMAKE_SOURCE_DIR} ${ESMX_DISABLE_COMPS}
   RESULT_VARIABLE ret)
 esmx_check_ret(${ret} "esmx_comp_config.py failed processing ${ESMX_BUILD_FILE}")
 

--- a/src/addon/ESMX/Driver/CMakeLists.txt
+++ b/src/addon/ESMX/Driver/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 if(NOT DEFINED ESMX_SDIR)
   set(ESMX_SDIR ${CMAKE_SOURCE_DIR})
 endif()
+set(ENV{ESMX_SDIR} "${ESMX_SDIR}")
 
 # test options
 if(ESMX_TEST)

--- a/src/addon/ESMX/Driver/esmx_comp_config.py
+++ b/src/addon/ESMX/Driver/esmx_comp_config.py
@@ -3,7 +3,7 @@ import sys
 import argparse
 from esmx_tools import *
 
-def create_compList(cmpCfg: ESMXCmpCfg, odir):
+def create_compList(cmpCfg: ESMXCmpCfg, odir, sdir):
     # open file
     with open(os.path.join(odir, 'compList.txt'), 'w') as f:
         # loop through components and create use statements
@@ -43,7 +43,7 @@ def create_compList(cmpCfg: ESMXCmpCfg, odir):
                         for i in range(len(dirs)):
                             dirs[i] = dirs[i].strip()
                             if not dirs[i].startswith('$'):
-                                dirs[i] = os.path.abspath(dirs[i])
+                                dirs[i] = os.path.abspath(sdir + "/" + dirs[i])
                         val = ';'.join(dirs)
                 f.write('set({}-{} {})\n'.format(cmp, opt.upper(), val))
                 if opt.option == "link_into_app":
@@ -81,12 +81,14 @@ def main(argv):
 
     # default value
     odir = '.'
+    sdir = '.'
     disable_comps = []
 
     # read input arguments
     parser = argparse.ArgumentParser()
     parser.add_argument('--ifile' , help='Input driver yaml file', required=True)
     parser.add_argument('--odir'  , help='Output directory for generated code')
+    parser.add_argument('--sdir'  , help='Component source root directory')
     parser.add_argument('--disable_comps' , help='List of components to disable')
     args = parser.parse_args()
 
@@ -94,6 +96,8 @@ def main(argv):
         ifile = args.ifile
     if args.odir:
         odir = args.odir
+    if args.sdir:
+        sdir = args.sdir
     if args.disable_comps:
         disable_comps = list(args.disable_comps.lower().split(","))
 
@@ -115,7 +119,7 @@ def main(argv):
         comps.remove_ci(dis)
 
     # create compList.txt for CMake, and remove unlinked components from list
-    create_compList(comps, odir)
+    create_compList(comps, odir, sdir)
 
     # create compUse.inc
     create_compUse(comps, odir)

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -42,7 +42,7 @@ The `ESMX_EXE_NAME` executable for a project that leverages ESMX can be build di
 
 Assuming the ESMX build configuration file `esmxBuild.yaml` (discussed later in the text) is located in the current working directory.
 ```
-cmake [-DCMAKE_INSTALL_PREFIX=<your-install-location>] -S $ESMF_ESMXDIR -B build
+cmake [-DCMAKE_INSTALL_PREFIX=<your-install-location>] -S $ESMF_ESMXDIR -B build -DESMX_SDIR=`pwd`
 ```
 Here the shell variable `ESMF_ESMXDIR` is assumed to be set according to your ESMF installation. The correct value can be looked up in the file `esmf.mk` associated with the ESMF installation.
 

--- a/src/addon/esmpy/src/esmpy/api/field.py
+++ b/src/addon/esmpy/src/esmpy/api/field.py
@@ -369,9 +369,6 @@ class Field(object):
         Read data into an existing :class:`~esmpy.api.field.Field` from a
         CF-compliant NetCDF file.
 
-        :note: This interface is not supported when ESMF is built with
-            ``ESMF_COMM=mpiuni``.
-
         :note: This interface does not currently support reading ungridded 
                dimensions.
 

--- a/src/apps/ESMX_Builder/ESMX_Builder.sh
+++ b/src/apps/ESMX_Builder/ESMX_Builder.sh
@@ -279,7 +279,7 @@ if [ "${VERBOSE}" = true ] ; then
   echo --- CMake Configuring ---
   set -x
 fi
-cmake -S${ESMF_ESMXDIR} -B${BUILD_DIR} ${CMAKE_SETTINGS[@]}
+cmake -S${ESMF_ESMXDIR} -B${BUILD_DIR} -DESMX_SDIR=`pwd` ${CMAKE_SETTINGS[@]}
 RC=$?
 { set +x; } 2>/dev/null
 if [ $RC -ne 0 ]; then


### PR DESCRIPTION
There is an edge case for which the traditional CMake build procedure was broken under ESMX. For the traditional CMake procedure, the configuration step is executed from within the `build` directory as `cmake ..`, or pointing to wherever the `CMakeLists.txt` file is located. The traditional approach is expected to work with ESMX in addition to the modern CMake approach, using the `-S` and `-B` options, and also the `ESMX_Builder` approach.

The problem with the traditional CMake approach comes in when ESMX is searching for component source directories, where the default source directory is assumed to be a subdirectory under the current working directory. However, for the traditional CMake procedure that will be inside of `build`, where of course component sources are NOT located. The fix implemented in this PR is to use the `CMAKE_SOURCE_DIR`, which is the expected default. This works for both traditional and modern CMake procedures. To be compatible with `ESMX_Builder`, pass the current working directory (from where ESMX_Builder is expected to be called) into CMake via variable.

The solution was tested with the NUOPC apps protos, and also under NEPTUNE and ESPC, where the edge case was found. The PR resolves the issue.