### PR TITLE
Update ESMPy documentation for allowing multiple DEs per PET

### DIFF
--- a/src/addon/esmpy/doc/api.rst
+++ b/src/addon/esmpy/doc/api.rst
@@ -860,6 +860,8 @@ Dimension Ordering
         In [8]: field.data.shape
         Out[8]: (3, 4, 10)
 
+.. _des:
+
 ----------------------------
 Decomposition Elements (DEs)
 ----------------------------

--- a/src/addon/esmpy/doc/api.rst
+++ b/src/addon/esmpy/doc/api.rst
@@ -860,6 +860,51 @@ Dimension Ordering
         In [8]: field.data.shape
         Out[8]: (3, 4, 10)
 
+----------------------------
+Decomposition Elements (DEs)
+----------------------------
+
+In ESMF, data classes are distributed over DEs, or Decomposition Elements. DEs are virtual
+units, not necessarily having a 1-to-1 correspondence to the Persistent Execution Threads
+(PETs) of a VM or the physical Processing Elements (PEs) in the underlying physical
+machine. In ESMPy data classes, there is typically exactly one DE per PET. The main
+exception to this is cubed-sphere grids that are represented as multi-tile grids; for
+these, there can be multiple DEs on a single PET (with the default decomposition, this
+occurs for < 6 PETs) or zero DEs on a PET (with the default decomposition, this occurs for
+> 6 PETs). (In the case of a non-cubed-sphere grid that is simply too small to decompose
+across the PETs, there is still 1 DE on each PET but some of these DEs will have data with
+size 0.)
+
+For ESMPy classes that support multiple DEs per PET (:class:`~esmpy.api.grid.Grid` and
+:class:`~esmpy.api.field.Field`), there are two versions of data accessor properties for
+any data that is decomposed across DEs. Examples are a :class:`~esmpy.api.field.Field`'s
+:class:`esmpy.api.field.Field.data` vs. :class:`esmpy.api.field.Field.all_data` and a
+:class:`~esmpy.api.grid.Grid`'s :class:`esmpy.api.grid.Grid.area` vs.
+:class:`esmpy.api.grid.Grid.all_areas`. Versions of these properties *without* the
+``all_`` prefix can only be used in the common case where there is exactly one DE per PET;
+these properties return the data on the single DE for the current PET. Versions of these
+properties *with* the ``all_`` prefix return lists indexed by DE. For example, to work
+with a :class:`~esmpy.api.field.Field`'s data in the situation where there may be multiple
+DEs per PET, user code should loop over DEs like:
+
+.. code::
+
+   for de in range(myfield.local_de_count):
+       this_data = myfield.all_data[de]
+       # operate on this_data
+
+Some methods, such as a :class:`~esmpy.api.grid.Grid`'s
+:class:`esmpy.api.grid.Grid.get_item`, default to retrieving values for the first DE
+(``localde=0``). Thus, for the common case with 1 DE per PET, these can be called without
+a ``localde`` argument. But in cases where there may be multiple DEs per PET, these should
+be called in a loop like in the above example. Furthermore, these methods with an optional
+``localde`` argument should not be called in cases where there are zero DEs on a given
+PET; this can be handled via the same looping structure, or if it is known that the only
+possible cases are zero or one DE per PET, then via a conditional like ``if
+grid.local_de_count == 1``.
+
+Finally, note that slicing of a :class:`~esmpy.api.field.Field` or
+:class:`~esmpy.api.grid.Grid` is currently not supported with multiple DEs per PET.
 
 ------------------
 Parallel Execution

--- a/src/addon/esmpy/doc/api.rst
+++ b/src/addon/esmpy/doc/api.rst
@@ -878,9 +878,9 @@ size 0.)
 For ESMPy classes that support multiple DEs per PET (:class:`~esmpy.api.grid.Grid` and
 :class:`~esmpy.api.field.Field`), there are two versions of data accessor properties for
 any data that is decomposed across DEs. Examples are a :class:`~esmpy.api.field.Field`'s
-:class:`esmpy.api.field.Field.data` vs. :class:`esmpy.api.field.Field.all_data` and a
-:class:`~esmpy.api.grid.Grid`'s :class:`esmpy.api.grid.Grid.area` vs.
-:class:`esmpy.api.grid.Grid.all_areas`. Versions of these properties *without* the
+:attr:`~esmpy.api.field.Field.data` vs. :attr:`~esmpy.api.field.Field.all_data` and a
+:class:`~esmpy.api.grid.Grid`'s :attr:`~esmpy.api.grid.Grid.area` vs.
+:attr:`~esmpy.api.grid.Grid.all_areas`. Versions of these properties *without* the
 ``all_`` prefix can only be used in the common case where there is exactly one DE per PET;
 these properties return the data on the single DE for the current PET. Versions of these
 properties *with* the ``all_`` prefix return lists indexed by DE. For example, to work
@@ -894,7 +894,7 @@ DEs per PET, user code should loop over DEs like:
        # operate on this_data
 
 Some methods, such as a :class:`~esmpy.api.grid.Grid`'s
-:class:`esmpy.api.grid.Grid.get_item`, default to retrieving values for the first DE
+:meth:`~esmpy.api.grid.Grid.get_item`, default to retrieving values for the first DE
 (``localde=0``). Thus, for the common case with 1 DE per PET, these can be called without
 a ``localde`` argument. But in cases where there may be multiple DEs per PET, these should
 be called in a loop like in the above example. Furthermore, these methods with an optional

--- a/src/addon/esmpy/doc/field.rst
+++ b/src/addon/esmpy/doc/field.rst
@@ -4,6 +4,7 @@ Field
 
 .. autoclass:: esmpy.api.field.Field
     :members: copy, destroy, get_area, read,
-        data, grid, lower_bounds, name, ndbounds, rank, staggerloc, type,
-        upper_bounds, xd
+        all_data, all_lower_bounds, all_upper_bounds,
+        data, finalized, grid, local_de_count, lower_bounds,
+        name, ndbounds, rank, staggerloc, type, upper_bounds, xd
     

--- a/src/addon/esmpy/doc/grid.rst
+++ b/src/addon/esmpy/doc/grid.rst
@@ -4,6 +4,7 @@ Grid
 
 .. autoclass:: esmpy.api.grid.Grid
     :members: add_coords, add_item, copy, destroy, get_coords, get_item,
-        area, areatype, coords, coord_sys, has_corners,
-        lower_bounds, mask, max_index, num_peri_dims, periodic_dim, pole_dim,
-        rank, size, staggerloc, type, upper_bounds
+        all_areas, all_coords, all_lower_bounds, all_masks, all_sizes, all_upper_bounds,
+        area, areatype, coords, coord_sys, finalized, has_corners, local_de_count,
+        lower_bounds, mask, max_index, name, ndims, num_peri_dims, periodic_dim, pole_dim,
+        pole_kind, rank, size, staggerloc, type, upper_bounds

--- a/src/addon/esmpy/doc/install.rst
+++ b/src/addon/esmpy/doc/install.rst
@@ -149,10 +149,7 @@ to ESMF offline and integrated regridding capabilities.
   :class:`~esmpy.api.field.Field` values on a source :class:`~esmpy.api.mesh.Mesh`
   created from file when using conservative regridding.
 - Multi-tile :class:`~esmpy.api.grid.Grid` support is limited to cubed-sphere 
-  grids created on 6 processors. A cubed-sphere grid can be created on any
-  number of processors, but only when it is created on 6 processors will the
-  coordinates be retrievable for the entire object. A 
-  :class:`~esmpy.api.field.Field` created from a cubed-sphere 
+  grids. A :class:`~esmpy.api.field.Field` created from a cubed-sphere
   :class:`~esmpy.api.grid.Grid` cannot be written to file in parallel.
 - There is no ``FieldBundle`` class, only single :class:`Fields <esmpy.api.field.Field>`.
 

--- a/src/addon/esmpy/doc/install.rst
+++ b/src/addon/esmpy/doc/install.rst
@@ -156,4 +156,4 @@ to ESMF offline and integrated regridding capabilities.
 Testing related:
 
 - Nightly regression testing is limited to a small subset of the ESMF test platforms,
-  including Darwin and Linux running gfortran with openMPI.
+  including Darwin and Linux with the gfortran and intel compilers.

--- a/src/addon/esmpy/src/esmpy/api/field.py
+++ b/src/addon/esmpy/src/esmpy/api/field.py
@@ -250,8 +250,8 @@ class Field(object):
     @property
     def all_data(self):
         """
-        :rtype: A list of ndarrays with an entry for each local DE.
-                (In the typical case of 1 DE per PET, this is a single-element list
+        :rtype: A list of ndarrays with an entry for each local :ref:`DE <des>`.
+                (In the typical case of 1 :ref:`DE <des>` per PET, this is a single-element list
                 containing a single ndarray. For this case, see also
                 :attr:`~esmpy.api.field.Field.data`.)
         :return: The data of the :class:`~esmpy.api.field.Field`
@@ -261,8 +261,8 @@ class Field(object):
     @property
     def all_lower_bounds(self):
         """
-        :rtype: A list of ndarrays with an entry for each local DE.
-                (In the typical case of 1 DE per PET, this is a single-element list
+        :rtype: A list of ndarrays with an entry for each local :ref:`DE <des>`.
+                (In the typical case of 1 :ref:`DE <des>` per PET, this is a single-element list
                 containing a single ndarray. For this case, see also
                 :attr:`~esmpy.api.field.Field.lower_bounds`.)
         :return: The lower bounds of the :class:`~esmpy.api.field.Field`.
@@ -272,8 +272,8 @@ class Field(object):
     @property
     def all_upper_bounds(self):
         """
-        :rtype: A list of ndarrays with an entry for each local DE.
-                (In the typical case of 1 DE per PET, this is a single-element list
+        :rtype: A list of ndarrays with an entry for each local :ref:`DE <des>`.
+                (In the typical case of 1 :ref:`DE <des>` per PET, this is a single-element list
                 containing a single ndarray. For this case, see also
                 :attr:`~esmpy.api.field.Field.upper_bounds`.)
         :return: The upper bounds of the :class:`~esmpy.api.field.Field`.
@@ -286,8 +286,8 @@ class Field(object):
         :rtype: ndarray
         :return: The data of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
-                 where there is something other than 1 DE per PET; in that case,
-                 use :attr:`~esmpy.api.field.Field.all_data`.)
+                 where there is something other than 1 :ref:`DE <des>` per PET;
+                 in that case, use :attr:`~esmpy.api.field.Field.all_data`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod
@@ -317,7 +317,7 @@ class Field(object):
     def local_de_count(self):
         """
         :rtype: int
-        :return: The number of DEs in the :class:`~esmpy.api.field.Field`
+        :return: The number of :ref:`DEs <des>` in the :class:`~esmpy.api.field.Field`
             on this PET.
         """
         return self._local_de_count
@@ -328,8 +328,8 @@ class Field(object):
         :rtype: ndarray
         :return: The lower bounds of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
-                 where there is something other than 1 DE per PET; in that case,
-                 use :attr:`~esmpy.api.field.Field.all_lower_bounds`.)
+                 where there is something other than 1 :ref:`DE <des>` per PET;
+                 in that case, use :attr:`~esmpy.api.field.Field.all_lower_bounds`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod
@@ -401,8 +401,8 @@ class Field(object):
         :rtype: ndarray
         :return: The upper bounds of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
-                 where there is something other than 1 DE per PET; in that case,
-                 use :attr:`~esmpy.api.field.Field.all_upper_bounds`.)
+                 where there is something other than 1 :ref:`DE <des>` per PET;
+                 in that case, use :attr:`~esmpy.api.field.Field.all_upper_bounds`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod

--- a/src/addon/esmpy/src/esmpy/api/field.py
+++ b/src/addon/esmpy/src/esmpy/api/field.py
@@ -253,7 +253,7 @@ class Field(object):
         :rtype: A list of ndarrays with an entry for each local DE.
                 (In the typical case of 1 DE per PET, this is a single-element list
                 containing a single ndarray. For this case, see also
-                :meth:`~esmpy.api.field.data`.)
+                :attr:`~esmpy.api.field.Field.data`.)
         :return: The data of the :class:`~esmpy.api.field.Field`
         """
         return self._all_data
@@ -264,7 +264,7 @@ class Field(object):
         :rtype: A list of ndarrays with an entry for each local DE.
                 (In the typical case of 1 DE per PET, this is a single-element list
                 containing a single ndarray. For this case, see also
-                :meth:`~esmpy.api.field.lower_bounds`.)
+                :attr:`~esmpy.api.field.Field.lower_bounds`.)
         :return: The lower bounds of the :class:`~esmpy.api.field.Field`.
         """
         return self._all_lower_bounds
@@ -275,7 +275,7 @@ class Field(object):
         :rtype: A list of ndarrays with an entry for each local DE.
                 (In the typical case of 1 DE per PET, this is a single-element list
                 containing a single ndarray. For this case, see also
-                :meth:`~esmpy.api.field.upper_bounds`.)
+                :attr:`~esmpy.api.field.Field.upper_bounds`.)
         :return: The upper bounds of the :class:`~esmpy.api.field.Field`.
         """
         return self._all_upper_bounds
@@ -287,7 +287,7 @@ class Field(object):
         :return: The data of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
                  where there is something other than 1 DE per PET; in that case,
-                 use :meth:`~esmpy.api.field.all_data`.)
+                 use :attr:`~esmpy.api.field.Field.all_data`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod
@@ -329,7 +329,7 @@ class Field(object):
         :return: The lower bounds of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
                  where there is something other than 1 DE per PET; in that case,
-                 use :meth:`~esmpy.api.field.all_lower_bounds`.)
+                 use :attr:`~esmpy.api.field.Field.all_lower_bounds`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod
@@ -402,7 +402,7 @@ class Field(object):
         :return: The upper bounds of the :class:`~esmpy.api.field.Field`.
                  (It is an error to use this property in the uncommon case
                  where there is something other than 1 DE per PET; in that case,
-                 use :meth:`~esmpy.api.field.all_upper_bounds`.)
+                 use :attr:`~esmpy.api.field.Field.all_upper_bounds`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod

--- a/src/addon/esmpy/src/esmpy/api/grid.py
+++ b/src/addon/esmpy/src/esmpy/api/grid.py
@@ -542,6 +542,8 @@ class Grid(object):
         :rtype: 2D list of numpy arrays, where the first index represents the
             local DE and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
+            (In the typical case of 1 DE per PET, see also
+            :attr:`~esmpy.api.grid.Grid.area`.)
         :return: The :class:`~esmpy.api.grid.Grid` cell areas represented as
             numpy arrays of floats of size given by
             ``upper_bounds - lower_bounds``.
@@ -556,6 +558,8 @@ class Grid(object):
             the local DE, the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid` and the third index represents
             the coordinate dimensions of the :class:`~esmpy.api.grid.Grid`.
+            (In the typical case of 1 DE per PET, see also
+            :attr:`~esmpy.api.grid.Grid.coords`.)
         :return: The coordinates of the :class:`~esmpy.api.grid.Grid`.
         """
         return self._all_coords
@@ -566,6 +570,8 @@ class Grid(object):
         :rtype: 2D list of numpy arrays, where the first index represents the
             local DE and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
+            (In the typical case of 1 DE per PET, see also
+            :attr:`~esmpy.api.grid.Grid.lower_bounds`.)
         :return: The lower bounds of the :class:`~esmpy.api.grid.Grid`
             represented as numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
@@ -578,6 +584,8 @@ class Grid(object):
         :rtype: 2D list of numpy arrays, where the first index represents the
             local DE and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
+            (In the typical case of 1 DE per PET, see also
+            :attr:`~esmpy.api.grid.Grid.mask`.)
         :return: The masks of the :class:`~esmpy.api.grid.Grid` represented as
             numpy arrays of ints of size given by `
             `upper_bounds - lower_bounds``.
@@ -590,6 +598,8 @@ class Grid(object):
         :rtype: 2D list of numpy arrays, where the first index represents the
             local DE and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
+            (In the typical case of 1 DE per PET, see also
+            :attr:`~esmpy.api.grid.Grid.size`.)
         :return: The sizes of the :class:`~esmpy.api.grid.Grid` represented as
             numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
@@ -606,6 +616,8 @@ class Grid(object):
         :rtype: 2D list of numpy arrays, where the first index represents the
             local DE and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
+            (In the typical case of 1 DE per PET, see also
+            :attr:`~esmpy.api.grid.Grid.upper_bounds`.)
         :return: The upper bounds of the :class:`~esmpy.api.grid.Grid`
             represented as numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
@@ -622,7 +634,7 @@ class Grid(object):
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
             where there is something other than 1 DE per PET; in that case, use
-            :meth:`~esmpy.api.grid.all_areas`.)
+            :attr:`~esmpy.api.grid.Grid.all_areas`.)
         """
 
         if self.local_de_count != 1:
@@ -650,7 +662,7 @@ class Grid(object):
         :return: The coordinates of the :class:`~esmpy.api.grid.Grid`.
             (It is an error to use this property in the uncommon case
             where there is something other than 1 DE per PET; in that case, use
-            :meth:`~esmpy.api.grid.all_coords`.)
+            :attr:`~esmpy.api.grid.Grid.all_coords`.)
         """
 
         if self.local_de_count != 1:
@@ -706,7 +718,7 @@ class Grid(object):
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
             where there is something other than 1 DE per PET; in that case, use
-            :meth:`~esmpy.api.grid.all_lower_bounds`.)
+            :attr:`~esmpy.api.grid.Grid.all_lower_bounds`.)
         """
 
         if self.local_de_count != 1:
@@ -723,7 +735,7 @@ class Grid(object):
             `upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
             where there is something other than 1 DE per PET; in that case, use
-            :meth:`~esmpy.api.grid.all_masks`.)
+            :attr:`~esmpy.api.grid.Grid.all_masks`.)
         """
 
         if self.local_de_count != 1:
@@ -830,7 +842,7 @@ class Grid(object):
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
             where there is something other than 1 DE per PET; in that case, use
-            :meth:`~esmpy.api.grid.all_sizes`.)
+            :attr:`~esmpy.api.grid.Grid.all_sizes`.)
         """
 
         if self.local_de_count != 1:
@@ -876,7 +888,7 @@ class Grid(object):
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
             where there is something other than 1 DE per PET; in that case, use
-            :meth:`~esmpy.api.grid.all_upper_bounds`.)
+            :attr:`~esmpy.api.grid.Grid.all_upper_bounds`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod

--- a/src/addon/esmpy/src/esmpy/api/grid.py
+++ b/src/addon/esmpy/src/esmpy/api/grid.py
@@ -119,7 +119,8 @@ class Grid(object):
 
     *OPTIONAL:*
 
-    :param list regDecompPTile: List of DE counts for each dimension. The second index steps through
+    :param list regDecompPTile: List of :ref:`DE <des>`
+        counts for each dimension. The second index steps through
         the tiles. The total deCount is determined as the sum over
         the products of regDecompPTile elements for each tile.
         By default every tile is decomposed in the same way.  If the total
@@ -540,9 +541,10 @@ class Grid(object):
     def all_areas(self):
         """
         :rtype: 2D list of numpy arrays, where the first index represents the
-            local DE and the second index represents the stagger locations of
+            local :ref:`DE <des>`
+            and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
-            (In the typical case of 1 DE per PET, see also
+            (In the typical case of 1 :ref:`DE <des>` per PET, see also
             :attr:`~esmpy.api.grid.Grid.area`.)
         :return: The :class:`~esmpy.api.grid.Grid` cell areas represented as
             numpy arrays of floats of size given by
@@ -555,10 +557,11 @@ class Grid(object):
         """
         :rtype: 3D list of numpy arrays of size given by
             ``upper_bounds - lower_bounds``, where the first index represents
-            the local DE, the second index represents the stagger locations of
+            the local :ref:`DE <des>`,
+            the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid` and the third index represents
             the coordinate dimensions of the :class:`~esmpy.api.grid.Grid`.
-            (In the typical case of 1 DE per PET, see also
+            (In the typical case of 1 :ref:`DE <des>` per PET, see also
             :attr:`~esmpy.api.grid.Grid.coords`.)
         :return: The coordinates of the :class:`~esmpy.api.grid.Grid`.
         """
@@ -568,9 +571,10 @@ class Grid(object):
     def all_lower_bounds(self):
         """
         :rtype: 2D list of numpy arrays, where the first index represents the
-            local DE and the second index represents the stagger locations of
+            local :ref:`DE <des>`
+            and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
-            (In the typical case of 1 DE per PET, see also
+            (In the typical case of 1 :ref:`DE <des>` per PET, see also
             :attr:`~esmpy.api.grid.Grid.lower_bounds`.)
         :return: The lower bounds of the :class:`~esmpy.api.grid.Grid`
             represented as numpy arrays of ints of size given by
@@ -582,9 +586,10 @@ class Grid(object):
     def all_masks(self):
         """
         :rtype: 2D list of numpy arrays, where the first index represents the
-            local DE and the second index represents the stagger locations of
+            local :ref:`DE <des>`
+            and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
-            (In the typical case of 1 DE per PET, see also
+            (In the typical case of 1 :ref:`DE <des>` per PET, see also
             :attr:`~esmpy.api.grid.Grid.mask`.)
         :return: The masks of the :class:`~esmpy.api.grid.Grid` represented as
             numpy arrays of ints of size given by `
@@ -596,9 +601,10 @@ class Grid(object):
     def all_sizes(self):
         """
         :rtype: 2D list of numpy arrays, where the first index represents the
-            local DE and the second index represents the stagger locations of
+            local :ref:`DE <des>`
+            and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
-            (In the typical case of 1 DE per PET, see also
+            (In the typical case of 1 :ref:`DE <des>` per PET, see also
             :attr:`~esmpy.api.grid.Grid.size`.)
         :return: The sizes of the :class:`~esmpy.api.grid.Grid` represented as
             numpy arrays of ints of size given by
@@ -614,9 +620,10 @@ class Grid(object):
     def all_upper_bounds(self):
         """
         :rtype: 2D list of numpy arrays, where the first index represents the
-            local DE and the second index represents the stagger locations of
+            local :ref:`DE <des>`
+            and the second index represents the stagger locations of
             the :class:`~esmpy.api.grid.Grid`.
-            (In the typical case of 1 DE per PET, see also
+            (In the typical case of 1 :ref:`DE <des>` per PET, see also
             :attr:`~esmpy.api.grid.Grid.upper_bounds`.)
         :return: The upper bounds of the :class:`~esmpy.api.grid.Grid`
             represented as numpy arrays of ints of size given by
@@ -633,8 +640,8 @@ class Grid(object):
             numpy arrays of floats of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there is something other than 1 DE per PET; in that case, use
-            :attr:`~esmpy.api.grid.Grid.all_areas`.)
+            where there is something other than 1 :ref:`DE <des>` per PET;
+            in that case, use :attr:`~esmpy.api.grid.Grid.all_areas`.)
         """
 
         if self.local_de_count != 1:
@@ -661,8 +668,8 @@ class Grid(object):
             :class:`~esmpy.api.grid.Grid`.
         :return: The coordinates of the :class:`~esmpy.api.grid.Grid`.
             (It is an error to use this property in the uncommon case
-            where there is something other than 1 DE per PET; in that case, use
-            :attr:`~esmpy.api.grid.Grid.all_coords`.)
+            where there is something other than 1 :ref:`DE <des>` per PET;
+            in that case, use :attr:`~esmpy.api.grid.Grid.all_coords`.)
         """
 
         if self.local_de_count != 1:
@@ -702,7 +709,7 @@ class Grid(object):
     def local_de_count(self):
         """
         :rtype: int
-        :return: The number of DEs in the
+        :return: The number of :ref:`DEs <des>` in the
             :class:`~esmpy.api.grid.Grid` on this PET.
         """
 
@@ -717,8 +724,8 @@ class Grid(object):
             represented as numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there is something other than 1 DE per PET; in that case, use
-            :attr:`~esmpy.api.grid.Grid.all_lower_bounds`.)
+            where there is something other than 1 :ref:`DE <des>` per PET;
+            in that case, use :attr:`~esmpy.api.grid.Grid.all_lower_bounds`.)
         """
 
         if self.local_de_count != 1:
@@ -734,8 +741,8 @@ class Grid(object):
             numpy arrays of ints of size given by `
             `upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there is something other than 1 DE per PET; in that case, use
-            :attr:`~esmpy.api.grid.Grid.all_masks`.)
+            where there is something other than 1 :ref:`DE <des>` per PET;
+            in that case, use :attr:`~esmpy.api.grid.Grid.all_masks`.)
         """
 
         if self.local_de_count != 1:
@@ -841,8 +848,8 @@ class Grid(object):
             numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there is something other than 1 DE per PET; in that case, use
-            :attr:`~esmpy.api.grid.Grid.all_sizes`.)
+            where there is something other than 1 :ref:`DE <des>` per PET;
+            in that case, use :attr:`~esmpy.api.grid.Grid.all_sizes`.)
         """
 
         if self.local_de_count != 1:
@@ -887,8 +894,8 @@ class Grid(object):
             represented as numpy arrays of ints of size given by
             ``upper_bounds - lower_bounds``.
             (It is an error to use this property in the uncommon case
-            where there is something other than 1 DE per PET; in that case, use
-            :attr:`~esmpy.api.grid.Grid.all_upper_bounds`.)
+            where there is something other than 1 :ref:`DE <des>` per PET;
+            in that case, use :attr:`~esmpy.api.grid.Grid.all_upper_bounds`.)
         """
         if self.local_de_count != 1:
             raise SingleLocalDEMethod
@@ -912,7 +919,7 @@ class Grid(object):
             :class:`~esmpy.api.grid.Grid` has already been created from file.
 
         :return: A numpy array of coordinate values if a single staggerloc is given,
-            coord_dim is specified and there is a single local DE,
+            coord_dim is specified and there is a single local :ref:`DE <des>`,
             otherwise return None.
         """
         if isinstance(staggerloc, type(None)):
@@ -966,7 +973,7 @@ class Grid(object):
             :class:`~esmpy.api.grid.Grid` has already been created from file.
 
         :return: A numpy array of the mask or area values if a single
-            staggerloc is given and there is a single local DE,
+            staggerloc is given and there is a single local :ref:`DE <des>`,
             otherwise return None.
         """
         if isinstance(staggerloc, type(None)):
@@ -1034,7 +1041,8 @@ class Grid(object):
     def get_coords(self, coord_dim, staggerloc=None, localde=0):
         """
         Return a numpy array of coordinates at a specified stagger 
-        location, for a single local DE. The returned array is NOT a copy,
+        location, for a single local :ref:`DE <des>`.
+        The returned array is NOT a copy,
         it is directly aliased to the underlying memory allocated by esmpy.
 
         *REQUIRED:*
@@ -1051,8 +1059,8 @@ class Grid(object):
             :attr:`~esmpy.api.constants.StaggerLoc.CENTER`
             in 2D and :attr:`~esmpy.api.constants.StaggerLoc.CENTER_VCENTER` in
             3D.
-        :param int localde: The local decompositional element (DE). This is
-            relevant in the uncommon case where there are multiple DEs per PET.
+        :param int localde: The local :ref:`decompositional element (DE) <des>`.
+            This is relevant in the uncommon case where there are multiple DEs per PET.
 
         :return: A numpy array of coordinate values at the specified staggerloc.
         """
@@ -1074,7 +1082,8 @@ class Grid(object):
     def get_item(self, item, staggerloc=None, localde=0):
         """
         Return a numpy array of item values at a specified stagger
-        location, for a single local DE. The returned array is NOT a copy,
+        location, for a single local :ref:`DE <des>`.
+        The returned array is NOT a copy,
         it is directly aliased to the underlying memory allocated by esmpy.
 
         *REQUIRED:*
@@ -1088,8 +1097,8 @@ class Grid(object):
             values. If ``None``, defaults to
             :attr:`~esmpy.api.constants.StaggerLoc.CENTER` in 2D and
             :attr:`~esmpy.api.constants.StaggerLoc.CENTER_VCENTER` in 3D.
-        :param int localde: The local decompositional element (DE). This is
-            relevant in the uncommon case where there are multiple DEs per PET.
+        :param int localde: The local :ref:`decompositional element (DE) <des>`.
+            This is relevant in the uncommon case where there are multiple DEs per PET.
 
         :return: A numpy array of mask or area values at the specified staggerloc.
         """


### PR DESCRIPTION
This PR adds some documentation on the use of multiple DEs per PET in ESMPy and removes a no-longer-true limitation.