### PR TITLE
ESMPy: Fix Grid size property following slicing

### DIFF
--- a/src/addon/esmpy/src/esmpy/api/grid.py
+++ b/src/addon/esmpy/src/esmpy/api/grid.py
@@ -428,9 +428,6 @@ class Grid(object):
         # all_upper_bounds[de][staggerLoc]
         self._all_upper_bounds = [[None for _ in range(2**self.rank)]
                                   for _ in range(self.local_de_count)]
-        # all_sizes[de][staggerloc]
-        self._all_sizes = [[None for _ in range(2**self.rank)]
-                           for _ in range(self.local_de_count)]
         # all_coords[de][staggerLoc][coord_dim]
         self._all_coords = [[[None for _ in range(self.rank)]
                              for _ in range(2**self.rank)]
@@ -591,7 +588,11 @@ class Grid(object):
             numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
         """
-        return self._all_sizes
+        return [[(None if self.all_upper_bounds[localde][stagger] is None
+                  or self.all_lower_bounds[localde][stagger] is None
+                  else self.all_upper_bounds[localde][stagger] - self.all_lower_bounds[localde][stagger])
+                  for stagger in range(2 ** self.rank)]
+                  for localde in range(self.local_de_count)]
 
     @property
     def all_upper_bounds(self):
@@ -828,7 +829,7 @@ class Grid(object):
 
         if self.local_de_count > 1:
             raise SingleLocalDEMethod
-        return self._all_sizes[0]
+        return self.all_sizes[0]
 
     @property
     def staggerloc(self):
@@ -1136,10 +1137,6 @@ class Grid(object):
 
             self._all_lower_bounds[localde][stagger] = np.copy(lb)
             self._all_upper_bounds[localde][stagger] = np.copy(ub)
-
-            # find the local size of this stagger
-            self._all_sizes[localde][stagger] = np.array(self.all_upper_bounds[localde][stagger] -
-                                                         self.all_lower_bounds[localde][stagger])
         else:
             lb, ub = ESMP_GridGetCoordBounds(self, staggerloc=stagger, localde=localde)
             assert(self.all_lower_bounds[localde][stagger].all() == lb.all())

--- a/src/addon/esmpy/src/esmpy/test/test_api/test_grid.py
+++ b/src/addon/esmpy/src/esmpy/test/test_api/test_grid.py
@@ -109,6 +109,7 @@ class TestGrid(TestBase):
         """
         assert grid.coords[staggerloc][0].shape == expected_shape
         assert grid.upper_bounds[staggerloc].tolist() == list(expected_shape)
+        assert grid.size[staggerloc].tolist() == list(expected_shape)
 
     def make_grid_2d(self):
         typekind = TypeKind.R8

--- a/src/addon/esmpy/src/esmpy/test/test_api/test_grid.py
+++ b/src/addon/esmpy/src/esmpy/test/test_api/test_grid.py
@@ -98,6 +98,18 @@ class TestGrid(TestBase):
                     assert (
                         grid.area[i].shape == tuple(np.array(grid.upper_bounds[i]) - np.array(grid.lower_bounds[i])))
 
+    def assert_expected_grid_shape(self, grid, staggerloc, expected_shape):
+        """
+        Assert that various properties of the given :class:`~esmpy.api.grid.Grid` at the
+        given stagger location match the given expected shape.
+
+        :param Grid grid: The Grid to check
+        :param StaggerLoc staggerloc: The stagger location to check
+        :param tuple expected_shape: The expected shape of the Grid
+        """
+        assert grid.coords[staggerloc][0].shape == expected_shape
+        assert grid.upper_bounds[staggerloc].tolist() == list(expected_shape)
+
     def make_grid_2d(self):
         typekind = TypeKind.R8
         grid = Grid(np.array([100, 100]), coord_sys=CoordSys.CART,
@@ -308,18 +320,13 @@ class TestGrid(TestBase):
         grid2 = grid[1:21, 3:17]
         grid3 = grid2[4:6, 5:6]
 
-        assert grid.coords[StaggerLoc.CENTER][0].shape == (100, 100)
-        assert grid.upper_bounds[StaggerLoc.CENTER].tolist() == [100, 100]
-
+        self.assert_expected_grid_shape(grid, StaggerLoc.CENTER, (100, 100))
         del grid
 
-        assert grid2.coords[StaggerLoc.CENTER][0].shape == (20, 14)
-        assert grid2.upper_bounds[StaggerLoc.CENTER].tolist() == [20, 14]
-
+        self.assert_expected_grid_shape(grid2, StaggerLoc.CENTER, (20, 14))
         del grid2
 
-        assert grid3.coords[StaggerLoc.CENTER][0].shape == (2, 1)
-        assert grid3.upper_bounds[StaggerLoc.CENTER].tolist() == [2, 1]
+        self.assert_expected_grid_shape(grid3, StaggerLoc.CENTER, (2, 1))
 
     @pytest.mark.skipif(pet_count()!=1, reason="test must be run in serial")
     def test_grid_slice_2d_corners(self):
@@ -338,19 +345,13 @@ class TestGrid(TestBase):
         grid2 = grid[1:21, 3:17]
         grid3 = grid2[4:6, 5:6]
 
-        assert grid.coords[StaggerLoc.CORNER][0].shape == (101, 101)
-        assert grid.upper_bounds[StaggerLoc.CORNER].tolist() == [101, 101]
-
+        self.assert_expected_grid_shape(grid, StaggerLoc.CORNER, (101, 101))
         del grid
 
-        assert grid2.coords[StaggerLoc.CORNER][0].shape == (21, 15)
-        assert grid2.upper_bounds[StaggerLoc.CORNER].tolist() == [21, 15]
-
+        self.assert_expected_grid_shape(grid2, StaggerLoc.CORNER, (21, 15))
         del grid2
 
-        assert grid3.coords[StaggerLoc.CORNER][0].shape == (3, 2)
-        assert grid3.upper_bounds[StaggerLoc.CORNER].tolist() == [3, 2]
-
+        self.assert_expected_grid_shape(grid3, StaggerLoc.CORNER, (3, 2))
 
     @pytest.mark.skipif(pet_count()!=1, reason="test must be run in serial")
     def test_grid_slice_3d(self):
@@ -359,18 +360,13 @@ class TestGrid(TestBase):
         grid2 = grid[1:21, 3:17, 7:47]
         grid3 = grid[4:6, 5:6, 0:2]
 
-        assert grid.coords[StaggerLoc.CENTER][0].shape == (100, 100, 100)
-        assert grid.upper_bounds[StaggerLoc.CENTER].tolist() == [100, 100, 100]
-
+        self.assert_expected_grid_shape(grid, StaggerLoc.CENTER, (100, 100, 100))
         del grid
 
-        assert grid2.coords[StaggerLoc.CENTER][0].shape == (20, 14, 40)
-        assert grid2.upper_bounds[StaggerLoc.CENTER].tolist() == [20, 14, 40]
-
+        self.assert_expected_grid_shape(grid2, StaggerLoc.CENTER, (20, 14, 40))
         del grid2
 
-        assert grid3.coords[StaggerLoc.CENTER][0].shape == (2, 1, 2)
-        assert grid3.upper_bounds[StaggerLoc.CENTER].tolist() == [2, 1, 2]
+        self.assert_expected_grid_shape(grid3, StaggerLoc.CENTER, (2, 1, 2))
 
     @pytest.mark.skipif(pet_count()!=1, reason="test must be run in serial")
     def test_grid_slice_3d_corners(self):
@@ -394,18 +390,13 @@ class TestGrid(TestBase):
         grid2 = grid[1:21, 3:17, 7:47]
         grid3 = grid[4:6, 5:6, 0:2]
 
-        assert grid.coords[cvf][0].shape == (101, 101, 101)
-        assert grid.upper_bounds[cvf].tolist() == [101, 101, 101]
-
+        self.assert_expected_grid_shape(grid, cvf, (101, 101, 101))
         del grid
 
-        assert grid2.coords[cvf][0].shape == (21, 15, 41)
-        assert grid2.upper_bounds[cvf].tolist() == [21, 15, 41]
-
+        self.assert_expected_grid_shape(grid2, cvf, (21, 15, 41))
         del grid2
 
-        assert grid3.coords[cvf][0].shape == (3, 2, 3)
-        assert grid3.upper_bounds[cvf].tolist() == [3, 2, 3]
+        self.assert_expected_grid_shape(grid3, cvf, (3, 2, 3))
 
     @pytest.mark.skipif(pet_count()!=1, reason="test must be run in serial")
     def test_grid_slice_periodic(self):
@@ -414,24 +405,16 @@ class TestGrid(TestBase):
         grid2 = grid[1:21, 3:17]
         grid3 = grid2[4:6, 5:6]
 
-        assert grid.coords[StaggerLoc.CENTER][0].shape == (x, y)
-        assert grid.upper_bounds[StaggerLoc.CENTER].tolist() == [x, y]
-        assert grid.coords[StaggerLoc.CORNER][0].shape == (x, y + 1)
-        assert grid.upper_bounds[StaggerLoc.CORNER].tolist() == [x, y + 1]
-
+        self.assert_expected_grid_shape(grid, StaggerLoc.CENTER, (x, y))
+        self.assert_expected_grid_shape(grid, StaggerLoc.CORNER, (x, y + 1))
         del grid
 
-        assert grid2.coords[StaggerLoc.CENTER][0].shape == (20, 14)
-        assert grid2.upper_bounds[StaggerLoc.CENTER].tolist() == [20, 14]
-        assert grid2.coords[StaggerLoc.CORNER][0].shape == (21, 15)
-        assert grid2.upper_bounds[StaggerLoc.CORNER].tolist() == [21, 15]
-
+        self.assert_expected_grid_shape(grid2, StaggerLoc.CENTER, (20, 14))
+        self.assert_expected_grid_shape(grid2, StaggerLoc.CORNER, (21, 15))
         del grid2
 
-        assert grid3.coords[StaggerLoc.CENTER][0].shape == (2, 1)
-        assert grid3.upper_bounds[StaggerLoc.CENTER].tolist() == [2, 1]
-        assert grid3.coords[StaggerLoc.CORNER][0].shape == (3, 2)
-        assert grid3.upper_bounds[StaggerLoc.CORNER].tolist() == [3, 2]
+        self.assert_expected_grid_shape(grid3, StaggerLoc.CENTER, (2, 1))
+        self.assert_expected_grid_shape(grid3, StaggerLoc.CORNER, (3, 2))
 
     @pytest.mark.skipif(_ESMF_NETCDF==False, reason="NetCDF required in ESMF build")
     @pytest.mark.skipif(pet_count()!=1, reason="test must be run in serial")
@@ -452,13 +435,10 @@ class TestGrid(TestBase):
 
         grid2 = grid[0:5, 0:5]
 
-        assert grid.coords[0][0].shape == (128, 64)
-        assert grid.upper_bounds[0].tolist() == [128, 64]
-
+        self.assert_expected_grid_shape(grid, StaggerLoc.CENTER, (128, 64))
         del grid
 
-        assert grid2.coords[0][0].shape == (5, 5)
-        assert grid2.upper_bounds[0].tolist() == [5, 5]
+        self.assert_expected_grid_shape(grid2, StaggerLoc.CENTER, (5, 5))
 
     def test_grid_copy(self):
         grid = self.make_grid_2d()


### PR DESCRIPTION
This PR fixes the size property of an ESMPy Grid created by slicing another Grid. This also adds tests of this case (which failed before these changes but pass now).

Note that I have implemented this by calculating the size property on the fly rather than storing it. This seems less error-prone, because now size doesn't need to be kept in sync with the bounds.

Resolves #441 