### PR TITLE
Add unit test of ESMC_ArrayGetLocalDECount

### DIFF
--- a/src/Infrastructure/Array/tests/ESMC_ArrayUTest.c
+++ b/src/Infrastructure/Array/tests/ESMC_ArrayUTest.c
@@ -95,6 +95,15 @@ int main(void){
   array = ESMC_ArrayCreate(arrayspec, distgrid, "array1", &rc);
   ESMC_Test((rc==ESMF_SUCCESS), name, failMsg, &result, __FILE__, __LINE__, 0);
   //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  //NEX_UTest
+  strcpy(name, "Get localDECount from ESMC_Array object");
+  strcpy(failMsg, "Did not return correct localDECount");
+  int localDECount;
+  rc = ESMC_ArrayGetLocalDECount(array, &localDECount);
+  ESMC_Test((rc==ESMF_SUCCESS && localDECount==1), name, failMsg, &result, __FILE__, __LINE__, 0);
+  //----------------------------------------------------------------------------
   
   //----------------------------------------------------------------------------
   //NEX_UTest


### PR DESCRIPTION
This was already covered indirectly via other unit tests, but we need a direct test of this to satisfy the API test coverage script.