### PR TITLE
Correctly handle absent regDecompPTile in ESMC_GridCreateCubedSphere

### DIFF
--- a/src/Infrastructure/Grid/interface/ESMF_Grid_C.F90
+++ b/src/Infrastructure/Grid/interface/ESMF_Grid_C.F90
@@ -208,14 +208,28 @@
     enddo
 
 
-    grid = ESMF_GridCreateCubedSphere(tilesize, &
-                                      regDecompPTile=regDecompPTile, &
-                                      !decompFlagPTile=decompFlagPTile_local, &
-                                      !deLabelList=deLabelList, &
-                                      !delayout=delayout, &
-                                      staggerLocList=staggerLocList_local, &
-                                      name=name, &
-                                      rc=rc)
+    ! Because decompFlagPTile and deLabelList are currently commented-out in this call, we
+    ! don't need to handle dfpresent or llpresent. If we wanted to enable those arguments,
+    ! then we'd need a combinatoric set of conditionals as is found in some other Fortran
+    ! interface routines.
+    if (rdpresent == 1) then
+       grid = ESMF_GridCreateCubedSphere(tilesize, &
+                                         regDecompPTile=regDecompPTile, &
+                                         !decompFlagPTile=decompFlagPTile_local, &
+                                         !deLabelList=deLabelList, &
+                                         !delayout=delayout, &
+                                         staggerLocList=staggerLocList_local, &
+                                         name=name, &
+                                         rc=rc)
+    else
+       grid = ESMF_GridCreateCubedSphere(tilesize, &
+                                         !decompFlagPTile=decompFlagPTile_local, &
+                                         !deLabelList=deLabelList, &
+                                         !delayout=delayout, &
+                                         staggerLocList=staggerLocList_local, &
+                                         name=name, &
+                                         rc=rc)
+    end if
 
     if (ESMF_LogFoundError(rc, ESMF_ERR_PASSTHRU, &
       ESMF_CONTEXT, rcToReturn=rc)) return

--- a/src/Infrastructure/Grid/tests/ESMC_GridUTest.c
+++ b/src/Infrastructure/Grid/tests/ESMC_GridUTest.c
@@ -133,7 +133,13 @@ int main(void){
   char namecs[18] = "cubed sphere grid";
 
   //NEX_UTest
-  strcpy(name, "GridCreateCubedSphere");
+  strcpy(name, "GridCreateCubedSphere without regDecompPTile");
+  strcpy(failMsg, "Did not return ESMF_SUCCESS");
+  grid_cs = ESMC_GridCreateCubedSphere(&tilesize, NULL, &i_sl, namecs, &rc);
+  ESMC_Test((rc==ESMF_SUCCESS), name, failMsg, &result, __FILE__, __LINE__, 0);
+
+  //NEX_UTest
+  strcpy(name, "GridCreateCubedSphere with regDecompPTile");
   strcpy(failMsg, "Did not return ESMF_SUCCESS");
   grid_cs = ESMC_GridCreateCubedSphere(&tilesize, &i_rd, &i_sl, namecs, &rc);
   ESMC_Test((rc==ESMF_SUCCESS), name, failMsg, &result, __FILE__, __LINE__, 0);


### PR DESCRIPTION
This is needed for ESMPy testing to pass on derecho-intel.

I see (at least) two methods for handling optional arguments passed from C to Fortran:
1. An explicit "foopresent" integer passed as an argument and then checked, with "foo" *not* declared as optional in the Fortran
2. Declaring "foo" as optional in the Fortran, with the C passing a NULL pointer

(2) seems like the cleaner approach where possible, and it avoids a combinatoric explosion of conditionals. But I'm using (1) here because that's what was set up. **Do we (eventually) want to migrate to (2) in cases like this, or is this not possible in this situation?**

Note that there is currently no combinatoric explosion in this routine because two of the arguments that should be optional (decompFlagPTile and deLayoutList) are currently commented-out. (Eventually I imagine we may want to enable those arguments....)