### PR TITLE
Fix problem when ESMF_RUNTIME_ABORT_LOGMSG_TYPES is set in the environment

### DIFF
--- a/src/Infrastructure/Util/src/ESMF_LogErr.F90
+++ b/src/Infrastructure/Util/src/ESMF_LogErr.F90
@@ -1785,8 +1785,7 @@ end subroutine ESMF_LogGet
         ESMF_CONTEXT, rcToReturn=rc)
       return
     elseif (msgAbortCnt > 0) then
-      call ESMF_LogSet(ESMF_LogDefault, &
-        logmsgAbort=msgAbortLst(1:msgAbortCnt), rc=localrc)
+      call ESMF_LogSet(logmsgAbort=msgAbortLst(1:msgAbortCnt), rc=localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
     endif


### PR DESCRIPTION
This PR fixes an issue first flagged by Dan under ESMX, but I think it was probably affecting any ESMF application when the `ESMF_RUNTIME_ABORT_LOGMSG_TYPES` environment variable was used. Dan's original report:

On 7/3/25 08:07, Dan Rosen wrote:
> So if I set ESMF_RUNTIME_ABORT_LOGMSG_TYPES in the esmxRun.yml then this works. If I set ESMF_RUNTIME_ABORT_LOGMSG_TYPES in the environment then it fails with the following error. I think this is because the code I wrote is using the environment variable to modify the default log but ESMX doesn't use a default log? Everything works fine for a normal application. Thoughts?
>
>  ESMF_LogSet(): ESMF_Log not open -- cannot ESMF_LogSet().
>  ESMF_LogSet(): ESMF_Log not open -- cannot ESMF_LogSet().
>  ESMF_LogSet(): ESMF_Log not open -- cannot ESMF_LogSet().
>  ESMF_LogSet(): ESMF_Log not open -- cannot ESMF_LogSet().
>  ESMF_FrameworkInternalInit: Error LogInitialize() log file: Cannot set value
>  ESMF_Initialize: Error initializing framework
>  ESMF_FrameworkInternalInit: Error LogInitialize() log file: Cannot set value
>  ESMF_Initialize: Error initializing framework
>  ESMF_FrameworkInternalInit: Error LogInitialize() log file: Cannot set value
>  ESMF_Initialize: Error initializing framework
>  ESMF_FrameworkInternalInit: Error LogInitialize() log file: Cannot set value
>  ESMF_Initialize: Error initializing framework
>
> -- 
> ----------------------------------------------------------
> Dan Rosen
> Earth System Modeling Framework (ESMF)
> Climate & Global Dynamics (CGD)
> National Center for Atmospheric Research (NCAR)
> Email: [drosen@ucar.edu](mailto:drosen@ucar.edu)