### PR TITLE
Output esmpy json report to named file

### DIFF
--- a/src/addon/esmpy/Makefile
+++ b/src/addon/esmpy/Makefile
@@ -18,10 +18,12 @@ clean:
 		find . -name "*__pycache__" -exec rm -rf {} \; || :
 		find . -name "*ESMF_LogFile*" -exec rm -f {} \; || :
 		find . -name "*.report.json" -exec rm -rf {} \; || :
+		find . -name "*-summary.json" -exec rm -rf {} \; || :
 		find . -name "*.test" -exec rm -rf {} \; || :
 dust:
 		find . -name "*ESMF_LogFile*" -exec rm -f {} \; || :
 		find . -name "*.report.json" -exec rm -rf {} \; || :
+		find . -name "*-summary.json" -exec rm -rf {} \; || :
 		find . -name "*.test" -exec rm -rf {} \; || :
 
 install:

--- a/src/addon/esmpy/src/esmpy/test/test_all.bash
+++ b/src/addon/esmpy/src/esmpy/test/test_all.bash
@@ -27,11 +27,14 @@ fi
 for NP in ${PE_COUNTS[@]}
 do
     REPORT="esmpy${VERSION}-petx${NP}.test"
-    COMMAND="${MPIEXEC} -np ${NP} python3 -m pytest -vs --json-report --json-report-summary > $REPORT 2>&1"
+    SUMMARY="esmpy${VERSION}-petx${NP}-summary.json"
+    COMMAND="${MPIEXEC} -np ${NP} python3 -m pytest -vs --json-report --json-report-summary"
+    COMMAND+=" --json-report-file ${SUMMARY} > $REPORT 2>&1"
+    echo "// esmpy ${VERSION} with PET count ${NP} summary" > ${SUMMARY}
     echo ${COMMAND}
     eval "${COMMAND}"
     find . -name "*.ESMF_LogFile" -exec cat {} >> ${REPORT} \;
-    cat .report.json >> ${REPORT}
+    cat ${SUMMARY} >> ${REPORT}
 done
 
 echo "Report is in ${REPORT}"


### PR DESCRIPTION
This will help preserve the json summary report from pytest, which is processed by esmf-test-scripts. The report is bootstrapped with a comment, so if it crashes then the file will still exist.

Once merged the `esmpy${VERSION}-petx${NP}-summary.json` should be added to the esmf-test-scripts artifacts and used when creating the summary.