### PR TITLE
Fixes in ESMPy to work with 0 DEs per PET and related changes

### DIFF
--- a/src/addon/esmpy/src/esmpy/api/field.py
+++ b/src/addon/esmpy/src/esmpy/api/field.py
@@ -183,7 +183,7 @@ class Field(object):
         if pet_count() > 1:
             raise SerialMethod
 
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
 
         slc = get_formatted_slice(slc, self.rank)
@@ -286,10 +286,10 @@ class Field(object):
         :rtype: ndarray
         :return: The data of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
-                 where there are multiple DEs per PET. In that case,
+                 where there is something other than 1 DE per PET; in that case,
                  use :meth:`~esmpy.api.field.all_data`.)
         """
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_data[0]
 
@@ -328,10 +328,10 @@ class Field(object):
         :rtype: ndarray
         :return: The lower bounds of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
-                 where there are multiple DEs per PET. In that case,
+                 where there is something other than 1 DE per PET; in that case,
                  use :meth:`~esmpy.api.field.all_lower_bounds`.)
         """
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_lower_bounds[0]
 
@@ -401,10 +401,10 @@ class Field(object):
         :rtype: ndarray
         :return: The upper bounds of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
-                 where there are multiple DEs per PET. In that case,
+                 where there is something other than 1 DE per PET; in that case,
                  use :meth:`~esmpy.api.field.all_upper_bounds`.)
         """
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_upper_bounds[0]
 

--- a/src/addon/esmpy/src/esmpy/api/grid.py
+++ b/src/addon/esmpy/src/esmpy/api/grid.py
@@ -473,7 +473,7 @@ class Grid(object):
         if pet_count() > 1:
             raise SerialMethod
 
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
 
         # format and copy
@@ -621,11 +621,11 @@ class Grid(object):
             numpy arrays of floats of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there are multiple DEs per PET. In that case, use
+            where there is something other than 1 DE per PET; in that case, use
             :meth:`~esmpy.api.grid.all_areas`.)
         """
 
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_areas[0]
 
@@ -649,11 +649,11 @@ class Grid(object):
             :class:`~esmpy.api.grid.Grid`.
         :return: The coordinates of the :class:`~esmpy.api.grid.Grid`.
             (It is an error to use this property in the uncommon case
-            where there are multiple DEs per PET. In that case, use
+            where there is something other than 1 DE per PET; in that case, use
             :meth:`~esmpy.api.grid.all_coords`.)
         """
 
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_coords[0]
 
@@ -705,11 +705,11 @@ class Grid(object):
             represented as numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there are multiple DEs per PET. In that case, use
+            where there is something other than 1 DE per PET; in that case, use
             :meth:`~esmpy.api.grid.all_lower_bounds`.)
         """
 
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_lower_bounds[0]
 
@@ -722,11 +722,11 @@ class Grid(object):
             numpy arrays of ints of size given by `
             `upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there are multiple DEs per PET. In that case, use
+            where there is something other than 1 DE per PET; in that case, use
             :meth:`~esmpy.api.grid.all_masks`.)
         """
 
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_masks[0]
 
@@ -829,11 +829,11 @@ class Grid(object):
             numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there are multiple DEs per PET. In that case, use
+            where there is something other than 1 DE per PET; in that case, use
             :meth:`~esmpy.api.grid.all_sizes`.)
         """
 
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self.all_sizes[0]
 
@@ -875,10 +875,10 @@ class Grid(object):
             represented as numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there are multiple DEs per PET. In that case, use
+            where there is something other than 1 DE per PET; in that case, use
             :meth:`~esmpy.api.grid.all_upper_bounds`.)
         """
-        if self.local_de_count > 1:
+        if self.local_de_count != 1:
             raise SingleLocalDEMethod
         return self._all_upper_bounds[0]
 

--- a/src/addon/esmpy/src/esmpy/test/test_api/test_field.py
+++ b/src/addon/esmpy/src/esmpy/test/test_api/test_field.py
@@ -58,7 +58,10 @@ class TestField(TestBase):
 
         mask = grid.add_item(GridItem.MASK)
         mask[:] = 1
-        mask[0, 1] = 0
+        if mask.shape[0] > 0 and mask.shape[1] > 1:
+            # (This conditional guards against an out-of-bounds error for small grids
+            # relative to the PET count)
+            mask[0, 1] = 0
 
         if ndbounds:
             field = Field(grid, ndbounds=[5, 2])


### PR DESCRIPTION
Three separate but related changes:

(1) Fix ESMPy Grid class to work with 0 DEs per PET

(2) Allow tests in test_field.py to pass with larger PET counts (which can lead to some PETs having 0-sized data)

(3) Raise SingleLocalDEMethod exception for 0 DEs as well as > 1 DE, to give a hopefully more informative error message in this case 