### PR TITLE
Fix ORIG symbol in esmfversiongit

### DIFF
--- a/scripts/esmfversiongit
+++ b/scripts/esmfversiongit
@@ -9,6 +9,6 @@ if [ -z "$TAG" ] ; then TAG="$BRCH+g$SHA1" ; fi
 ORIG=`git config --get remote.origin.url 2>&1`
 case "$ORIG" in
   *"esmf-org/esmf"*) echo $TAG ;;
-  *) echo $TAG"#"$ORIG ;;
+  *) echo $TAG":"$ORIG ;;
 esac
 fi


### PR DESCRIPTION
Using `#` was a bad idea because it cuts off the remainder of a line in the esmf.mk makefile
Can I swap this to `:` or do you think there's a better symbol?

![esmf_mk_example](https://github.com/user-attachments/assets/68523d9c-5432-4d9b-9a02-ec4b43426035)
