### PR TITLE
Change NUOPC default to unmappedaction=error

### DIFF
--- a/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
+++ b/src/addon/NUOPC/doc/NUOPC_ConnectionOptions.tex
@@ -39,7 +39,7 @@ OptionName and the value strings are case insensitive. There are single and mult
      {\tt srcMaskValues} & List of integer values that defines the mask values. & multi & List of integers.\\ \hline
      {\tt srcTermProcessing} & Number of terms in each partial sum of the interpolation to process on the source side. This setting impacts the bit-for-bit reproducibility of the parallel interpolation results between runs. The strictest bit-for-bit setting is achieved by setting the value to 0 or 1. & single & integer\\ \hline
      {\tt termOrder} & Order of the terms in each partial sum of the interpolation. This setting impacts the bit-for-bit reproducibility of the parallel interpolation results between runs. The strictest bit-for-bit setting is achieved by setting the value to {\tt srcseq}. & single & {\tt free}(default), {\tt srcseq}, {\tt srcpet}\\ \hline
-     {\tt unmappedAction} & The action to take when unmapped destination elements are encountered. & single & {\tt ignore}(default), {\tt error}\\ \hline
+     {\tt unmappedAction} & The action to take when unmapped destination elements are encountered. & single & {\tt error}(default), {\tt ignore}\\ \hline
      {\tt zeroRegion} & The region of destination elements set to zero before adding the result of the sparse matrix multiplication. The available options support total, selective, or no zeroing of destination elements. & single & {\tt total}(default), {\tt select}, {\tt empty}\\ \hline
      \hline
 \end{longtable}

--- a/src/addon/NUOPC/doc/NUOPC_IPD.tex
+++ b/src/addon/NUOPC/doc/NUOPC_IPD.tex
@@ -624,7 +624,7 @@ An optional specialization method for custom finalization code and deallocations
   \item Use the {\tt CplList} attribute to construct {\tt srcFields} and {\tt dstFields} FieldBundles in the internal state that hold matched Field pairs.
   \item Set the {\tt Connected} attribute to {\tt true} in the Field metadata for each Field that is added to the {\tt srcFields} and {\tt dstFields} FieldBundles.
   \item {\it Optional specialization} to precompute a Connector operation: {\tt label\_ComputeRouteHandle}. Simple custom implementations store the precomputed communication RouteHandle in the {\tt rh} member of the internal state. More complex implementations use the {\tt state} member in the internal state to store auxiliary Fields, FieldBundles, and RouteHandles.
-  \item By default (if {\tt label\_ComputeRouteHandle} was {\em not} provided) precompute the Connector RouteHandle as a bilinear Regrid operation between {\tt srcFields} and {\tt dstFields}, with {\tt unmappedaction} set to {\tt ESMF\_UNMAPPEDACTION\_IGNORE}. The resulting RouteHandle is stored in the {\tt rh} member of the internal state.
+  \item By default (if {\tt label\_ComputeRouteHandle} was {\em not} provided) precompute the Connector RouteHandle as a bilinear Regrid operation between {\tt srcFields} and {\tt dstFields}, with {\tt unmappedaction} set to {\tt ESMF\_UNMAPPEDACTION\_ERROR}. The resulting RouteHandle is stored in the {\tt rh} member of the internal state.
   \end{itemize}  
 \end{itemize}
 

--- a/src/addon/NUOPC/src/NUOPC_Connector.F90
+++ b/src/addon/NUOPC/src/NUOPC_Connector.F90
@@ -7750,7 +7750,7 @@ call ESMF_VMLogCurrentGarbageInfo(trim(name)//": FieldBundleCplStore enter: ")
       enddo
 
       ! determine "unmappedaction"
-      unmappedaction = ESMF_UNMAPPEDACTION_IGNORE ! default
+      unmappedaction = ESMF_UNMAPPEDACTION_ERROR ! default
       do j=2, size(chopStringList)
         if (index(chopStringList(j),"unmappedaction=")==1) then
           call NUOPC_ChopString(chopStringList(j), chopChar="=", &


### PR DESCRIPTION
* Forces end-user to handle unmapped points, which fixes potential incorrect results due to zeroing unmapped cells
* Non-backwards compatible for NUOPC applications that are not handling unmapped points
* Previous behavior is replicated by adding `:unmappedaction=ignore` to NUOPC Connector options in run sequence
* Other options include adding `:extrapmethod=<extrapmethod>` or `:unmappedaction=ignore:zeroregion=select` to Connector options

### Notes
* Expected errors in NUOPC App Prototypes will need to be fixed