### PR TITLE
Implement unique ID for NamedAlias

### DIFF
--- a/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
+++ b/src/Infrastructure/Array/tests/ESMF_ArrayCreateGetUTest.F90
@@ -354,9 +354,9 @@ program ESMF_ArrayCreateGetUTest
 
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
-  write(name, *) "Verify Attribute count from an Array"
+  write(name, *) "Verify Attribute count on newly created Array"
   write(failMsg, *) "Incorrect count"
-  call ESMF_Test((count.eq.0), name, failMsg, result, ESMF_SRCLINE)
+  call ESMF_Test((count.eq.1), name, failMsg, result, ESMF_SRCLINE)
 
   !------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only

--- a/src/Infrastructure/Base/src/ESMCI_Base.C
+++ b/src/Infrastructure/Base/src/ESMCI_Base.C
@@ -127,7 +127,7 @@ esmc_error::esmc_error (const std::string &code_name, int esmc_rc, const std::st
 #define ESMC_METHOD "ESMC_Base::constructInfo()"
 void ESMC_Base::constructInfo(ESMC_Base& base) {
   base.info = new ESMCI::Info(
-    std::string("{\"ESMF\":{\"Instance\":{\"NamedAliasCount\": 0}}}"));
+    std::string("{\"ESMF\":{\"Instance\":{\"NamedAliasCount\":0}}}"));
   base.infoalias = false;
 }
 

--- a/src/Infrastructure/Base/src/ESMCI_Base.C
+++ b/src/Infrastructure/Base/src/ESMCI_Base.C
@@ -126,7 +126,8 @@ esmc_error::esmc_error (const std::string &code_name, int esmc_rc, const std::st
 #undef ESMC_METHOD
 #define ESMC_METHOD "ESMC_Base::constructInfo()"
 void ESMC_Base::constructInfo(ESMC_Base& base) {
-  base.info = new ESMCI::Info();
+  base.info = new ESMCI::Info(
+    std::string("{\"ESMF\":{\"Instance\":{\"NamedAliasCount\": 0}}}"));
   base.infoalias = false;
 }
 

--- a/src/Infrastructure/Base/tests/ESMCI_BaseUTest.C
+++ b/src/Infrastructure/Base/tests/ESMCI_BaseUTest.C
@@ -114,11 +114,14 @@ void testSerializeDeserialize(int& rc, char failMsg[]) {
     try {
       std::string dump = infod->dump();
       if (arflag == ESMC_ATTRECONCILE_OFF) {
-        if (dump != "{}") {
+        const std::string desired = "{\"ESMF\":{\"Instance\":{\"NamedAliasCount\":0}}}";
+        if (dump != desired) {
           return finalizeFailure(rc, failMsg, "if not reconciling info, then object should be empty");
         }
       } else {
-        const std::string desired = "{\"a-string-key\":\"some-data\",\"key1\":44,\"key123\":3.146789}";
+cout << dump << "\n";
+        const std::string desired = "{\"ESMF\":{\"Instance\":{\"NamedAliasCount\":0}},"
+          "\"a-string-key\":\"some-data\",\"key1\":44,\"key123\":3.146789}";
         if (dump != desired) {
           return finalizeFailure(rc, failMsg, "if reconciling info, then object should have data");
         }

--- a/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleUTest.F90
+++ b/src/Infrastructure/FieldBundle/tests/ESMF_FieldBundleUTest.F90
@@ -1834,7 +1834,7 @@
       ! Verify Attribute count Test
       write(failMsg, *) "Incorrect count"
       write(name, *) "Verify Attribute count from a FieldBundle "
-      call ESMF_Test((count.eq.1), name, failMsg, result, ESMF_SRCLINE)
+      call ESMF_Test((count.eq.2), name, failMsg, result, ESMF_SRCLINE)
       !------------------------------------------------------------------------
 
       !EX_UTest

--- a/src/Infrastructure/IO/src/ESMCI_IO_NetCDF.C
+++ b/src/Infrastructure/IO/src/ESMCI_IO_NetCDF.C
@@ -1016,6 +1016,7 @@ void IO_NetCDF::destruct(void) {
     }
     for (json::const_iterator it_info=j.cbegin(); it_info!=j.cend(); it_info++) {
       auto attrname = it_info.key().c_str();
+      if (attrname == string("ESMF")) continue; // skip over ESMF JSON root
       if (it_info.value().is_string()) {
         string value_string = it_info.value().get<string>();
         ncerror = nc_put_att_text(netCdfFile, thisVar, attrname, value_string.size(), value_string.c_str());

--- a/src/Infrastructure/Util/include/ESMF_InitMacros.inc
+++ b/src/Infrastructure/Util/include/ESMF_InitMacros.inc
@@ -63,7 +63,7 @@ automatic initialization of types.
                  finit(var)
 #else
 #define ESMF_INIT_DECLARE ESMF_INIT_TYPE :: isInit = ESMF_INIT_UNDEFINED
-#define ESMF_INIT_DECLARE_NAMED_ALIAS ESMF_INIT_TYPE :: isInit = ESMF_INIT_UNDEFINED ; logical :: isNamedAlias = .false. ; character(ESMF_MAXSTR) :: name
+#define ESMF_INIT_DECLARE_NAMED_ALIAS ESMF_INIT_TYPE :: isInit = ESMF_INIT_UNDEFINED ; logical :: isNamedAlias = .false. ; character(ESMF_MAXSTR) :: name ; integer :: id = -1
 #define ESMF_INIT_CHECK_SET_SHALLOW(fget,finit,var)
 #endif
 

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackABundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackABundleUTest.cppF90
@@ -49,6 +49,7 @@ program ESMF_AttPackArrayBundleUTest
   type(ESMF_Array), dimension(2) :: array
   type(ESMF_ArraySpec)           :: arrayspec
   type(ESMF_DistGrid)            :: distgrid
+  type(ESMF_Info)                :: info
 
   AttPackTestVariablesMacro()
 
@@ -66,19 +67,35 @@ program ESMF_AttPackArrayBundleUTest
   !-----------------------------------------------------------------------------
 
   call ESMF_ArraySpecSet(arrayspec, typekind=ESMF_TYPEKIND_R8, rank=2, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   distgrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/5,5/), &
     regDecomp=(/2,3/), rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   array(1) = ESMF_ArrayCreate(arrayspec=arrayspec, distgrid=distgrid, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   array(2) = ESMF_ArrayCreate(arrayspec=arrayspec, distgrid=distgrid, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   arraybundle = ESMF_ArrayBundleCreate(arrayList=array, &
     name="MyArrayBundle", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(arraybundle, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(arraybundle, "an ArrayBundle", EX_UTest, "MyArrayBundle")
 
   call ESMF_ArrayBundleDestroy(arraybundle, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   call ESMF_ArrayDestroy(array(1), rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   call ESMF_ArrayDestroy(array(2), rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   call ESMF_DistGridDestroy(distgrid, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackArrayUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackArrayUTest.cppF90
@@ -48,6 +48,7 @@ program ESMF_AttPackArrayUTest
   type(ESMF_Array)     :: array
   type(ESMF_ArraySpec) :: arrayspec
   type(ESMF_DistGrid)  :: distgrid
+  type(ESMF_Info)      :: info
 
   AttPackTestVariablesMacro()
 
@@ -65,10 +66,20 @@ program ESMF_AttPackArrayUTest
   !-----------------------------------------------------------------------------
 
   call ESMF_ArraySpecSet(arrayspec, typekind=ESMF_TYPEKIND_R8, rank=2, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   distgrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/5,5/), &
     regDecomp=(/2,3/), rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   array = ESMF_ArrayCreate(arrayspec=arrayspec, distgrid=distgrid, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(array, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(array, "an Array", EX_UTest, "Array002")
 
   AttPackStandardTestMacro(array, "an Array", "ESMF   ", "General", EX_UTest)
@@ -77,7 +88,9 @@ program ESMF_AttPackArrayUTest
   AttPackStandardTestMacro(array, "an Array", "CF     ", "General", EX_UTest)
 
   call ESMF_ArrayDestroy(array, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   call ESMF_DistGridDestroy(distgrid, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackCplCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackCplCompUTest.cppF90
@@ -46,6 +46,7 @@ program ESMF_AttPackCplCompUTest
 
   ! local variables
   type(ESMF_CplComp) :: cplcomp
+  type(ESMF_Info)    :: info
 
   AttPackTestVariablesMacro()
 
@@ -63,7 +64,15 @@ program ESMF_AttPackCplCompUTest
   !-----------------------------------------------------------------------------
 
   cplcomp = ESMF_CplCompCreate(name="cplcomp", petList=(/0/), rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(cplcomp, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(cplcomp, "a CplComp", EX_UTest, "cplcomp")
 
   AttPackStandardTestMacro(cplcomp, "a CplComp", "ESMF   ", "General", EX_UTest)
@@ -77,6 +86,7 @@ program ESMF_AttPackCplCompUTest
   AttPackStandardTestMacro(cplcomp, "a CplComp", "ISO 19115", "Citation ", EX_disabledUTest)
 ^endif
   call ESMF_CplCompDestroy(cplcomp, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackDistGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackDistGridUTest.cppF90
@@ -46,6 +46,7 @@ program ESMF_AttPackDistGridUTest
 
   ! local variables
   type(ESMF_DistGrid) :: distgrid
+  type(ESMF_Info)     :: info
 
   AttPackTestVariablesMacro()
 
@@ -64,10 +65,19 @@ program ESMF_AttPackDistGridUTest
 
   distgrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/5,5/), &
                                  regDecomp=(/2,3/), rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(distgrid, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(distgrid, "a DistGrid", EX_UTest, "DistGrid000")
 
   call ESMF_DistGridDestroy(distgrid, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFBundleUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFBundleUTest.cppF90
@@ -46,6 +46,7 @@ program ESMF_AttPackFieldBundleUTest
 
   ! local variables
   type(ESMF_FieldBundle) :: fieldbundle
+  type(ESMF_Info)        :: info
 
   AttPackTestVariablesMacro()
 
@@ -63,10 +64,19 @@ program ESMF_AttPackFieldBundleUTest
   !-----------------------------------------------------------------------------
 
   fieldbundle = ESMF_FieldBundleCreate(name="fieldbundle", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(fieldbundle, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(fieldbundle, "a FieldBundle", EX_UTest, "fieldbundle")
 
   call ESMF_FieldBundleDestroy(fieldbundle, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFieldUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackFieldUTest.cppF90
@@ -46,6 +46,7 @@ program ESMF_AttPackFieldUTest
 
   ! local variables
   type(ESMF_Field) :: field
+  type(ESMF_Info)  :: info
 
   AttPackTestVariablesMacro()
 
@@ -63,7 +64,15 @@ program ESMF_AttPackFieldUTest
   !-----------------------------------------------------------------------------
 
   field = ESMF_FieldEmptyCreate(name="field", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(field, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(field, "an Field", EX_UTest, "field")
   AttPackStandardTestMacro(field, "a Field", "ESMF   ", "General", EX_UTest)
   AttPackStandardTestMacro(field, "a Field", "CIM 1.5", "Inputs ", EX_UTest)
@@ -71,6 +80,7 @@ program ESMF_AttPackFieldUTest
   AttPackStandardTestMacro(field, "a Field", "CF     ", "General", EX_UTest)
 
   call ESMF_FieldDestroy(field, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridCompUTest.cppF90
@@ -46,6 +46,7 @@ program ESMF_AttPackGridCompUTest
 
   ! local variables
   type(ESMF_GridComp) :: gridcomp
+  type(ESMF_Info)     :: info
 
   AttPackTestVariablesMacro()
 
@@ -63,7 +64,15 @@ program ESMF_AttPackGridCompUTest
   !-----------------------------------------------------------------------------
 
   gridcomp = ESMF_GridCompCreate(name="gridcomp", petList=(/0/), rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(gridcomp, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(gridcomp, "a GridComp", EX_UTest, "gridcomp")
   AttPackStandardTestMacro(gridcomp, "a GridComp", "ESMF   ", "General", EX_UTest)
   AttPackStandardTestMacro(gridcomp, "a GridComp", "CIM 1.5  ", "ModelComp", EX_UTest)
@@ -77,6 +86,7 @@ program ESMF_AttPackGridCompUTest
 ^endif
 
   call ESMF_GridCompDestroy(gridcomp, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackGridUTest.cppF90
@@ -46,6 +46,7 @@ character(*), parameter :: version = '$Id$'
 
   ! local variables
   type(ESMF_Grid) :: grid
+  type(ESMF_Info) :: info
 
   AttPackTestVariablesMacro()
 
@@ -63,12 +64,21 @@ character(*), parameter :: version = '$Id$'
   !-----------------------------------------------------------------------------
 
   grid = ESMF_GridEmptyCreate(rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(grid, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(grid, "a Grid", EX_UTest, "unnamed000")
   AttPackStandardTestMacro(grid, "a Grid", "CIM 1.5.1", "grids    ", EX_UTest)
   AttPackStandardTestMacro(grid, "a Grid", "ESMF   ", "General", EX_UTest)
 
   call ESMF_GridDestroy(grid, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackLocStreamUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackLocStreamUTest.cppF90
@@ -46,6 +46,7 @@ program ESMF_AttPackLocStreamUTest
 
   ! local variables
   type(ESMF_LocStream) :: locStream
+  type(ESMF_Info)      :: info
 
   AttPackTestVariablesMacro()
 
@@ -63,11 +64,19 @@ program ESMF_AttPackLocStreamUTest
   !-----------------------------------------------------------------------------
 
   locstream = ESMF_LocStreamCreate(20, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(locstream, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(locStream, "a LocStream", EX_UTest, "LocStream002")
 
   call ESMF_LocStreamDestroy(locStream, rc=rc)
-  if (rc .ne. ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackSciCompUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackSciCompUTest.cppF90
@@ -46,6 +46,7 @@ program ESMF_AttPackSciCompUTest
 
   ! local variables
   type(ESMF_SciComp) :: scicomp
+  type(ESMF_Info)    :: info
 
   AttPackTestVariablesMacro()
 
@@ -62,8 +63,16 @@ program ESMF_AttPackSciCompUTest
   if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   !-----------------------------------------------------------------------------
 
- scicomp = ESMF_SciCompCreate(name="scicomp", rc=rc)
+  scicomp = ESMF_SciCompCreate(name="scicomp", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(scicomp, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(scicomp, "a SciComp", EX_UTest, "scicomp")
   AttPackStandardTestMacro(scicomp, "a SciComp", "ESMF   ", "General", EX_UTest)
   AttPackStandardTestMacro(scicomp, "a SciComp", "CIM 1.5  ", "ModelComp", EX_UTest)
@@ -77,6 +86,7 @@ program ESMF_AttPackSciCompUTest
 ^endif
 
   call ESMF_SciCompDestroy(scicomp, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttPackStateUTest.cppF90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttPackStateUTest.cppF90
@@ -46,6 +46,7 @@ character(*), parameter :: version = '$Id$'
 
   ! local variables
   type(ESMF_State) :: state
+  type(ESMF_Info)  :: info
 
   AttPackTestVariablesMacro()
 
@@ -64,11 +65,20 @@ character(*), parameter :: version = '$Id$'
 
   state = ESMF_StateCreate(name="state",  &
                            stateintent=ESMF_STATEINTENT_IMPORT, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because AttPack testing cannot handle it
+  call ESMF_InfoGetFromHost(state, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! now start testing...
   AttPackTestMacro(state, "a State", EX_UTest, "state")
   AttPackStandardTestMacro(state, "a State", "ESMF   ", "General", EX_UTest)
 
   call ESMF_StateDestroy(state, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   !-----------------------------------------------------------------------------
   call ESMF_TestEnd(ESMF_SRCLINE)

--- a/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUtilUTest.F90
+++ b/src/Superstructure/AttributeAPI/tests/ESMF_AttributeUtilUTest.F90
@@ -53,7 +53,7 @@ program ESMF_AttributeUtilUTest
 
   type(ESMF_FieldBundle) :: src_fb, dst_fb, src_fb2, dst_fb2, src_fb3, dst_fb3, &
                             fb_idx
-  type(ESMF_Info) :: infoh, infoh2
+  type(ESMF_Info) :: infoh, infoh2, info
   character(:), allocatable :: actual
   type(ESMF_Grid) :: grid
   type(ESMF_Field) :: field,field2,field3,field4
@@ -146,6 +146,12 @@ program ESMF_AttributeUtilUTest
   field=ESMF_FieldCreate(grid,typekind=ESMF_TYPEKIND_R4,rc=rc)
   if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+  ! remove the ESMF JSON root - because access by index cannot handle it
+  call ESMF_InfoGetFromHost(field, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
   field2=ESMF_FieldCreate(grid,typekind=ESMF_TYPEKIND_R4,rc=rc)
   if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
@@ -190,6 +196,12 @@ program ESMF_AttributeUtilUTest
   write(failMsg, *) "Did not return ESMF_SUCCESS"
 
   field3=ESMF_FieldCreate(grid,typekind=ESMF_TYPEKIND_R4,rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! remove the ESMF JSON root - because access by index cannot handle it
+  call ESMF_InfoGetFromHost(field3, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
   if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   field4=ESMF_FieldCreate(grid,typekind=ESMF_TYPEKIND_R4,rc=rc)
@@ -390,6 +402,12 @@ program ESMF_AttributeUtilUTest
   write(failMsg, *) "Did not return ESMF_SUCCESS"
 
   fb_idx = ESMF_FieldBundleCreate(name="fb_idx", rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+  ! remove the ESMF JSON root - because access by index cannot handle it
+  call ESMF_InfoGetFromHost(fb_idx, info=info, rc=rc)
+  if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  call ESMF_InfoRemove(info, keyParent="ESMF", rc=rc)
   if (rc /= ESMF_SUCCESS) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   call ESMF_AttributeSet(fb_idx, "is_32bit", actual_value, convention="NetCDF", &

--- a/src/Superstructure/NamedAlias/src/ESMF_NamedAlias.F90
+++ b/src/Superstructure/NamedAlias/src/ESMF_NamedAlias.F90
@@ -36,6 +36,8 @@ use ESMF_FieldMod
 use ESMF_FieldGetMod
 use ESMF_ArrayBundleMod
 use ESMF_ArrayMod
+use ESMF_InfoMod
+use ESMF_InfoSyncMod
 
 implicit none
 
@@ -44,6 +46,7 @@ implicit none
 
 private
 public ESMF_NamedAlias
+public ESMF_NamedAliasGet
 
 !==============================================================================
 !==============================================================================
@@ -59,19 +62,31 @@ interface ESMF_NamedAlias
   module procedure ESMF_NamedAliasArray
 end interface
 
+interface ESMF_NamedAliasGet
+  module procedure ESMF_NamedAliasGetState
+  module procedure ESMF_NamedAliasGetGridComp
+  module procedure ESMF_NamedAliasGetCplComp
+  module procedure ESMF_NamedAliasGetSciComp
+  module procedure ESMF_NamedAliasGetFieldBundle
+  module procedure ESMF_NamedAliasGetField
+  module procedure ESMF_NamedAliasGetArrayBundle
+  module procedure ESMF_NamedAliasGetArray
+end interface
+
 contains !=====================================================================
 
 ! -------------------------- ESMF-public method -------------------------------
 !BOP
-! !IROUTINE: ESMF_NamedAlias - Generate a Named Alias
+! !IROUTINE: ESMF_NamedAlias - Generate a NamedAlias
 !
 ! !INTERFACE:
-!   function ESMF_NamedAlias(object, name, rc)
+!   function ESMF_NamedAlias(object, keywordEnforcer, name, rc)
 !
 ! !RETURN VALUE:
 !   type(ESMF_*)        :: ESMF_NamedAlias
 ! !ARGUMENTS:
 !   type(ESMF_*),       intent(in)            :: object
+!   type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   character(len = *), intent(in),  optional :: name
 !   integer,            intent(out), optional :: rc
 !
@@ -91,7 +106,8 @@ contains !=====================================================================
 !   The arguments are:
 !   \begin{description}
 !   \item[object]
-!     The incoming object for which a named alias is generated.
+!     The incoming object (alias or named alias) for which a named alias is
+!     generated.
 !   \item [{[name]}]
 !     The name of the named alias. By default use the name of {\tt object}.
 !   \item [{[rc]}]
@@ -123,6 +139,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -141,6 +158,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
       ESMF_NamedAliasState%name = trim(nameDefault)
     endif
+
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasState%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
 
   end function ESMF_NamedAliasState
 !------------------------------------------------------------------------------
@@ -167,6 +192,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -185,6 +211,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
       ESMF_NamedAliasGridComp%name = trim(nameDefault)
     endif
+
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasGridComp%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
 
   end function ESMF_NamedAliasGridComp
 !------------------------------------------------------------------------------
@@ -211,6 +245,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -229,6 +264,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
       ESMF_NamedAliasCplComp%name = trim(nameDefault)
     endif
+
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasCplComp%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
 
   end function ESMF_NamedAliasCplComp
 !------------------------------------------------------------------------------
@@ -255,6 +298,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -273,6 +317,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
       ESMF_NamedAliasSciComp%name = trim(nameDefault)
     endif
+
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasSciComp%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
 
   end function ESMF_NamedAliasSciComp
 !------------------------------------------------------------------------------
@@ -299,6 +351,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -317,6 +370,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
       ESMF_NamedAliasFieldBundle%name = trim(nameDefault)
     endif
+
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasFieldBundle%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
 
   end function ESMF_NamedAliasFieldBundle
 !------------------------------------------------------------------------------
@@ -343,6 +404,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -361,6 +423,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
       ESMF_NamedAliasField%name = trim(nameDefault)
     endif
+
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasField%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
 
   end function ESMF_NamedAliasField
 !------------------------------------------------------------------------------
@@ -387,6 +457,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -405,6 +476,14 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         ESMF_CONTEXT, rcToReturn=rc)) return
       ESMF_NamedAliasArrayBundle%name = trim(nameDefault)
     endif
+
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasArrayBundle%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
 
   end function ESMF_NamedAliasArrayBundle
 !------------------------------------------------------------------------------
@@ -431,6 +510,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !------------------------------------------------------------------------------
     integer                 :: localrc
     character(ESMF_MAXSTR)  :: nameDefault
+    type(ESMF_Info)         :: info
 
     if (present(rc)) rc = ESMF_SUCCESS
 
@@ -450,7 +530,350 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       ESMF_NamedAliasArray%name = trim(nameDefault)
     endif
 
+    ! handle unique named alias id
+    call ESMF_InfoGetFromHost(object, info=info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+    ESMF_NamedAliasArray%id = handleNamedAliasId(info, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+
   end function ESMF_NamedAliasArray
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-internal method -----------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "handleNamedAliasId()"
+!BOPI
+! !IROUTINE: handleNamedAliasId - increment NamedAliasCount and return as id
+!
+! !INTERFACE:
+  function handleNamedAliasId(info, rc)
+!
+! !RETURN VALUE:
+    integer                         :: handleNamedAliasId
+!
+! !ARGUMENTS:
+    type(ESMF_Info),    intent(inout)         :: info
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    ! get the current NamedAliasCount
+    call ESMF_InfoGet(info, key="/ESMF/Instance/NamedAliasCount", &
+      value=handleNamedAliasId, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+
+    ! increment as id
+    handleNamedAliasId = handleNamedAliasId + 1
+
+    ! set back as new NamedAliasCount
+    call ESMF_InfoSet(info, key="/ESMF/Instance/NamedAliasCount", &
+      value=handleNamedAliasId, rc=localrc)
+    if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+      ESMF_CONTEXT, rcToReturn=rc)) return
+
+  end function handleNamedAliasId
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+!BOP
+! !IROUTINE: ESMF_NamedAliasGet - Get NamedAlias information
+!
+! !INTERFACE:
+!   subroutine ESMF_NamedAliasGet(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+!   type(ESMF_*),       intent(in)            :: object
+!   type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+!   integer,            intent(out), optional :: id
+!   integer,            intent(out), optional :: rc
+!
+! !DESCRIPTION:
+!   Query an object for named alias information. The supported classes are:
+!   \begin{itemize}
+!   \item {\tt ESMF\_State}
+!   \item {\tt ESMF\_GridComp}
+!   \item {\tt ESMF\_CplComp}
+!   \item {\tt ESMF\_SciComp}
+!   \item {\tt ESMF\_FieldBundle}
+!   \item {\tt ESMF\_Field}
+!   \item {\tt ESMF\_ArrayBundle}
+!   \item {\tt ESMF\_Array}
+!   \end{itemize}
+!
+!   The arguments are:
+!   \begin{description}
+!   \item[object]
+!     The incoming object (alias or named alias) that is queried.
+!   \item [{[id]}]
+!     For a named alias {\tt object}, the returned {\tt id} > 0 identifies the
+!     specific named alias. Every named alias of the same ESMF object has its
+!     unique {\tt id}. Regular aliases, on the other hand, all return the same
+!     {\tt id} == 0 value.
+!   \item [{[rc]}]
+!     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
+!   \end{description}
+!
+!EOP
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetState()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetState - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetState(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_State),   intent(in)            :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetState
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetGridComp()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetGridComp - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetGridComp(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_GridComp),intent(in)            :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetGridComp
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetCplComp()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetCplComp - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetCplComp(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_CplComp), intent(in)            :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetCplComp
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetSciComp()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetSciComp - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetSciComp(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_SciComp), intent(in)            :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetSciComp
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetFieldBundle()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetFieldBundle - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetFieldBundle(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_FieldBundle), intent(in)        :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetFieldBundle
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetField()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetField - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetField(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_Field),   intent(in)            :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetField
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetArrayBundle()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetArrayBundle - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetArrayBundle(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_ArrayBundle), intent(in)        :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetArrayBundle
+!------------------------------------------------------------------------------
+
+! -------------------------- ESMF-public method -------------------------------
+#undef  ESMF_METHOD
+#define ESMF_METHOD "ESMF_NamedAliasGetArray()"
+!BOPI
+! !IROUTINE: ESMF_NamedAliasGetArray - Get NamedAlias information
+!
+! !INTERFACE:
+  ! Private name; call using ESMF_NamedAliasGet()
+  subroutine ESMF_NamedAliasGetArray(object, keywordEnforcer, id, rc)
+!
+! !ARGUMENTS:
+    type(ESMF_Array),   intent(in)            :: object
+type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
+    integer,            intent(out), optional :: id
+    integer,            intent(out), optional :: rc
+!EOPI
+!------------------------------------------------------------------------------
+    integer                 :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(id)) then
+      if (object%isNamedAlias) then
+        id = object%id  ! return actual id for named alias
+      else
+        id = 0          ! return 0 for regular alias
+      endif
+    endif
+
+  end subroutine ESMF_NamedAliasGetArray
 !------------------------------------------------------------------------------
 
 end module ESMF_NamedAliasMod

--- a/src/Superstructure/NamedAlias/tests/ESMF_NamedAliasUTest.F90
+++ b/src/Superstructure/NamedAlias/tests/ESMF_NamedAliasUTest.F90
@@ -100,6 +100,7 @@ contains !======================================================================
     integer, intent(out)  :: rc
     type(ESMF_State)      :: object1, object2
     type(ESMF_State)      :: state
+    integer               :: id
 
     object1 = ESMF_StateCreate(name="Test Name 1", rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -117,6 +118,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias State Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias State Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias State Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias State Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias State Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -275,6 +308,70 @@ contains !======================================================================
 
     !------------------------------------------------------------------------
     !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for State Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias State Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias State Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged State Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged State Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for State Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again State Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again State Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
     write(name, *) "Destroy object through NamedAlias State Test"
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     call ESMF_StateDestroy(object2, rc=rc)
@@ -299,6 +396,7 @@ contains !======================================================================
   subroutine TestGridCompNamedAlias(rc)
     integer, intent(out)  :: rc
     type(ESMF_GridComp)   :: object1, object2
+    integer               :: id
 
     object1 = ESMF_GridCompCreate(name="Test Name 1", rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -316,6 +414,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias GridComp Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias GridComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias GridComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias GridComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias GridComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -414,6 +544,70 @@ contains !======================================================================
 
     !------------------------------------------------------------------------
     !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for GridComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias GridComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias GridComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged GridComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged GridComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for GridComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again GridComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again GridComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
     write(name, *) "Destroy object through NamedAlias GridComp Test"
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     call ESMF_GridCompDestroy(object2, rc=rc)
@@ -438,6 +632,7 @@ contains !======================================================================
   subroutine TestCplCompNamedAlias(rc)
     integer, intent(out)  :: rc
     type(ESMF_CplComp)    :: object1, object2
+    integer               :: id
 
     object1 = ESMF_CplCompCreate(name="Test Name 1", rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -455,6 +650,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias CplComp Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias CplComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias CplComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias CplComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias CplComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -553,6 +780,70 @@ contains !======================================================================
 
     !------------------------------------------------------------------------
     !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for CplComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias CplComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias CplComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged CplComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged CplComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for CplComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again CplComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again CplComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
     write(name, *) "Destroy object through NamedAlias CplComp Test"
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     call ESMF_CplCompDestroy(object2, rc=rc)
@@ -577,6 +868,7 @@ contains !======================================================================
   subroutine TestSciCompNamedAlias(rc)
     integer, intent(out)  :: rc
     type(ESMF_SciComp)    :: object1, object2
+    integer               :: id
 
     object1 = ESMF_SciCompCreate(name="Test Name 1", rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -594,6 +886,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias SciComp Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias SciComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias SciComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias SciComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias SciComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -692,6 +1016,70 @@ contains !======================================================================
 
     !------------------------------------------------------------------------
     !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for SciComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias SciComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias SciComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged SciComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged SciComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for SciComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again SciComp Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again SciComp Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
     write(name, *) "Destroy object through NamedAlias SciComp Test"
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     call ESMF_SciCompDestroy(object2, rc=rc)
@@ -717,6 +1105,7 @@ contains !======================================================================
     integer, intent(out)  :: rc
     type(ESMF_FieldBundle):: object1, object2
     type(ESMF_State)      :: state
+    integer               :: id
 
     object1 = ESMF_FieldBundleCreate(name="Test Name 1", rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -734,6 +1123,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias FieldBundle Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias FieldBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias FieldBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias FieldBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias FieldBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -830,6 +1251,70 @@ contains !======================================================================
 
     !------------------------------------------------------------------------
     !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for FieldBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias FieldBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias FieldBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged FieldBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged FieldBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for FieldBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again FieldBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again FieldBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
     write(name, *) "Destroy object through NamedAlias FieldBundle Test"
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     call ESMF_FieldBundleDestroy(object2, rc=rc)
@@ -852,10 +1337,11 @@ contains !======================================================================
   !============================================================================
 
   subroutine TestFieldNamedAlias(rc)
-    integer, intent(out)        :: rc
-    type(ESMF_Field)            :: object1, object2
-    type(ESMF_Grid)             :: grid
-    type(ESMF_State)            :: state
+    integer, intent(out)  :: rc
+    type(ESMF_Field)      :: object1, object2
+    type(ESMF_Grid)       :: grid
+    type(ESMF_State)      :: state
+    integer               :: id
 
     grid = ESMF_GridCreateNoPeriDim(minIndex=(/1,1/), maxIndex=(/16,20/), rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -876,6 +1362,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias Field Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias Field Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias Field Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias Field Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias Field Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -1035,6 +1553,70 @@ contains !======================================================================
 
     !------------------------------------------------------------------------
     !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for Field Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias Field Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias Field Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged Field Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged Field Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for Field Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again Field Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again Field Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
     write(name, *) "Destroy object through NamedAlias Field Test"
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     call ESMF_FieldDestroy(object2, rc=rc)
@@ -1060,6 +1642,7 @@ contains !======================================================================
     integer, intent(out)  :: rc
     type(ESMF_ArrayBundle):: object1, object2
     type(ESMF_State)      :: state
+    integer               :: id
 
     object1 = ESMF_ArrayBundleCreate(name="Test Name 1", rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -1077,6 +1660,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias ArrayBundle Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias ArrayBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias ArrayBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias ArrayBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias ArrayBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -1173,6 +1788,70 @@ contains !======================================================================
 
     !------------------------------------------------------------------------
     !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for ArrayBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias ArrayBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias ArrayBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged ArrayBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged ArrayBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for ArrayBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again ArrayBundle Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again ArrayBundle Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
     write(name, *) "Destroy object through NamedAlias ArrayBundle Test"
     write(failMsg, *) "Did not return ESMF_SUCCESS"
     call ESMF_ArrayBundleDestroy(object2, rc=rc)
@@ -1195,10 +1874,11 @@ contains !======================================================================
   !============================================================================
 
   subroutine TestArrayNamedAlias(rc)
-    integer, intent(out)        :: rc
-    type(ESMF_Array)            :: object1, object2
-    type(ESMF_DistGrid)         :: distgrid
-    type(ESMF_State)            :: state
+    integer, intent(out)  :: rc
+    type(ESMF_Array)      :: object1, object2
+    type(ESMF_DistGrid)   :: distgrid
+    type(ESMF_State)      :: state
+    integer               :: id
 
     distgrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/16,20/), rc=rc)
     if (rc /= ESMF_SUCCESS) return
@@ -1219,6 +1899,38 @@ contains !======================================================================
     write(name, *) "NamedAlias is an Alias Array Test"
     write(failMsg, *) "Incorrect result"
     testFlag = (object1 == object2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias Array Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias Array Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias Array Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias Array Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 1)
     call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
     !------------------------------------------------------------------------
 
@@ -1375,6 +2087,70 @@ contains !======================================================================
 
     call ESMF_StateDestroy(state, rc=rc)
     if (rc /= ESMF_SUCCESS) return
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from NamedAlias for Array Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object2, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for NamedAlias from NamedAlias Array Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias Array Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 2)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias unchanged Array Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object1, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for Alias unchanged Array Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 0)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAlias() from Alias again for Array Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    object2 = ESMF_NamedAlias(object1, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "NamedAliasGet() for Alias again Array Test"
+    write(failMsg, *) "Did not return ESMF_SUCCESS"
+    call ESMF_NamedAliasGet(object2, id=id, rc=rc)
+    call ESMF_Test((rc==ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
+
+    !------------------------------------------------------------------------
+    !NEX_UTest
+    write(name, *) "ID for NamedAlias again Array Test"
+    write(failMsg, *) "Incorrect result"
+    testFlag = (id == 3)
+    call ESMF_Test(testFlag, name, failMsg, result, ESMF_SRCLINE)
+    !------------------------------------------------------------------------
 
     !------------------------------------------------------------------------
     !NEX_UTest

--- a/src/doc/ESMF_api.tex
+++ b/src/doc/ESMF_api.tex
@@ -149,22 +149,38 @@ ESMF provides the concept of a {\bf named alias}. A named alias behaves just
 like an alias in all aspects, except when it comes to setting and getting the
 {\em name} of the deep object it is associated with. While regular aliases
 all access the same name string in the actual deep object, a named alias keeps
-its private name string. This allows the same deep object to be known under a
-different name in different contexts.
+its private name string. Usage of named aliases allows the same deep object to
+be known under a different name in different contexts. To further facilitate the
+use of named aliases, each instance is identified by a unique {\em id} that can
+be queried from the alias itself.
 
 The assignment
 \begin{verbatim}
-deep2 = ESMF_NamedAlias(deep1)
+deep2 = ESMF_NamedAlias(deep1, [name])
 \end{verbatim}
-makes {\tt deep2} a {\bf named alias} of {\tt deep1}. Any {\em name} changes on
-{\tt deep2} only affect {\tt deep2}. However, the {\em name} retrieved from
-{\tt deep1}, or from any regular aliases created from {\tt deep1}, is
-unaffected.
+makes {\tt deep2} a {\bf named alias} of {\tt deep1}. By default, i.e. without
+providing the optional {\tt name} argument, {\tt deep2} starts out with the
+same name as {\tt deep1}. However, providing the {\tt name} argument, or
+subsequently changing the name on {\tt deep2}, only affects {\tt deep2}.
+The name retrieved from {\tt deep1}, or any {\em regular} alias created from it,
+remains unaffected.
 
-Notice that aliases generated from a named alias are again named aliases. This
-is true even when using the regular assignment operator with a named alias on
-the right hand side. Named aliases own their unique name string that cannot
-be accessed or altered through any other alias.
+Notice that with {\tt deep2} a named alias, the assignment
+\begin{verbatim}
+deep3 = deep2
+\end{verbatim}
+automatically makes {\tt deep3} a named alias that starts out with
+its {\em name} and {\em id} identical to that of {\tt deep2}. This is typically
+the expected behavior for simple assignments, but technically {\tt deep3} is a
+new and separate named alias! Specifically this means that name changes made on
+{\tt deep2} only affect {\tt deep2}, and name changes made on {\tt deep3} only
+affect {\tt deep3}. There is no link between the two named aliases, and the fact
+that they both report the same {\em id} is strictly speaking incorrect, yet
+convenient for most use cases. It is therefore best practice to use
+{\tt ESMF\_NamedAlias()} when a new named alias is needed and to set its
+{\em name} as part of this call. Further name changes on named aliases,
+especially after the first use of direct assignments involving it, are
+discouraged.
 
 \input{../Superstructure/NamedAlias/doc/ESMF_NamedAlias_fapi}
 


### PR DESCRIPTION
## Description
This PR implements the `ESMF_NamedAliasGet()` method that supports return of a unique `id` for incoming objects identified as a named alias.

The implementation utilizes the `/ESMF/Instance` Info namespace on the Base of any deep object created. Required modifications for the deprecated Attribute/AttPack class testing are applied.

## Issues addressed
This resolves #482.