### PR TITLE
Add ESMPy testing on 8 PEs

### DIFF
--- a/src/addon/esmpy/src/esmpy/test/test_all.bash
+++ b/src/addon/esmpy/src/esmpy/test/test_all.bash
@@ -21,7 +21,7 @@ if [ "$MPIEXEC_END_OF_PATH" = "mpiuni/mpirun" ]
 then
     PE_COUNTS=(1)
 else
-    PE_COUNTS=(1 4 6)
+    PE_COUNTS=(1 4 6 8)
 fi
 
 for NP in ${PE_COUNTS[@]}

--- a/src/addon/esmpy/src/esmpy/test/test_api/test_regrid.py
+++ b/src/addon/esmpy/src/esmpy/test/test_api/test_regrid.py
@@ -251,6 +251,10 @@ class TestRegrid(TestBase):
 
         return dstfield, srcfracfield, dstfracfield
 
+    # The following test fails with 12 PETs with the message, "some types of regridding
+    # (e.g. bilinear) are not supported on Grids that contain a DE of width 1"; so skip it
+    # for > 10 PETs.
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for regridding with larger PET counts")
     def test_field_regrid(self):
         # create grids
         max_index = np.array([20, 20])
@@ -390,6 +394,10 @@ class TestRegrid(TestBase):
 
                 rh.destroy()
 
+    # The following test fails with 12 PETs with the message, "some types of regridding
+    # (e.g. bilinear) are not supported on Grids that contain a DE of width 1"; so skip it
+    # for > 10 PETs.
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for regridding with larger PET counts")
     @pytest.mark.skipif(_ESMF_PIO==False, reason="PIO required in ESMF build")
     @pytest.mark.skipif(_ESMF_NETCDF==False, reason="NetCDF required in ESMF build")
     def test_field_regrid_file1(self):
@@ -445,6 +453,10 @@ class TestRegrid(TestBase):
             if os.path.isfile(path):
                 os.remove(path)
 
+    # The following test fails with 12 PETs with the message, "some types of regridding
+    # (e.g. bilinear) are not supported on Grids that contain a DE of width 1"; so skip it
+    # for > 10 PETs.
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for regridding with larger PET counts")
     @pytest.mark.skipif(_ESMF_PIO==False, reason="PIO required in ESMF build")
     @pytest.mark.skipif(_ESMF_NETCDF==False, reason="NetCDF required in ESMF build")
     def test_field_regrid_file2(self):
@@ -577,6 +589,10 @@ class TestRegrid(TestBase):
             if os.path.isfile(path):
                 os.remove(path)
 
+    # The following test fails with 12 PETs with the message, "some types of regridding
+    # (e.g. bilinear) are not supported on Grids that contain a DE of width 1"; so skip it
+    # for > 10 PETs.
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for regridding with larger PET counts")
     @pytest.mark.skipif(_ESMF_PIO==False, reason="PIO required in ESMF build")
     @pytest.mark.skipif(_ESMF_NETCDF==False, reason="NetCDF required in ESMF build")
     def test_field_regrid_file3(self):
@@ -672,6 +688,10 @@ class TestRegrid(TestBase):
             if os.path.isfile(path):
                 os.remove(path)
 
+    # The following test fails with 12 PETs with the message, "some types of regridding
+    # (e.g. bilinear) are not supported on Grids that contain a DE of width 1"; so skip it
+    # for > 10 PETs.
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for regridding with larger PET counts")
     def test_field_regrid_file4(self):
         mgr = Manager()
         filename = 'routehandlefile.nc'
@@ -971,6 +991,10 @@ class TestRegrid(TestBase):
         self.assertAlmostEqual(meanrel, 0.0016447124122954575)
         self.assertAlmostEqual(csrvrel, 0.0)
 
+    # The following test fails with 12 PETs with the message, "some types of regridding
+    # (e.g. bilinear) are not supported on Grids that contain a DE of width 1", and also
+    # "Bad processor number"; so skip it for > 10 PETs.
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for regridding with larger PET counts")
     def test_grid_grid_3d_bilinear_cartesian(self):
         # RO: This test creates the same Grid on every processor, it could be improved
 
@@ -1029,6 +1053,10 @@ class TestRegrid(TestBase):
         self.assertAlmostEqual(meanrel, 0.00061587737764545617)
         self.assertAlmostEqual(csrvrel, 0.0)
 
+    # The following test fails with 12 PETs in grid_create_from_coordinates_3d, with
+    # "UnboundLocalError: cannot access local variable 'i0' where it is not associated
+    # with a value"; so skip it for > 10 PETs
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for larger PET counts")
     def test_grid_grid_regrid_csrv_mask_3D(self):
         # RO: This test creates the same Grid on every processor, it could be improved
 
@@ -1069,6 +1097,10 @@ class TestRegrid(TestBase):
         self.assertAlmostEqual(meanrel, 0.0021560174316746865)
         self.assertAlmostEqual(csrvrel, 0.0)
 
+    # The following test fails with 12 PETs in grid_create_from_coordinates, with
+    # "UnboundLocalError: cannot access local variable 'i0' where it is not associated
+    # with a value"; so skip it for > 10 PETs
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for larger PET counts")
     def test_grid_grid_regrid_csrv_mask(self):
         # RO: This test creates the same Grid on every processor, it could be improved
 
@@ -1110,6 +1142,10 @@ class TestRegrid(TestBase):
         self.assertAlmostEqual(meanrel, 0.0024803189848013785)
         self.assertAlmostEqual(csrvrel, 0.0)
 
+    # The following test fails with 12 PETs in grid_create_from_coordinates, with
+    # "UnboundLocalError: cannot access local variable 'i0' where it is not associated
+    # with a value"; so skip it for > 10 PETs
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for larger PET counts")
     def test_grid_grid_regrid_csrv_2nd_mask(self):
         # RO: This test creates the same Grid on every processor, it could be improved
 
@@ -1151,6 +1187,10 @@ class TestRegrid(TestBase):
         self.assertAlmostEqual(meanrel, 0.0020296891000258252)
         self.assertAlmostEqual(csrvrel, 0.0)
 
+    # The following test fails with 12 PETs in grid_create_from_coordinates, with
+    # "UnboundLocalError: cannot access local variable 'i0' where it is not associated
+    # with a value"; so skip it for > 10 PETs
+    @pytest.mark.skipif(pet_count()>10, reason="grids too small for larger PET counts")
     def test_grid_grid_regrid_srcmask_types(self):
         # NOTE: this tests an old issue where the items of a grid were not properly set when
         # the grid coord_typekind differed from the field typekind.


### PR DESCRIPTION
This covers the situation where we have cubed-sphere grids with some PETs having 0 DEs.

I have confirmed that tests pass with 8 PEs on my Mac.

I have also tested with 10 PEs on my Mac and tests also pass with that PE count, but I feel like it probably isn't worth the testing time to add testing with both 8 and 10 PEs. (In fact, even adding this testing with 8 PEs seems like marginal benefit: As far as I'm aware, the only extra coverage it adds is to cover the issue fixed by https://github.com/esmf-org/esmf/pull/447/commits/523a99779d3ce8dd98b0df0614ec7ec26f4b0a6c.)

I ran into problems trying to run testing with 12 PEs on my Mac (note that I need `-oversubscribe` in the mpirun command for running testing with 12 PEs... it's possible that some issues were due to this, though I haven't experienced issues with oversubscribing processors in the past): some tests in test_regrid.py fail with this processor count (I haven't tried digging into why), and then I got a hang.