### PR TITLE
Fix a problem with false positive ESMF_OS=Unicos detection

### DIFF
--- a/scripts/esmf_os
+++ b/scripts/esmf_os
@@ -7,7 +7,7 @@ fi
 if [ $esmf_os = Linux ]; then
 # determine if this is Linux on Cray, i.e. Unicos
 which ftn > esmf_os.tmp 2>&1
-ftn_test=`grep -e cray -e bin/ftn esmf_os.tmp`
+ftn_test=`grep -v "no ftn in" esmf_os.tmp | grep -e cray -e bin/ftn`
 rm -f esmf_os.tmp
 if [ -n "$ftn_test" ]; then
 esmf_os=Unicos


### PR DESCRIPTION
This PR addresses a very basic bug in the `./scripts/esmf_os` script, where `ESMF_OS=Unicos` is returned in case `ftn` is **NOT found**, but there is `cray` somewhere in the path.

Working toward #434, where @climbfuji noted this bug in comment https://github.com/esmf-org/esmf/issues/434#issuecomment-2972151040. The larger issue of false positive `ESMF_OS=Unicos` detection when `ftn` IS in the path is still outstanding and not addressed in this PR.