### PR TITLE
Update Intel configurations and doc for LLVM-based compilers

### DIFF
--- a/build_config/Darwin.llvm.default/build_rules.mk
+++ b/build_config/Darwin.llvm.default/build_rules.mk
@@ -118,6 +118,22 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ESMF_F90OPTFLAG_G       +=
 
 ############################################################
+# Special sanitizer flags
+#
+# Activate to turn on UBSan:
+#ESMF_OPTFLAG_G          += -fsanitize=undefined
+#ESMF_LINKOPTFLAG_G      += -fsanitize=undefined
+# Also set environment variable UBSAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+# Activate to turn on ASan:
+#ESMF_OPTFLAG_G          += -fsanitize=address
+#ESMF_LINKOPTFLAG_G      += -fsanitize=address
+# Also set environment variable ASAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+
+############################################################
 # Fortran symbol convention
 #
 ifeq ($(ESMF_FORTRANSYMBOLS),default)

--- a/build_config/Linux.intel.default/README.md
+++ b/build_config/Linux.intel.default/README.md
@@ -1,10 +1,10 @@
-## Linux, using the commercial Intel compiler suite, including oneAPI
+## Linux, using the commercial Intel compiler suite branded as oneAPI
 
 Activated by setting: `ESMF_COMPILER=intel`
 
 Defaults to `ESMF_COMM=mpiuni`. This can be overridden by explicitly setting the
 `ESMF_COMM` environment variable.
-The common setting are:
+The common settings are:
 - mpiuni
 - intelmpi
 - mpich
@@ -12,22 +12,21 @@ The common setting are:
 - mpt
 
 ### With `ESMF_COMM=mpiuni`
-The **classic** Intel compiler front-ends are chosen by default:
-- `ESMF_F90=ifort`
-- `ESMF_CXX=icpc`
-- `ESMF_C=icc`
+The LLVM-based Intel compiler front-ends are chosen by default:
+- `ESMF_F90=ifx`
+- `ESMF_CXX=icpx`
+- `ESMF_C=icx`
 
 These defaults can be overridden by explicitly setting the appropriate
 environment variable.
 
-To choose a *combination* of **classic** Fortran and **oneAPI** C/C++ set:
-- `ESMF_CXX=icpx`
-- `ESMF_C=icx`
+To choose a *combination* of **classic** Fortran and **LLVM-based** C/C++ set:
+- `ESMF_F90=ifort`
 
-To choose **oneAPI** Fortran and C/C++ front-ends set:
-- `ESMF_F90=ifx`
-- `ESMF_CXX=icpx`
-- `ESMF_C=icx``
+To choose **classic** Fortran *and* C/C++ front-ends set:
+- `ESMF_F90=ifort`
+- `ESMF_CXX=icpc`
+- `ESMF_C=icc`
 
 ### With `ESMF_COMM=intelmpi`
 The IntelMPI compiler front-ends are chosen by default:
@@ -39,7 +38,7 @@ These defaults can be overridden by explicitly setting the appropriate
 environment variable.
 
 Notice that it depends on the specific IntelMPI installation which actual
-compilers, classic vs. oneAPI, are chosen by default under each MPI wrapper.
+compilers, classic vs. LLVM-based, are chosen by default under each MPI wrapper.
 The IntelMPI defaults can be overridden using the `I_MPI_F90`, `I_MPI_CXX`,
 and `I_MPI_CC` environment variables.
 
@@ -48,7 +47,7 @@ To choose **classic** Fortran and C/C++ set:
 - `I_MPI_CXX=<path>/icpc`
 - `I_MPI_CC=<path>/icc`
 
-To choose **oneAPI** Fortran and C/C++ set:
+To choose **LLVM-based** Fortran and C/C++ set:
 - `I_MPI_F90=<path>/ifx`
 - `I_MPI_CXX=<path>/icpx`
 - `I_MPI_CC=<path>/icx`

--- a/build_config/Linux.intel.default/build_rules.mk
+++ b/build_config/Linux.intel.default/build_rules.mk
@@ -6,9 +6,9 @@
 ############################################################
 # Default compiler setting.
 #
-ESMF_F90DEFAULT         = ifort
-ESMF_CXXDEFAULT         = icpc
-ESMF_CDEFAULT           = icc
+ESMF_F90DEFAULT         = ifx
+ESMF_CXXDEFAULT         = icpx
+ESMF_CDEFAULT           = icx
 
 ############################################################
 # Default MPI setting.

--- a/build_config/Linux.intel.default/build_rules.mk
+++ b/build_config/Linux.intel.default/build_rules.mk
@@ -153,6 +153,22 @@ ESMF_F90OPTFLAG_G       += -traceback -check arg_temp_created,bounds,format,outp
 ESMF_CXXOPTFLAG_G       += -traceback -Wcheck
 
 ############################################################
+# Special sanitizer flags
+#
+# Activate to turn on UBSan:
+#ESMF_OPTFLAG_G          += -fsanitize=undefined
+#ESMF_LINKOPTFLAG_G      += -fsanitize=undefined
+# Also set environment variable UBSAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+# Activate to turn on ASan:
+#ESMF_OPTFLAG_G          += -fsanitize=address
+#ESMF_LINKOPTFLAG_G      += -fsanitize=address
+# Also set environment variable ASAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+
+############################################################
 # Enable TR15581/F2003 Allocatable array resizing
 #
 ESMF_F90COMPILEOPTS += -assume realloc_lhs

--- a/build_config/Linux.llvm.default/build_rules.mk
+++ b/build_config/Linux.llvm.default/build_rules.mk
@@ -118,6 +118,22 @@ ESMF_CCOMPILER_VERSION      = ${ESMF_CCOMPILER} -v --version
 ESMF_F90OPTFLAG_G       +=
 
 ############################################################
+# Special sanitizer flags
+#
+# Activate to turn on UBSan:
+#ESMF_OPTFLAG_G          += -fsanitize=undefined
+#ESMF_LINKOPTFLAG_G      += -fsanitize=undefined
+# Also set environment variable UBSAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+# Activate to turn on ASan:
+#ESMF_OPTFLAG_G          += -fsanitize=address
+#ESMF_LINKOPTFLAG_G      += -fsanitize=address
+# Also set environment variable ASAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+
+############################################################
 # Fortran symbol convention
 #
 ifeq ($(ESMF_FORTRANSYMBOLS),default)

--- a/build_config/Unicos.intel.default/README.md
+++ b/build_config/Unicos.intel.default/README.md
@@ -1,11 +1,11 @@
-## Unicos, using the commercial Intel compiler suite, including oneAPI
+## Unicos, using the commercial Intel compiler suite branded as oneAPI
 
 This covers all Cray systems that utilize the Cray Programming Environment.
 
 Activated by setting: `ESMF_COMPILER=intel`
 
 Defaults to `ESMF_COMM=mpi`. This can be overridden by explicitly setting the
-`ESMF_COMM` environment variable. The common setting are:
+`ESMF_COMM` environment variable. The common settings are:
 - mpiuni
 - mpi (Cray-MPICH)
 
@@ -18,7 +18,7 @@ The Cray compiler front-ends are chosen by default:
 These defaults can be overridden by explicitly setting the appropriate
 environment variable.
 
-The typical procedure to select between the **classic** and **oneAPI** Intel
-compilers is by loading the appropriate compiler module. The details are
-system dependent. From an ESMF user perspective it essentially swithes out the
-compilers used underneath the Cray compiler wrappers.
+The typical procedure to select between the **classic** and **LLVM-based** Intel
+compilers is by loading the appropriate compiler module. The details are system
+dependent. From an ESMF user perspective, this essentially switches out the
+compilers that are used underneath the Cray compiler wrappers.

--- a/build_config/Unicos.intel.default/build_rules.mk
+++ b/build_config/Unicos.intel.default/build_rules.mk
@@ -61,6 +61,22 @@ ESMF_F90OPTFLAG_G       += -traceback -check arg_temp_created,bounds,format,outp
 ESMF_CXXOPTFLAG_G       += -traceback -Wcheck
 
 ############################################################
+# Special sanitizer flags
+#
+# Activate to turn on UBSan:
+#ESMF_OPTFLAG_G          += -fsanitize=undefined
+#ESMF_LINKOPTFLAG_G      += -fsanitize=undefined
+# Also set environment variable UBSAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+# Activate to turn on ASan:
+#ESMF_OPTFLAG_G          += -fsanitize=address
+#ESMF_LINKOPTFLAG_G      += -fsanitize=address
+# Also set environment variable ASAN_OPTIONS="help=1" to see available
+# run-time options.
+#
+
+############################################################
 # Enable TR15581/F2003 Allocatable array resizing
 #
 ESMF_F90COMPILEOPTS += -assume realloc_lhs

--- a/src/doc/ESMF_install.tex
+++ b/src/doc/ESMF_install.tex
@@ -59,36 +59,19 @@ Once downloaded, development snapshots are built in the same way as releases.
 \label{sec:systemreq}
 \input{ESMF_systemreq}
 
-\subsubsection{Intel Compiler (Classic and oneAPI)}
+\subsubsection{Intel Compiler (Classic and LLVM-based)}
 
-ESMF supports the Intel compiler suite via {\tt ESMF\_COMPILER=intel}. Starting in 2020, Intel began promoting their
-new LLVM-based C/C++ and Fortran compiler line under the oneAPI brand. As of 2023, the older compilers are still
-part of the Intel compiler suite and referred to as Intel Compiler Classic. ESMF supports both the classic and oneAPI
-compiler lines. The following paragraphs provide important details that allow users to fine-tune the interaction
-with the Intel compilers.
+ESMF supports the Intel compiler suite via {\tt ESMF\_COMPILER=intel}. Starting in 2020, Intel began promoting their new LLVM-based C/C++ and Fortran compiler line as part of the oneAPI brand. During a multi-year transition period, the oneAPI product shipped with both classic ({\tt icc}, {\tt icpc}, {\tt ifort}) {\em and} LLVM-based ({\tt icx}, {\tt icpx}, {\tt ifx}) compilers. As of version 2024.0 of oneAPI, only the LLVM-based compilers are provided by Intel. ESMF supports both Intel compiler lines. The following paragraphs provide important details that allow users to fine-tune the interaction with the Intel compiler suite.
 
-Under {\tt ESMF\_OS=Linux}, with {\tt ESMF\_COMPILER=intel} and {\tt ESMF\_COMM=mpiuni} set, the C, C++, and
-Fortran compiler front-ends default to the classic options {\tt icc}, {\tt icpc}, and {\tt ifort}, respectively. Any
-of these defaults can be overridden by explicitly setting the {\tt ESMF\_C}, {\tt ESMF\_CXX}, or {\tt ESMF\_F90}
-environment variables to the oneAPI options {\tt icx}, {\tt icpx}, and {\tt ifx}, respectively.
+Under {\tt ESMF\_OS=Linux}, with {\tt ESMF\_COMPILER=intel} and {\tt ESMF\_COMM=mpiuni} set, the C, C++, and Fortran compiler front-ends default to the LLVM-based option {\tt icx}, {\tt icpx}, and {\tt ifx}, respectively. Any of these defaults can be overridden by explicitly setting the {\tt ESMF\_C}, {\tt ESMF\_CXX}, or {\tt ESMF\_F90} environment variables, e.g. to the classic compiler options {\tt icc}, {\tt icpc}, and {\tt ifort}, respectively.
 
-Under {\tt ESMF\_OS=Linux}, with {\tt ESMF\_COMPILER=intel} and {\tt ESMF\_COMM=intelmpi} set, the C, C++, and
-Fortran compiler front-ends default to the MPI compiler wrappers {\tt mpiicc}, {\tt mpicpc}, and {\tt mpiifort},
-respectively. It depends on the IntelMPI installation details whether classic, oneAPI, or a mixture of compilers
-are used underneath the MPI wrappers. The IntelMPI defaults can be overridden by explicitly setting the
-{\tt I\_MPI\_CC}, {\tt I\_MPI\_CXX}, or {\tt I\_MPI\_F90} environment variables. This is an IntelMPI feature.
+Under {\tt ESMF\_OS=Linux}, with {\tt ESMF\_COMPILER=intel} and {\tt ESMF\_COMM=intelmpi} set, the C, C++, and Fortran compiler front-ends default to the MPI compiler wrappers {\tt mpiicc}, {\tt mpicpc}, and {\tt mpiifort}, respectively. It depends on the IntelMPI installation details whether classic, LLVM-based, or a mixture of compilers are used underneath the MPI wrappers. The IntelMPI defaults can be overridden by explicitly setting the IntelMPI-specific environment variables {\tt I\_MPI\_CC}, {\tt I\_MPI\_CXX}, or {\tt I\_MPI\_F90}. This is an IntelMPI feature.
 
-The recommendation for Cray systems that use the Cray compiler wrappers {\tt cc}, {\tt CC}, and {\tt ftn},
-respectively, is to use {\tt ESMF\_OS=Unicos}. In most cases this setting is detected automatically by the ESMF
-build system, and should {\em not} be overridden.
+The recommendation for Cray systems that utilize the Cray Programming Environment (CPE) is to use {\tt ESMF\_OS=Unicos}. In most cases this setting is detected automatically by the ESMF build system, and should {\em not} be overridden.
 
-Under {\tt ESMF\_OS=Unicos}, with {\tt ESMF\_COMPILER=intel}, the C, C++, and Fortran compiler front-ends default to
-{\tt cc}, {\tt CC}, and {\tt ftn}, respectively, regardless of the  {\tt ESMF\_COMM} setting. The appropriate
-classic, oneAPI, or mixed compiler combination is typically determined by the Intel environment module loaded.
-Common module names on Cray systems are {\tt intel-classic}, {\tt intel-oneAPI}, and {\tt intel}, respectively.
+Under {\tt ESMF\_OS=Unicos}, with {\tt ESMF\_COMPILER=intel}, the C, C++, and Fortran compiler front-ends default to {\tt cc}, {\tt CC}, and {\tt ftn}, respectively, regardless of the  {\tt ESMF\_COMM} setting. The appropriate classic, oneAPI, or mixed compiler combination is typically determined by the Intel environment module loaded. Common module names on Cray systems are {\tt intel-classic}, {\tt intel-oneAPI}, and {\tt intel}, respectively.
 
-{\bf Tip: } Use the ESMF "{\tt make info}" target to query compiler version information. This can be used to determine the
-appropriate settings, and to diagnose issues before kicking off the complete ESMF build procedure.
+{\bf Tip: } Use the ESMF "{\tt make info}" target to query detailed compiler version information. This can be used to determine the appropriate settings, and to diagnose issues before kicking off the complete ESMF build procedure.
 
 \subsubsection{MacOS Darwin}
 


### PR DESCRIPTION
This PR makes LLVM-based Intel compilers the default for Linux/mpiuni.  This is to stay current with the Intel oneAPI product line that removed the Classic Intel compilers starting with version 2024.0.  This PR also updates relevant ESMF documentation accordingly.