### PR TITLE
Prevent floating point exceptions (FPE) due to compiler optimization pre-computation

### DIFF
--- a/src/Infrastructure/VM/src/ESMCI_VMKernel.C
+++ b/src/Infrastructure/VM/src/ESMCI_VMKernel.C
@@ -2596,8 +2596,8 @@ void *VMK::startup(class VMKPlan *vmp, void *(fctp)(void *, void *),
     pos = stdTemp.rfind('*');  // right most asterisk
     if (pos != string::npos){
       // found wildcard -> replace with local pet number
-      int digits = 1; // default number of digits needed
-      if (new_npets>1) digits = (int) log10(new_npets-1) + 1;
+      int digits = (int) log10(new_npets);    // always safe
+      if (digits * 10 != new_npets) ++digits; // correct number of digits
       std::stringstream label;                    // fill with zeros from left
       label << setw(digits) << setfill('0') << to_string(sarg[i].mypet);
       sarg[i].stdoutName = stdTemp.substr(0, pos) + label.str()
@@ -2613,8 +2613,8 @@ void *VMK::startup(class VMKPlan *vmp, void *(fctp)(void *, void *),
     pos = stdTemp.rfind('*');  // right most asterisk
     if (pos != string::npos){
       // found wildcard -> replace with local pet number
-      int digits = 1; // default number of digits needed
-      if (new_npets>1) digits = (int) log10(new_npets-1) + 1;
+      int digits = (int) log10(new_npets);    // always safe
+      if (digits * 10 != new_npets) ++digits; // correct number of digits
       std::stringstream label;                    // fill with zeros from left
       label << setw(digits) << setfill('0') << to_string(sarg[i].mypet);
       sarg[i].stderrName = stdTemp.substr(0, pos) + label.str()


### PR DESCRIPTION
This PR resolves #464.

Code that utilizes the `log10()` library function is reformulate to ensure  argument is `>0` under _all_ conditions, even those where `log10()` is protected by conditional and should never be called! This is necessary to prevent compiler pre-computation to raise FPE that are trapped when main program is compiled with FPE trapping, i.e. `-fpe0` flag under Intel.