### PR TITLE
Remove broken ESMF_YAMLCPP=OFF build option

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -1699,16 +1699,22 @@ endif
 #-------------------------------------------------------------------------------
 # yaml-cpp C++ YAML API
 #-------------------------------------------------------------------------------
-ifeq ($(ESMF_YAMLCPP),internal)
+ESMF_YAMLCPP_LC := $(shell echo "$(ESMF_YAMLCPP)" | tr '[:upper:]' '[:lower:]')
+
+ifeq ($(ESMF_YAMLCPP_LC),off)
+$(error ESMF_YAMLCPP=OFF is not longer supported. See ESMF User's Guide for valid options.)
+endif
+
 ESMF_YAMLCPP_PRESENT = TRUE
+
+ifeq ($(ESMF_YAMLCPP_LC),internal)
 ESMF_CXXCOMPILEPATHS += -I$(ESMF_DIR)/src/prologue/yaml-cpp/include
 ESMF_YAMLCPP_INCLUDE =
 ESMF_YAMLCPP_LIBPATH =
 ESMF_YAMLCPP_LIBS =
 endif
 
-ifeq ($(ESMF_YAMLCPP),standard)
-ESMF_YAMLCPP_PRESENT = TRUE
+ifeq ($(ESMF_YAMLCPP_LC),standard)
 ifneq ($(origin ESMF_YAMLCPP_LIBS), environment)
 ESMF_YAMLCPP_LIBS = -lyaml-cpp
 endif

--- a/src/doc/ESMF_install.tex
+++ b/src/doc/ESMF_install.tex
@@ -498,7 +498,7 @@ typical case where {\tt ESMF\_XERCES} is set to {\tt "standard"},
 
 \subsubsection{yaml-cpp}
 \label{sec:yaml-cpp}
-Support for I/O in YAML Ain't Markup Language
+Support for YAML Ain't Markup Language
 (\htmladdnormallink{YAML\texttrademark}{http://yaml.org})
 may be added to ESMF through the open-source
 \htmladdnormallink{yaml-cpp}{https://github.com/jbeder/yaml-cpp} library,
@@ -512,17 +512,15 @@ with yaml-cpp:
 
 \begin{description}
 
-\item[ESMF\_YAMLCPP] Possible values: {\it "internal"} (default), {\tt "OFF"},
+\item[ESMF\_YAMLCPP] Possible values: {\tt "internal"} (default),
 {\tt "standard"}, {\it <userstring>}.
 
 \begin{description}
-\item[{\it "internal"} (default)] The YAML-dependent code inside of ESMF will
+\item[{\tt "internal"} (default)] The YAML-dependent code inside of ESMF will
 be enabled.
 The yaml-cpp sources included with ESMF will be used to provide YAML support.
 The {\tt ESMF\_YAMLCPP\_INCLUDE}, {\tt ESMF\_YAMLCPP\_LIBPATH}, and
 {\tt ESMF\_YAMLCPP\_LIBS} environment variables will be ignored.
-
-\item[{\tt "OFF"}] Disables YAML-dependent code.
 
 \item[{\tt "standard"}] The YAML-dependent code inside of ESMF will
 be enabled.


### PR DESCRIPTION
Remove the ESMF_YAMLCPP=OFF build option, which was broken since HConfig was added. This resolves https://github.com/esmf-org/esmf-support/issues/511