### PR TITLE
Maintenance work on GH workflows

### DIFF
--- a/.github/workflows/api-change.yml
+++ b/.github/workflows/api-change.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers
@@ -41,7 +41,7 @@ jobs:
         docker rm ${CID}
             
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: api-change
         path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers
@@ -63,13 +63,13 @@ jobs:
         docker stop ${CID}
         docker rm ${CID}
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: esmf-docs
         path: ${{ github.workspace }}/artifacts
     - name: Checkout esmf-org.github.io
       if: ${{github.repository_owner == 'esmf-org' && (github.event_name == 'push' || inputs.publish)}}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
           repository: esmf-org/esmf-org.github.io
           path: ${{github.workspace}}/esmf-org.github.io
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers
@@ -134,13 +134,13 @@ jobs:
         docker stop ${CID}
         docker rm ${CID}
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: esmpy-docs
         path: ${{ github.workspace }}/artifacts
     - name: Checkout esmpy_doc
       if: ${{github.repository_owner == 'esmf-org' && (github.event_name == 'push' || inputs.publish)}}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
           repository: esmf-org/esmpy_doc
           path: ${{github.workspace}}/esmpy_doc

--- a/.github/workflows/deploy-devcontainers.yml
+++ b/.github/workflows/deploy-devcontainers.yml
@@ -51,7 +51,7 @@ jobs:
       count: ${{ steps.set-matrix.outputs.count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Discover devcontainers and set matrix
         id: set-matrix
@@ -166,7 +166,7 @@ jobs:
         variant: ${{ fromJson(needs['variants-matrix'].outputs.build_matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -220,7 +220,7 @@ jobs:
           fi
 
       - name: Upload Build Cache
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: buildx-cache-${{ matrix.variant.title }}-${{ matrix.variant.cacheid }}
           path: /tmp/buildx-cache
@@ -237,7 +237,7 @@ jobs:
         variant: ${{ fromJson(needs['variants-matrix'].outputs.deploy_matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check Registries
         env:

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -203,7 +203,7 @@ jobs:
           make -j ${{matrix.config.cors}} install
         fi
     - name: Checkout ESMF
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: ESMF Configuration
       run: |
         echo "ESMF_DIR=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
@@ -255,7 +255,7 @@ jobs:
         fi
     - name: Archive Results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: logs-${{matrix.config.desc}}
         path: ${{env.ARTIFACTS}}

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -98,7 +98,7 @@ jobs:
         echo "${STACK_ROOT}/bin" >> $GITHUB_PATH
     - name: Cache Libraries
       id: cache-libraries
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{env.STACK_ROOT}}
         key: ${{matrix.config.desc}}

--- a/.github/workflows/maintain-copyrights.yml
+++ b/.github/workflows/maintain-copyrights.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -43,7 +43,7 @@ jobs:
         run: git diff --cached > ${{ runner.temp }}/copyright_update.patch
       - name: Upload Patch
         if: steps.update-copyright-dates.outputs.updated_count > 0
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: esmf_copyright_update
           path: ${{ runner.temp }}/copyright_update.patch

--- a/.github/workflows/mapl-tests.yml
+++ b/.github/workflows/mapl-tests.yml
@@ -80,7 +80,7 @@ jobs:
         pip install mepo
     - name: Cache Libraries
       id: cache-libraries
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{env.STACK_ROOT}}
         key: ${{matrix.config.desc}}

--- a/.github/workflows/mapl-tests.yml
+++ b/.github/workflows/mapl-tests.yml
@@ -222,7 +222,7 @@ jobs:
           make all install
         fi
     - name: Checkout ESMF
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: ${{env.esmf-sdir}}
     - name: ESMF Install
@@ -243,7 +243,7 @@ jobs:
         echo "ESMF_ROOT=${ESMF_INSTALL_PREFIX}" >> $GITHUB_ENV
         echo "ESMFMKFILE=${ESMF_INSTALL_PREFIX}/lib/esmf.mk" >> $GITHUB_ENV
     - name: Checkout MAPL
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{env.mapl-repo}}
         ref: ${{env.mapl-vers}}
@@ -273,7 +273,7 @@ jobs:
           > ${ARTIFACTS}/mapl-tests-essential.log 2>&1
     - name: Archive Results
       if: ${{failure() || env.enbl-artf == 'true'}}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: logs-${{matrix.config.desc}}
         path: ${{env.ARTIFACTS}}

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -14,12 +14,12 @@ on:
         type: string
         default: 'gcc@latest'
       esmf_version: 
-        description: 'ESMF version or tag like esmf@develop or esmf@=8.5.0b23'
+        description: 'ESMF version known to Spack like esmf@X.Y.Z (special case esmf@develop); or Git object like esmf@git.<hash|tag|branch>=X.Y.Z with X.Y.Z as pseudo-version for Spack rules'
         required: false
         type: string
         default: 'esmf@develop'
       nuopc_app_version:
-        description: 'NUOPC Application Prototypes version or tag like develop or v8.5.0b23'
+        description: 'NUOPC Application Prototypes version as Git hash, tag, or branch'
         required: false
         type: string
         default: 'develop'

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -88,7 +88,7 @@ jobs:
 
     # restore Intel oneAPI compiler installation from cache
     - name: Restore Intel oneAPI Compiler Installation
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: ${{ startsWith(matrix.compiler, 'oneapi') }}
       with:
         path: /opt/intel/oneapi

--- a/.github/workflows/test-build-spack.yml
+++ b/.github/workflows/test-build-spack.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
     # check out base repo
     - name: Checkout Base Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # prepare core environment
     - name: Install Core Development Tools
@@ -121,7 +121,7 @@ jobs:
 
     # checkout NUOPC app prototypes
     - name: Checkout NUOPC App Prototypes
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: esmf-org/nuopc-app-prototypes
         path: ${{ github.workspace }}/nuopc-app-prototypes
@@ -144,7 +144,7 @@ jobs:
 
    # push test results to artifacts
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Artifacts for ${{ matrix.compiler }} ${{ matrix.esmf }}
         path: ${{ github.workspace }}/nuopc-app-prototypes/Artifacts

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Checkout Dockerfiles
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
           repository: esmf-org/esmf-containers
           path: esmf-containers
@@ -32,7 +32,7 @@ jobs:
         docker rm ${CID}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: test-coverage
         path: ${{ github.workspace }}/artifacts


### PR DESCRIPTION
This PR makes the following version updates across workflows for actions:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `actions/cache` -> `v5`

In `test-build-spack.yml`, the `description` text of `esmf_version` and `nuopc_app_version` inputs was updated to reflect correct Spack 1.x syntax. Also better cover specification of Git objects (hash, tag, branch) including pseudo-version syntax for Spack rules.