### PR TITLE
Fix issue in HConfig where checking IsDefined for a non-existent key causes problems with future checks

### DIFF
--- a/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
+++ b/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
@@ -640,10 +640,11 @@ HConfig HConfig::createAt(
 //-----------------------------------------------------------------------------
 template <typename T> inline YAML::Node HConfig::find(const T self, HConfig *key){
   if ((*key->doc)[0].IsScalar()){
+    
     // Handle scalar key as simple string direct indexing
     // If key is found by [], it'll return an invalid Node that evaluates as true, so return that.
     // Otherwise, return an undefined Node.
-    if ((YAML::Node tmp = (self)[(*key->doc)[0].as<std::string>()])) return tmp;
+    if (YAML::Node tmp = (self)[(*key->doc)[0].as<std::string>()]) return tmp;
     else return YAML::Node(YAML::NodeType::Undefined);
   }else{
     // handle complex key by iteration and comparing serialized node

--- a/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
+++ b/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
@@ -640,9 +640,9 @@ HConfig HConfig::createAt(
 //-----------------------------------------------------------------------------
 template <typename T> inline YAML::Node HConfig::find(const T self, HConfig *key){
   if ((*key->doc)[0].IsScalar()){
-    
     // Handle scalar key as simple string direct indexing
-    // If key is found by [], it'll return an invalid Node that evaluates as true, so return that.
+    // If key is found by [], it'll return an invalid Node that evaluates as true,
+    // so return that.
     // Otherwise, return an undefined Node.
     if (YAML::Node tmp = (self)[(*key->doc)[0].as<std::string>()]) return tmp;
     else return YAML::Node(YAML::NodeType::Undefined);

--- a/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
+++ b/src/Infrastructure/HConfig/src/ESMCI_HConfig.C
@@ -638,10 +638,13 @@ HConfig HConfig::createAt(
 
 
 //-----------------------------------------------------------------------------
-template <typename T> inline YAML::Node HConfig::find(T self, HConfig *key){
+template <typename T> inline YAML::Node HConfig::find(const T self, HConfig *key){
   if ((*key->doc)[0].IsScalar()){
-    // handle scalar key as simple string direct indexing
-    return (self)[(*key->doc)[0].as<std::string>()];
+    // Handle scalar key as simple string direct indexing
+    // If key is found by [], it'll return an invalid Node that evaluates as true, so return that.
+    // Otherwise, return an undefined Node.
+    if ((YAML::Node tmp = (self)[(*key->doc)[0].as<std::string>()])) return tmp;
+    else return YAML::Node(YAML::NodeType::Undefined);
   }else{
     // handle complex key by iteration and comparing serialized node
     std::stringstream ss_key;


### PR DESCRIPTION
Fix for issue [#448](https://github.com/esmf-org/esmf/issues/448). In this issue NASA discovered that doing an ESMF_HConfigIsDefined() check with a missing key seems to alter the HConfig object which causes problems for future checks. The yaml-cpp documentation isn't very clear on whether doing [] on a non-existent key modifies the object. However, experimentally it seems to be so. To fix this, I changed the input to Hconfig find() to be const, so that it can't modify it. (This also shouldn't hurt anything since find() shouldn't modify the incoming object.) Doing this now returns an invalid YAML::Node when the object isn't found. This throws an exception with certain operations, so in that case, I now return a valid, but undefined Node. This fixes the NASA issue and passes all of the tests. However, since @theurich is the original developer, he should definitely take a look. 