### PR TITLE
Fix edge case in NUOPC_CheckSetClock()

### DIFF
--- a/src/addon/NUOPC/src/NUOPC_Base.F90
+++ b/src/addon/NUOPC/src/NUOPC_Base.F90
@@ -892,7 +892,7 @@ module NUOPC_Base
 
     ! Make sure to use the correct runDuration
     runDuration = stopTime - setCurrTime  ! duration to reach setClock stopTime
-    if (runDuration == zeroDuration .or. runDuration > timeStepCheck) then
+    if (runDuration <= zeroDuration .or. runDuration > timeStepCheck) then
       ! use one timeStep on the checkClock to step forward
       runDuration = timeStepCheck
     endif


### PR DESCRIPTION
Fix an edge case in `NUOPC_CheckSetClock()` that was showing up during NRL work with NUOPC-based output component in NEPTUNE, where the clock was incorrectly updated after switching from high frequency to low frequency writes in the middle of simulation.