### PR TITLE
Fix Mac OS CI OpenMPI Issue

### DIFF
--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -48,8 +48,8 @@ jobs:
             ncdf: nc-config
           }
         - {
-            desc: macos@15-gfortran@13-mpiuni-netcdf,
-            osys: macos-15,
+            desc: macos@14-gfortran@13-mpiuni-netcdf,
+            osys: macos-14,
             cors: 3,
             ropt: '',
             exhs: OFF,
@@ -61,8 +61,8 @@ jobs:
             ncdf: nc-config
           }
         - {
-            desc: macos@15-clang-gfortran@14-openmpi-netcdf,
-            osys: macos-15,
+            desc: macos@14-clang-gfortran@14-openmpi-netcdf,
+            osys: macos-14,
             cors: 3,
             ropt: '--oversubscribe',
             exhs: ON,
@@ -157,7 +157,7 @@ jobs:
       if: matrix.config.comm == 'openmpi'
       run: |
         if [[ "$CACHE_HIT" != 'true' ]]; then
-          OPENMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz"
+          OPENMPI_URL="https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.gz"
           mkdir ${{runner.temp}}/openmpi
           cd ${{runner.temp}}/openmpi
           curl -L $OPENMPI_URL | tar --strip-components=1 -xz

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -48,8 +48,8 @@ jobs:
             ncdf: nc-config
           }
         - {
-            desc: macos@14-gfortran@13-mpiuni-netcdf,
-            osys: macos-14,
+            desc: macos@15-gfortran@13-mpiuni-netcdf,
+            osys: macos-15,
             cors: 3,
             ropt: '',
             exhs: OFF,
@@ -61,8 +61,8 @@ jobs:
             ncdf: nc-config
           }
         - {
-            desc: macos@14-clang-gfortran@14-openmpi-netcdf,
-            osys: macos-14,
+            desc: macos@15-clang-gfortran@14-openmpi-netcdf,
+            osys: macos-15,
             cors: 3,
             ropt: '--oversubscribe',
             exhs: ON,


### PR DESCRIPTION
OpenMPI is failing with the following error

Upgrading to Mac OS 15 didn't fix the issue but upgrading OpenMPI to v5.0.8 did.


```
While trying to create a regular expression of the node names
used in this application, the regex parser has detected the
presence of an illegal character in the following node name:

 node:  iad20-fj917_90eafdb9-f2fb-487d-aef9-c646e68b63c1-32EA07A22EE3

Node names must be composed of a combination of ascii letters,
digits, dots, and the hyphen ('-') character. See the following
for an explanation:

 https://en.wikipedia.org/wiki/Hostname

Please correct the error and try again.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
An internal error has occurred in ORTE:

[[15085,0],0] FORCE-TERMINATE AT (null):1 - error base/plm_base_launch_support.c(555)

This is something that should be reported to the developers.
--------------------------------------------------------------------------
```