### PR TITLE
Darwin/LLVM support

### DIFF
--- a/build/doc/user_arch.tex
+++ b/build/doc/user_arch.tex
@@ -28,7 +28,9 @@ Darwin  &\tt intel                &\footnotesize \tt {\bf mpiuni},mpich,mpich1,m
         &                         &\footnotesize \tt openmpi,user &  \\
 Darwin  &\tt intelclang           &\footnotesize \tt {\bf mpiuni},mpich,mpich1,mpich2,intelmpi,lam,openmpi,user &\tt 32, 64 \\
 Darwin  &\tt intelgcc             &\footnotesize \tt {\bf mpiuni},mpich,mpich1,mpich2,intelmpi,lam,openmpi,user &\tt 32, 64 \\
+Darwin  &\tt llvm                 &\footnotesize \tt {\bf mpiuni},mpich,mpich1,mpich2,mvapich,openmpi,user &\tt 32, 64 \\
 Darwin  &\tt nag                  &\footnotesize \tt {\bf mpiuni},mpich,mpich1,mpich2,mvapich,lam,openmpi,user &\tt 32, 64 \\
+Darwin  &\tt nagclang             &\footnotesize \tt {\bf mpiuni},mpich,mpich1,mpich2,mvapich,lam,openmpi,user &\tt 32, 64 \\
 Darwin  &\tt pgi                  &\footnotesize \tt {\bf mpiuni},mpich,mpich1,mpich2,mvapich,lam,openmpi,user &\tt 32, 64 \\
 Darwin  &\tt xlf                  &\footnotesize \tt mpiuni,{\bf mpi},mpich,mpich1,mpich2,lam,openmpi,user &\tt 32 \\
 Darwin  &\tt xlfgcc               &\footnotesize \tt mpiuni,{\bf mpi},mpich,mpich1,mpich2,lam,openmpi,user &\tt 32 \\

--- a/build_config/Darwin.gfortranclang.default/build_rules.mk
+++ b/build_config/Darwin.gfortranclang.default/build_rules.mk
@@ -198,15 +198,14 @@ endif
 ############################################################
 # OpenMP compiler and linker flags
 #
-ESMF_OPENMPDEFAULT=OFF
-ESMF_OPENMP_F90COMPILEOPTS += -fopenmp
-# As of 2022-12-05, Apple's clang doesn't support -fopenmp directly; instead, it requires
-# -Xpreprocessor -fopenmp. In addition, you will need to install libomp and explicitly add
-# the appropriate include and link directories and libraries to pull it in (this is not
-# done here yet).
+# Apple Clang does not support OpenMP natively.
+# It requires explicit installation of libomp and manually pointing to the
+# associated include and lib directories.
+ESMF_OPENMPDEFAULT = OFF
 ESMF_OPENMP_CXXCOMPILEOPTS += -Xpreprocessor -fopenmp
-ESMF_OPENMP_F90LINKOPTS    += -fopenmp
 ESMF_OPENMP_CXXLINKOPTS    += -Xpreprocessor -fopenmp
+ESMF_OPENMP_F90COMPILEOPTS += -fopenmp
+ESMF_OPENMP_F90LINKOPTS    += -fopenmp
 
 ############################################################
 # Explicit flags for handling specific format and cpp combos

--- a/build_config/Darwin.llvm.default/ESMC_Conf.h
+++ b/build_config/Darwin.llvm.default/ESMC_Conf.h
@@ -30,12 +30,8 @@ Licensed under the University of Illinois-NCSA License.
 #if defined (__cplusplus)
 // Typedef to match the data type of the 'hidden' string length
 // argument that Fortran uses when passing CHARACTER strings.
-#if (__GNUC__ > 7)
 #include <cstddef>
 typedef size_t ESMCI_FortranStrLenArg;
-#else
-typedef int ESMCI_FortranStrLenArg;
-#endif
 #endif
 
 #define ESMC_PRESENT(arg) ( (arg) != 0 )

--- a/build_config/Darwin.llvm.default/build_rules.mk
+++ b/build_config/Darwin.llvm.default/build_rules.mk
@@ -213,8 +213,12 @@ endif
 # OpenMP compiler and linker flags
 #
 ifeq ($(ESMF_CLANGSTR),Apple clang)
-# Apple Clang does not support OpenMP
+# Apple Clang does not support OpenMP natively.
+# It requires explicit installation of libomp and manually pointing to the
+# associated include and lib directories.
 ESMF_OPENMPDEFAULT = OFF
+ESMF_OPENMP_CXXCOMPILEOPTS += -Xpreprocessor -fopenmp
+ESMF_OPENMP_CXXLINKOPTS    += -Xpreprocessor -fopenmp
 else
 # LLVM Clang supports OpenMP version 4
 ESMF_OPENMPDEFAULT = OMP4

--- a/build_config/Darwin.llvm.default/build_rules.mk
+++ b/build_config/Darwin.llvm.default/build_rules.mk
@@ -116,11 +116,11 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 # See if this is LLVM Clang or Apple Clang
 #
 ESMF_CLANGSTR := $(findstring Apple clang, $(shell $(ESMF_CXXCOMPILER) --version))
-ifeq ($(ESMF_CLANGSTR),Apple clang)
-$(info "The detected C++ compiler is Apple Clang.")
-else
-$(info "The detected C++ compiler is LLVM Clang.")
-endif
+#ifeq ($(ESMF_CLANGSTR),Apple clang)
+#$(info "The detected C++ compiler is Apple Clang.")
+#else
+#$(info "The detected C++ compiler is LLVM Clang.")
+#endif
 
 ############################################################
 # Special debug flags

--- a/build_config/Darwin.llvm.default/build_rules.mk
+++ b/build_config/Darwin.llvm.default/build_rules.mk
@@ -256,15 +256,24 @@ ESMF_CXXRPATHPREFIX         = -Wl,-rpath,
 ESMF_CRPATHPREFIX           = -Wl,-rpath,
 
 ############################################################
-# Determine where LLVM libraries are located for Fortran
+# Determine where clang's libraries are located
+# Use when linking against libesmf with F90 linker front-end
 #
+# Note that the result of -print-file-name will be the full path to the file if it is found
+# within the compiler installation, and simply the file name verbatim if it is NOT found.
+ifneq ($(ESMF_CLANGSTR),Apple clang)
+ESMF_LIBSTDCXX := $(shell $(ESMF_CXXLINKER) $(ESMF_CXXLINKOPTS) -print-file-name=libc++.dylib)
+ifeq ($(ESMF_LIBSTDCXX),libc++.dylib)
+ESMF_LIBSTDCXX := $(shell $(ESMF_CXXLINKER) $(ESMF_CXXLINKOPTS) -print-file-name=libc++.a)
+endif
+ESMF_F90LINKLIBS += $(ESMF_LIBSTDCXX)
+ESMF_F90LINKPATHS += -L$(dir $(ESMF_LIBSTDCXX))
+ESMF_F90LINKRPATHS += $(ESMF_F90RPATHPREFIX)$(dir $(ESMF_LIBSTDCXX))
+else
 ESMF_F90LINKPATHS += $(shell $(ESMF_DIR)/scripts/libpath.flang $(ESMF_F90COMPILER) $(ESMF_F90COMPILEOPTS))
 ESMF_F90LINKRPATHS += $(patsubst -L%,$(ESMF_F90RPATHPREFIX)%,$(ESMF_F90LINKPATHS))
-
-############################################################
-# Link against libesmf.a using the F90 linker front-end
-#
 ESMF_F90LINKLIBS += -lc++
+endif
 
 ############################################################
 # Determine where LLVM libraries are located for C++

--- a/build_config/Darwin.llvm.default/build_rules.mk
+++ b/build_config/Darwin.llvm.default/build_rules.mk
@@ -113,6 +113,16 @@ ESMF_CXXCOMPILER_VERSION    = ${ESMF_CXXCOMPILER} -v --version
 ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 
 ############################################################
+# See if this is LLVM Clang or Apple Clang
+#
+ESMF_CLANGSTR := $(findstring Apple clang, $(shell $(ESMF_CXXCOMPILER) --version))
+ifeq ($(ESMF_CLANGSTR),Apple clang)
+$(info "The detected C++ compiler is Apple Clang.")
+else
+$(info "The detected C++ compiler is LLVM Clang.")
+endif
+
+############################################################
 # Special debug flags
 #
 ESMF_F90OPTFLAG_G       +=
@@ -202,20 +212,31 @@ endif
 ############################################################
 # OpenMP compiler and linker flags
 #
+ifeq ($(ESMF_CLANGSTR),Apple clang)
+# Apple Clang does not support OpenMP
+ESMF_OPENMPDEFAULT = OFF
+else
+# LLVM Clang supports OpenMP version 4
 ESMF_OPENMPDEFAULT = OMP4
-ESMF_OPENMP_F90COMPILEOPTS += -fopenmp
 ESMF_OPENMP_CXXCOMPILEOPTS += -fopenmp
-ESMF_OPENMP_F90LINKOPTS    += -fopenmp
 ESMF_OPENMP_CXXLINKOPTS    += -fopenmp
+endif
+ESMF_OPENMP_F90COMPILEOPTS += -fopenmp
+ESMF_OPENMP_F90LINKOPTS    += -fopenmp
 
 ############################################################
 # OpenACC compiler and linker flags
 #
+ifeq ($(ESMF_CLANGSTR),Apple clang)
+# Apple Clang does not support OpenACC
 ESMF_OPENACCDEFAULT = OFF
-ESMF_OPENACC_F90COMPILEOPTS += -fopenacc
+else
+# LLVM Clang supports OpenACC, use ESMF default
 ESMF_OPENACC_CXXCOMPILEOPTS += -fopenacc
-ESMF_OPENACC_F90LINKOPTS    += -fopenacc
 ESMF_OPENACC_CXXLINKOPTS    += -fopenacc
+endif
+ESMF_OPENACC_F90COMPILEOPTS += -fopenacc
+ESMF_OPENACC_F90LINKOPTS    += -fopenacc
 
 ############################################################
 # Explicit flags for handling specific format and cpp combos

--- a/scripts/libs.llvm
+++ b/scripts/libs.llvm
@@ -1,5 +1,47 @@
 #!/bin/sh
 # this script expects the LLVM flang command (or a wrapper, e.g. mpif90)
 # and returns the LLVM flang runtime libraries that need to be linked explicitly when using clang as linker
-$* -v $ESMF_DIR/scripts/hello.f90 2>&1 | grep "\-L" | awk 'BEGIN { RS=" "}; /^-l/  || /\.dylib/' | xargs
+
+# Capture the raw compiler verbose output
+raw_tokens=$($* -v $ESMF_DIR/scripts/hello.f90 2>&1 | grep "\-L")
+
+filtered_libs=""
+skip_next=0
+
+# Parse tokens, validating explicit file paths
+for token in $raw_tokens; do
+    if [ $skip_next -eq 1 ]; then
+        skip_next=0
+        continue
+    fi
+
+    case "$token" in
+        # LTO library switch will be followed by file with path, might not exist
+        -lto_library)
+            # Next token is file with path
+            next_token=$(echo "$raw_tokens" | awk -v skip=$(($(echo "$filtered_libs" | wc -w) + 1)) '{print $(skip+1)}')
+            if [ -n "$next_token" ] && [ -f "$next_token" ]; then
+                filtered_libs="$filtered_libs $token"
+            else
+                # Phantom path, e.g. Homebrew Flang. Skip this flag and its preceeding argument
+                skip_next=1
+            fi
+            ;;
+        # Standard library flags pass through cleanly
+        -l*)
+            filtered_libs="$filtered_libs $token"
+            ;;
+        # Explicit shared objects (.dylib or .so) must exist on disk
+        *.dylib|*.so)
+            if [ -f "$token" ]; then
+                filtered_libs="$filtered_libs $token"
+            fi
+            ;;
+    esac
+done
+
+# Output on single line
+echo $filtered_libs | xargs
+
+# Clean-up
 rm -rf hello.o a.out*


### PR DESCRIPTION
Improve Darwin/LLVM support by recognizing Apple Clang vs LLVM Clang, handle OpenMP, OpenACC, and linking differences.