### PR TITLE
Fix a problem that trips up new version of CCE compiler

### DIFF
--- a/src/Infrastructure/Trace/src/ESMCI_TraceClock.C
+++ b/src/Infrastructure/Trace/src/ESMCI_TraceClock.C
@@ -186,8 +186,8 @@ namespace ESMCI {
 
     int myPet = vm->getLocalPet();
     int petCount = vm->getPetCount();
-    int64_t ret;
-    
+    int64_t ret = 0;  // initialize to ensure valid return for all conditions
+
     for (int peer = 1; peer < petCount; peer++) {
       vm->barrier();
       if (myPet == 0 || myPet == peer) {


### PR DESCRIPTION
This PR fixes an issue in the ESMF Trace implementation which under single PET execution would lead to undefined behavior. However, on Cray's CCE version 19, in optimized mode incorrect code is generated, leading to hanging unit tests. 

This PR fixes https://github.com/esmf-org/esmf-support/issues/543.