### PR TITLE
Implement a work-around for IFX bug in version 2025.0.0.

### DIFF
--- a/src/Infrastructure/Util/src/ESMF_UtilCubedSphere.F90
+++ b/src/Infrastructure/Util/src/ESMF_UtilCubedSphere.F90
@@ -1177,7 +1177,14 @@ subroutine ESMF_UtilCreateCSCoordsPar(npts, LonEdge,LatEdge, start, count, tile,
      ! cartesian points in the local domain.
      do j = lbound(lambda,2), ubound(lambda,2)
         do i = lbound(lambda,1), ubound(lambda,1)
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER == 20250000)
+           ! work around for IFX bug in version 2025.0.0
+           pp(1,i,j) = -rsq3
+           pp(2,i,j) = -b(i)
+           pp(3,i,j) = b(j)
+#else
            pp(:,i,j) = [-rsq3, -b(i), b(j)]
+#endif
         end do
      end do
 


### PR DESCRIPTION
This addresses the issue Bob and I discussed via email:

On 7/3/25 10:21, Robert Oehmke wrote:
> Hi Gerhard, 
>
>   I tried reproducing this on Discover with Intel 2025.1.1 and it worked fine (i.e. it didn’t reproduce). If you get a chance, would you mind trying a fix on GaeaC5?   All, I was going to do was to change line 1180 in .../src/Infrastructure/Util/src/ESMF_UtilCubedSphere.F90 to be pp(1:3,i,j) instead of pp(:,i,j).     Let me know if you have a chance to try it and how it goes. 
>
> Thanks! 
> - Bob
>
>> On Jun 27, 2025, at 5:02 PM, Gerhard Theurich <gerhard.j.theurich@noaa.gov> wrote:
>>
>> Looks like the compiler's left hand doesn't know what it's right hand is doing. Really strange indeed. I'd say a problem for next week ;-)
>>
>> Have a good weekend, too!
>>
>> -Gerhard
>> On 6/27/25 15:37, Robert Oehmke wrote:
>>> It’s very strange, the error says this: 
>>> forrtl: severe (408): fort: (3): Subscript #1 of the array PP has value 0 which is less than the lower bound of 1
>>>
>>> but it looks like this is the line: 
>>>            pp(:,i,j) = [-rsq3, -b(i), b(j)]
>>>
>>> Strange that the subscript would be wrong when the compiler is doing it…   
>>>
>>> Maybe the line number is wrong or something? I’ll dig into it more. 
>>>
>>> Have a good weekend,
>>> - Bob
>>>
>>>
>>>> On Jun 27, 2025, at 10:53 AM, Robert Oehmke [<oehmke@ucar.edu>](mailto:oehmke@ucar.edu) wrote:
>>>>
>>>> Roger that. I’ll take a look.
>>>>
>>>> Thanks,
>>>> - Bob
>>>>
>>>>> On Jun 27, 2025, at 9:55 AM, Gerhard Theurich [<gerhard.j.theurich@noaa.gov>](mailto:gerhard.j.theurich@noaa.gov) wrote:
>>>>>
>>>>> Hi Bob,
>>>>>
>>>>> I was working on restoring our Gaea nightlies yesterday. I found that they have upgraded default modules, etc. and decided it was time to move Intel testing on Gaea to Intel 2025. It's the first platform we test with that recent version of Intel. Side note is that for the "classic" option on Gaea I kept it at 2023.2.0 (but fixed up the modules loaded) because 2025 no longer contains the "classic" Fortran IFORT compiler.
>>>>>
>>>>> Anyway, all the 2025.0.0 and 2025.0.0-oneAPI tests in BOPT=g mode show the same CRASH in ESMF_GridCreateUTest.F90. We have bounds checking turned on in debug mode, and it looks like something going out of bounds, which is caught by the run-time checker. E.g. see: https://github.com/esmf-org/esmf-test-artifacts/blob/a17551d4cbcd03ed212f04fca955c6985fbdc84c/develop/intel/2025.0.0/g/mpiuni/None/test/ESMF_GridCreateUTest.stdout#L192
>>>>>
>>>>> Probably worth taking a look at that before 8.9.0. Looks like it is coming out of ESMF_UtilCubedSphere.F90.
>>>>>
>>>>> -Gerhard
>>>>>
>>>>
>>>
>