### PR TITLE
Move component sections in esmxRun.yaml under ESMX: Components: 

### DIFF
--- a/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
+++ b/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
@@ -8055,7 +8055,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 
 ! !INTERFACE:
 !  function ESMF_HConfigCreateAt(hconfig, keywordEnforcer, index, key, &
-!    keyString, doc, rc)
+!    keyString, keyStringList, doc, foundFlag, rc
 !
 ! !RETURN VALUE:
 !    type(ESMF_HConfig) :: ESMF_HConfigCreateAt
@@ -8066,12 +8066,15 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !    integer,            intent(in),  optional :: index
 !    type(ESMF_HConfig), intent(in),  optional :: key
 !    character(*),       intent(in),  optional :: keyString
+!    character(*),       intent(in),  optional :: keyStringList(:)
 !    integer,            intent(in),  optional :: doc
+!    logical,            intent(out), optional :: foundFlag
 !    integer,            intent(out), optional :: rc
 !
 ! !DESCRIPTION:
 !   Create a new HConfig object at the current iteration, or
-!   as specified by {\tt index}, {\tt key} or {\tt keyString}.
+!   as specified by {\tt index}, {\tt key}, {\tt keyString},
+!   or {\tt keyStringList}.
 !   The {\tt hconfig} must {\em not} be a map iterator.
 !
 !   The arguments are:
@@ -8081,14 +8084,25 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 !   \item[{[index]}]
 !     Attempt to access by index if specified.
 !     Requires {\tt hconfig} of NodeType Sequence.
-!     Muturally exclusive with {\tt key} and {\tt keyString}.
+!     Muturally exclusive with {\tt key}, {\tt keyString},
+!     and {\tt keyStringList}.
 !   \item[{[key]}]
-!     Attempt to access by key if specified. Muturally exclusive with
-!     {\tt index} and {\tt keyString},
+!     Attempt to access by key if specified.
+!     Muturally exclusive with {\tt index}, {\tt keyString},
+!     and {\tt keyStringList}.
 !   \item[{[keyString]}]
 !     Attempt to access by key string if specified.
 !     Requires {\tt hconfig} of NodeType Map.
-!     Muturally exclusive with {\tt index} and {\tt key}.
+!     Muturally exclusive with {\tt index}, {\tt key},
+!     and {\tt keyStringList}.
+!   \item[{[keyStringList]}]
+!     Attempt to access by nested key strings if specified.
+!     Requires {\tt hconfig} of NodeType Map.
+!     Muturally exclusive with {\tt index}, {\tt key},
+!     and {\tt keyString}.
+!   \item[{[foundFlag]}]
+!     Only valid for {\tt rc==ESMF\_SUCCESS}. A value of {\tt .true.} indicates
+!     that the requested item was found. Returns {\tt .false.} otherwise.
 !   \item[{[doc]}]
 !     The doc index. Defaults to the first document.
 !   \item[{[rc]}]
@@ -8104,40 +8118,54 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 #define ESMF_METHOD "ESMF_HConfigCreateAt()"
 
   function ESMF_HConfigCreateAt(hconfig, keywordEnforcer, index, key, &
-    keyString, doc, rc)
+    keyString, keyStringList, doc, foundFlag, rc) result (hconfigReturn)
 
-    type(ESMF_HConfig) :: ESMF_HConfigCreateAt
+    type(ESMF_HConfig) :: hconfigReturn
 
     type(ESMF_HConfig), intent(in)            :: hconfig
 type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer,            intent(in),  optional :: index
     type(ESMF_HConfig), intent(in),  optional :: key
     character(*),       intent(in),  optional :: keyString
+    character(*),       intent(in),  optional :: keyStringList(:)
     integer,            intent(in),  optional :: doc
+    logical,            intent(out), optional :: foundFlag
     integer,            intent(out), optional :: rc
 
     integer               :: localrc                ! local return code
-    type(ESMF_HConfig)    :: hKey
+    integer               :: presentCount, i
+    type(ESMF_HConfig)    :: hKey, hconfigNodePrev
+    logical               :: isFlag
 
     ! initialize return code; assume routine not implemented
     localrc = ESMF_RC_NOT_IMPL
     if (present(rc)) rc = ESMF_RC_NOT_IMPL
 
     ! invalidate return value
-    ESMF_HConfigCreateAt%shallowMemory = 0
+    hconfigReturn%shallowMemory = 0
 
     ! Check init status of arguments
     ESMF_INIT_CHECK_DEEP(ESMF_HConfigGetInit, hconfig, rc)
 
     ! Check mutual exclusions
-    if ((present(index) .and. (present(key) .or. present(keyString))) &
-      .or. (present(key) .and. present(keyString))) then
+    presentCount = count([present(index), present(key), present(keyString), &
+      present(keyStringList)])
+    if (presentCount > 1) then
       call ESMF_LogSetError(ESMF_RC_ARG_INCOMP, &
-        msg="The 'index', 'key', and 'keyString' arguments are mutual exclusive", &
-        ESMF_CONTEXT, rcToReturn=rc)
+        msg="The 'index', 'key', 'keyString', and 'keyStringList' arguments" //&
+        " are mutual exclusive", ESMF_CONTEXT, rcToReturn=rc)
       return
     endif
 
+    ! initialize foundFlag
+    if (present(foundFlag)) then
+      foundFlag = ESMF_HConfigIsDefined(hconfig, &
+        index=index, keyString=keyString, doc=doc, rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+    endif
+
+    ! handle different cases
     if (present(key) .or. present(keyString)) then
       if (present(keyString)) then
         hkey = ESMF_HConfigCreate(content=keyString, rc=localrc)
@@ -8148,7 +8176,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         hkey = key
       endif
       ! Call into the C++ interface, which will sort out optional arguments.
-      call c_ESMC_HConfigCreateAtKey(hconfig, ESMF_HConfigCreateAt, &
+      call c_ESMC_HConfigCreateAtKey(hconfig, hconfigReturn, &
         hkey, doc, localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
@@ -8157,16 +8185,46 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
       endif
+    else if (present(keyStringList)) then
+      ! Step through the nested keyStringList
+      hconfigReturn = ESMF_HConfigCreate(hconfig, rc=localrc)
+      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+        ESMF_CONTEXT, rcToReturn=rc)) return
+      do i=1, size(keyStringList)
+        isFlag = ESMF_HConfigIsDefined(hconfigReturn, &
+          keyString=keyStringList(i), rc=localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        if (i<size(keyStringList)) then
+          ! must be map again if not the last iteration yet
+          isFlag = ESMF_HConfigIsMap(hconfigReturn, &
+            keyString=keyStringList(i), rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+        endif
+        if (present(foundFlag)) then
+          foundFlag = isFlag
+          if (.not.foundFlag) exit  ! break out of loop
+        endif
+        hconfigNodePrev = hconfigReturn
+        hconfigReturn = ESMF_HConfigCreateAt(hconfigNodePrev, &
+          keyString=keyStringList(i),rc=localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+        call ESMF_HConfigDestroy(hconfigNodePrev, rc=localrc)
+        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+          ESMF_CONTEXT, rcToReturn=rc)) return
+      enddo
     else
       ! Call into the C++ interface, which will sort out optional arguments.
-      call c_ESMC_HConfigCreateAt(hconfig, ESMF_HConfigCreateAt, &
+      call c_ESMC_HConfigCreateAt(hconfig, hconfigReturn, &
         index, doc, localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
     endif
 
     ! Set init code
-    ESMF_INIT_SET_CREATED(ESMF_HConfigCreateAt)
+    ESMF_INIT_SET_CREATED(hconfigReturn)
 
     ! return successfully
     if (present(rc)) rc = ESMF_SUCCESS
@@ -8180,7 +8238,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
 #define ESMF_METHOD "ESMF_HConfigIterCreateAt()"
 
   function ESMF_HConfigIterCreateAt(hconfig, keywordEnforcer, index, key, &
-    keyString, doc, rc)
+    keyString, keyStringList, doc, foundFlag, rc)
 
     type(ESMF_HConfig) :: ESMF_HConfigIterCreateAt
 
@@ -8189,7 +8247,9 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer,            intent(in),  optional :: index
     type(ESMF_HConfig), intent(in),  optional :: key
     character(*),       intent(in),  optional :: keyString
+    character(*),       intent(in),  optional :: keyStringList(:)
     integer,            intent(in),  optional :: doc
+    logical,            intent(out), optional :: foundFlag
     integer,            intent(out), optional :: rc
 
     integer               :: localrc                ! local return code
@@ -8204,7 +8264,8 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       ESMF_CONTEXT, rcToReturn=rc)) return
 
     ESMF_HConfigIterCreateAt = ESMF_HConfigCreateAt(hconfigTemp, &
-      index=index, key=key, keyString=keyString, doc=doc, rc=localrc)
+      index=index, key=key, keyString=keyString, keyStringList=keyStringList, &
+      doc=doc, foundFlag=foundFlag, rc=localrc)
     if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
       ESMF_CONTEXT, rcToReturn=rc)) return
 

--- a/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
+++ b/src/Infrastructure/HConfig/interface/ESMF_HConfig.F90
@@ -8135,7 +8135,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     integer               :: localrc                ! local return code
     integer               :: presentCount, i
     type(ESMF_HConfig)    :: hKey, hconfigNodePrev
-    logical               :: isFlag
+    logical               :: isFlag, goDeep
 
     ! initialize return code; assume routine not implemented
     localrc = ESMF_RC_NOT_IMPL
@@ -8157,74 +8157,81 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
       return
     endif
 
+    goDeep = .true.
+
     ! initialize foundFlag
     if (present(foundFlag)) then
       foundFlag = ESMF_HConfigIsDefined(hconfig, &
         index=index, keyString=keyString, doc=doc, rc=localrc)
       if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
         ESMF_CONTEXT, rcToReturn=rc)) return
+      goDeep = foundFlag
     endif
 
-    ! handle different cases
-    if (present(key) .or. present(keyString)) then
-      if (present(keyString)) then
-        hkey = ESMF_HConfigCreate(content=keyString, rc=localrc)
+    if (goDeep) then
+
+      ! handle different cases
+      if (present(key) .or. present(keyString)) then
+        if (present(keyString)) then
+          hkey = ESMF_HConfigCreate(content=keyString, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+        else
+          ESMF_INIT_CHECK_DEEP(ESMF_HConfigGetInit, key, rc)
+          hkey = key
+        endif
+        ! Call into the C++ interface, which will sort out optional arguments.
+        call c_ESMC_HConfigCreateAtKey(hconfig, hconfigReturn, &
+          hkey, doc, localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-      else
-        ESMF_INIT_CHECK_DEEP(ESMF_HConfigGetInit, key, rc)
-        hkey = key
-      endif
-      ! Call into the C++ interface, which will sort out optional arguments.
-      call c_ESMC_HConfigCreateAtKey(hconfig, hconfigReturn, &
-        hkey, doc, localrc)
-      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
-        ESMF_CONTEXT, rcToReturn=rc)) return
-      if (present(keyString)) then
-        call ESMF_HConfigDestroy(hkey, rc=localrc)
-        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
-          ESMF_CONTEXT, rcToReturn=rc)) return
-      endif
-    else if (present(keyStringList)) then
-      ! Step through the nested keyStringList
-      hconfigReturn = ESMF_HConfigCreate(hconfig, rc=localrc)
-      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
-        ESMF_CONTEXT, rcToReturn=rc)) return
-      do i=1, size(keyStringList)
-        isFlag = ESMF_HConfigIsDefined(hconfigReturn, &
-          keyString=keyStringList(i), rc=localrc)
-        if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
-          ESMF_CONTEXT, rcToReturn=rc)) return
-        if (i<size(keyStringList)) then
-          ! must be map again if not the last iteration yet
-          isFlag = ESMF_HConfigIsMap(hconfigReturn, &
-            keyString=keyStringList(i), rc=localrc)
+        if (present(keyString)) then
+          call ESMF_HConfigDestroy(hkey, rc=localrc)
           if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
             ESMF_CONTEXT, rcToReturn=rc)) return
         endif
-        if (present(foundFlag)) then
-          foundFlag = isFlag
-          if (.not.foundFlag) exit  ! break out of loop
-        endif
-        hconfigNodePrev = hconfigReturn
-        hconfigReturn = ESMF_HConfigCreateAt(hconfigNodePrev, &
-          keyString=keyStringList(i),rc=localrc)
+      else if (present(keyStringList)) then
+        ! Step through the nested keyStringList
+        hconfigReturn = ESMF_HConfigCreate(hconfig, rc=localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-        call ESMF_HConfigDestroy(hconfigNodePrev, rc=localrc)
+        do i=1, size(keyStringList)
+          isFlag = ESMF_HConfigIsDefined(hconfigReturn, &
+            keyString=keyStringList(i), rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+          if (i<size(keyStringList)) then
+            ! must be map again if not the last iteration yet
+            isFlag = ESMF_HConfigIsMap(hconfigReturn, &
+              keyString=keyStringList(i), rc=localrc)
+            if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+              ESMF_CONTEXT, rcToReturn=rc)) return
+          endif
+          if (present(foundFlag)) then
+            foundFlag = isFlag
+            if (.not.foundFlag) exit  ! break out of loop
+          endif
+          hconfigNodePrev = hconfigReturn
+          hconfigReturn = ESMF_HConfigCreateAt(hconfigNodePrev, &
+            keyString=keyStringList(i),rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+          call ESMF_HConfigDestroy(hconfigNodePrev, rc=localrc)
+          if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+            ESMF_CONTEXT, rcToReturn=rc)) return
+        enddo
+      else
+        ! Call into the C++ interface, which will sort out optional arguments.
+        call c_ESMC_HConfigCreateAt(hconfig, hconfigReturn, &
+          index, doc, localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-      enddo
-    else
-      ! Call into the C++ interface, which will sort out optional arguments.
-      call c_ESMC_HConfigCreateAt(hconfig, hconfigReturn, &
-        index, doc, localrc)
-      if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
-        ESMF_CONTEXT, rcToReturn=rc)) return
-    endif
+      endif
 
-    ! Set init code
-    ESMF_INIT_SET_CREATED(hconfigReturn)
+      ! Set init code
+      ESMF_INIT_SET_CREATED(hconfigReturn)
+
+    endif
 
     ! return successfully
     if (present(rc)) rc = ESMF_SUCCESS

--- a/src/addon/ESMX/Comps/ESMX_Data/ESMX_Data.F90
+++ b/src/addon/ESMX/Comps/ESMX_Data/ESMX_Data.F90
@@ -89,6 +89,7 @@ module esmx_data
     character(80)              :: compLabel
     character(:), allocatable  :: badKey
     logical                    :: isFlag
+    character(:), allocatable  :: configKey(:)
 
     rc = ESMF_SUCCESS
 
@@ -162,9 +163,17 @@ module esmx_data
       call ESMF_GridCompGet(xdata, hconfig=hconfig, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__,    file=__FILE__)) return  ! bail out
-      hconfigNode = ESMF_HConfigCreateAt(hconfig, keyString=compLabel, rc=rc)
+      configKey = [ character(len=32) :: "ESMX", "Components", compLabel]
+      hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
+        foundFlag=isFlag, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=__FILE__)) return  ! bail out
+      if (.not.isFlag) then
+        call ESMF_LogSetError(ESMF_RC_ARG_INCOMP, &
+          msg="Must provide settings for component: "//compLabel, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)
+        return  ! bail out
+      endif
       ! component responsibility to validate ESMX handled options here, and
       ! potentially locally handled options
       isFlag = ESMF_HConfigValidateMapKeys(hconfigNode, &
@@ -743,6 +752,7 @@ module esmx_data
     logical            :: check
     type(ESMF_HConfig) :: hconfig
     type(ESMF_HConfig) :: xdatacfg
+    character(:), allocatable :: configKey(:)
 
     rc = ESMF_SUCCESS
 
@@ -761,14 +771,13 @@ module esmx_data
       call ESMF_GridCompGet(xdata, hconfig=hconfig, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=__FILE__)) return
-      isPresent = ESMF_HConfigIsDefined(hconfig, &
-        keyString=xstate%cname, rc=rc)
+      configKey = [ character(len=32) :: "ESMX", "Components", xstate%cname]
+      xdatacfg = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
+        foundFlag=isPresent, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, file=__FILE__)) return
       if (isPresent) then
-        ! access xdatacfg
-        xdatacfg = ESMF_HConfigCreateAt(hconfig, &
-          keyString=xstate%cname, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, file=__FILE__)) return
+        ! ingest xdatacfg
         call x_comp_read_output(xdatacfg, xstate, rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=__FILE__)) return
@@ -1635,6 +1644,5 @@ module esmx_data
   endfunction x_comp_hconfig_logical
 
   !-----------------------------------------------------------------------------
-
 
 endmodule esmx_data

--- a/src/addon/ESMX/Driver/ESMX_Driver.F90
+++ b/src/addon/ESMX/Driver/ESMX_Driver.F90
@@ -172,8 +172,8 @@ module ESMX_Driver
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=FILENAME)) return  ! bail out
       if (isFlag) then
-        componentList = ESMF_HConfigAsStringSeq(hconfigNode, stringLen=32, &
-          keyString="componentList", rc=rc)
+        componentList = ESMF_HConfigAsStringSeq(hconfigNode, &
+          stringLen=ESMF_MAXSTR, keyString="componentList", rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=FILENAME)) return  ! bail out
       endif
@@ -194,7 +194,8 @@ module ESMX_Driver
     do i=1, componentCount
       ! compLabel
       compLabel=trim(componentList(i))
-      configKey = [ character(len=32) :: "ESMX", "Components", compLabel]
+      configKey = [ character(len=ESMF_MAXSTR) :: "ESMX", "Components", &
+        compLabel]
 
       ! Find hconfigNode that holds component level settings
       hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &

--- a/src/addon/ESMX/Driver/ESMX_Driver.F90
+++ b/src/addon/ESMX/Driver/ESMX_Driver.F90
@@ -17,7 +17,7 @@ module ESMX_Driver
 
   private
 
-  public SetServices, SetVM, HConfigCreateFoundNode
+  public SetServices, SetVM
 
   type type_CompDef
     procedure(ESMF_I_GridCompServices), pointer, nopass :: ssPtr => null()
@@ -99,7 +99,7 @@ module ESMX_Driver
         line=__LINE__, file=FILENAME)) return  ! bail out
       ! Find hconfig node that holds driver level attributes, conditionally ingest
       configKey = ["ESMX      ", "Driver    ", "attributes"]
-      hconfigNode2 = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+      hconfigNode2 = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
         foundFlag=isFlag, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=FILENAME)) return  ! bail out
@@ -115,7 +115,7 @@ module ESMX_Driver
 
     ! Find hconfigNode that holds driver level settings according to configKey
     configKey = ["ESMX  ", "Driver"]
-    hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+    hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
       foundFlag=isFlag, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME)) return  ! bail out
@@ -194,9 +194,10 @@ module ESMX_Driver
     do i=1, componentCount
       ! compLabel
       compLabel=trim(componentList(i))
+      configKey = [ character(len=32) :: "ESMX", "Components", compLabel]
 
       ! Find hconfigNode that holds component level settings
-      hconfigNode = HConfigCreateFoundNode(hconfig, configKey=[compLabel], &
+      hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
         foundFlag=isFlag, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=FILENAME)) return  ! bail out
@@ -451,7 +452,7 @@ module ESMX_Driver
 
     ! Find hconfigNode that holds driver level settings according to configKey
     configKey = ["ESMX  ", "Driver"]
-    hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+    hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
       foundFlag=isFlag, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=FILENAME)) return  ! bail out
@@ -481,55 +482,6 @@ module ESMX_Driver
     endif
 
   end subroutine SetRunSequence
-
-  !-----------------------------------------------------------------------------
-
-  function HConfigCreateFoundNode(hconfig, configKey, foundFlag, rc)
-    type(ESMF_HConfig)    :: HConfigCreateFoundNode
-    type(ESMF_HConfig)    :: hconfig
-    character(*)          :: configKey(:)
-    logical, intent(out)  :: foundFlag
-    integer, intent(out)  :: rc
-
-    ! local variables
-    type(ESMF_HConfig)    :: hconfigNodePrev
-    integer               :: i
-    logical               :: isFlag
-
-    rc = ESMF_SUCCESS
-
-    HConfigCreateFoundNode = ESMF_HConfigCreate(hconfig, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, file=FILENAME)) return  ! bail out
-    foundFlag = .true.
-    do i=1, size(configKey)
-      isFlag = ESMF_HConfigIsDefined(HConfigCreateFoundNode, &
-        keyString=configKey(i), rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, file=FILENAME)) return  ! bail out
-      if (i<size(configKey)) then
-        ! must be map again if not the last iteration yet
-        isFlag = ESMF_HConfigIsMap(HConfigCreateFoundNode, &
-          keyString=configKey(i), rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, file=FILENAME)) return  ! bail out
-      endif
-      if (.not.isFlag) then
-        ! unsuccessful search 
-        foundFlag = .false.
-        exit  ! break out of loop
-      endif
-      hconfigNodePrev = HConfigCreateFoundNode
-      HConfigCreateFoundNode = ESMF_HConfigCreateAt(hconfigNodePrev, &
-        keyString=configKey(i),rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, file=FILENAME)) return  ! bail out
-      call ESMF_HConfigDestroy(hconfigNodePrev, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, file=FILENAME)) return  ! bail out
-    enddo
-
-  end function
 
   !-----------------------------------------------------------------------------
 

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -15,8 +15,7 @@ program ESMX_App
   use NUOPC
   use ESMX_Driver, only: &
     driverSV => SetVM, &
-    driverSS => SetServices, &
-    HConfigCreateFoundNode
+    driverSS => SetServices
 
   implicit none
 
@@ -43,7 +42,7 @@ program ESMX_App
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
   ! Find hconfigNode that holds app level settings according to configKey
-  hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
@@ -178,7 +177,7 @@ program ESMX_App
 
   ! set up petList
   configKey = ["ESMX   ", "Driver ", "petList"]
-  hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
@@ -198,7 +197,7 @@ program ESMX_App
 
   ! set up devList
   configKey = ["ESMX   ", "Driver ", "devList"]
-  hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
@@ -231,7 +230,7 @@ program ESMX_App
 
   ! Set OpenMP hints on info
   configKey = ["ESMX         ", "Driver       ", "ompNumThreads"]
-  hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
@@ -254,7 +253,7 @@ program ESMX_App
 
   ! Set stdout redirect hints on info
   configKey = ["ESMX  ", "Driver", "stdout"]
-  hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
@@ -284,7 +283,7 @@ program ESMX_App
 
   ! Set stderr redirect hints in info
   configKey = ["ESMX  ", "Driver", "stderr"]
-  hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &
@@ -332,7 +331,7 @@ program ESMX_App
 
   ! Find hconfigNode that holds driver level attributes, conditionally ingest
   configKey = ["ESMX      ", "Driver    ", "attributes"]
-  hconfigNode = HConfigCreateFoundNode(hconfig, configKey=configKey, &
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, file=FILENAME)) &

--- a/src/addon/ESMX/ESMX_App.F90
+++ b/src/addon/ESMX/ESMX_App.F90
@@ -41,6 +41,41 @@ program ESMX_App
     line=__LINE__, file=FILENAME)) &
     call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
+# if 0
+!TODO: Keeping disabled for now to simplify work that extends ESMX options.
+
+  ! Validate hconfig against ESMX controlled key vocabulary
+  hconfigNode = ESMF_HConfigCreateAt(hconfig, keyString="ESMX", &
+    foundFlag=isFlag, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, file=FILENAME)) &
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  if (.not.isFlag) then
+    call ESMF_LogSetError(ESMF_RC_ARG_INCOMP, &
+      msg="Must provide settings for: "//configKey(1)//":"//configKey(2), &
+      line=__LINE__, file=FILENAME, rcToReturn=rc)
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  endif
+  isFlag = ESMF_HConfigValidateMapKeys(hconfigNode, &
+    vocabulary=["App        ", & ! ESMX
+                "Driver     ", & ! ESMX
+                "Components "  & ! ESMX
+                ], badKey=valueString, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, file=FILENAME)) &
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  if (.not.isFlag) then
+    call ESMF_LogSetError(ESMF_RC_ARG_WRONG, &
+      msg="An invalid key was found in config under ESMX (maybe a typo?): "//valueString, &
+      line=__LINE__, file=FILENAME, rcToReturn=rc)
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  endif
+  call ESMF_HConfigDestroy(hconfigNode, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, file=FILENAME)) &
+    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+#endif
+
   ! Find hconfigNode that holds app level settings according to configKey
   hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, &
     foundFlag=isFlag, rc=rc)

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -162,7 +162,7 @@ This script installs `ESMX_EXE_NAME` into INSTALL_PREFIX/bin.
 
 Regardless which one of the three build options is chosen, the ESMX build system depends on a build file defined by the ESMX_BUILD_FILE variable. When unspecified the ESMX_BUILD_FILE defaults `esmxBuild.yaml`. This is a [YAML](https://yaml.org/) file with a very simple format. An example is given here:
 
-```
+```yaml
 application:
 
   disable_comps: ESMX_Data
@@ -285,7 +285,7 @@ At startup, the `ESMX_EXE_NAME` executable checks the first command line argumen
 An example *ESMX Run Configuration* file is given here:
 
 
-```
+```yaml
 ESMX:
 
   App:
@@ -412,25 +412,17 @@ A good starting point to explore this feature is the [ESMX_ExternalDriverAPIProt
 
 The typical situation where `ESMX_Driver` comes into play is where a user application needs to access a NUOPC based system that uses the unified ESMX driver. Assuming the user application uses CMake, integration of ESMX is straight forward. The critical piece required is to add `add_subdirectory()` in the application's `CMakeLists.txt` file to bring in the `${ESMF_ESMXDIR}/Driver` directory, and make the application dependent on target `esmx_driver`. An example for a very simple application is shown:
 
-```
+```cmake
 cmake_minimum_required(VERSION 3.22)
-
-# Where to look for the local Find<Package>.cmake files
-list(APPEND CMAKE_MODULE_PATH "${ESMF_ESMXDIR}/Driver/cmake")
-
-# Find ESMF
-find_package(ESMF 8.5.0 MODULE REQUIRED)
-
-# Set compilers consistent with ESMF
-set(CMAKE_Fortran_COMPILER        "${ESMF_F90COMPILER}")
-set(CMAKE_CXX_COMPILER            "${ESMF_CXXCOMPILER}")
-set(CMAKE_C_COMPILER              "${ESMF_CCOMPILER}")
 
 # Project
 project(ExternalDriverAPIProto
         VERSION 1.0.0
         LANGUAGES Fortran CXX C
         )
+
+# Find ESMF
+find_package(ESMF 9.0.0 REQUIRED)
 
 # Add ESMX driver
 add_subdirectory(${ESMF_ESMXDIR}/Driver ./ESMX_Driver)
@@ -439,6 +431,7 @@ add_subdirectory(${ESMF_ESMXDIR}/Driver ./ESMX_Driver)
 add_executable(externalApp externalApp.F90)
 target_include_directories(externalApp PUBLIC ${PROJECT_BINARY_DIR})
 target_link_libraries(externalApp PUBLIC esmx_driver)
+set_target_properties(externalApp PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Install executable
 install(
@@ -479,7 +472,29 @@ The ESMX layer includes a test system based on CTest. This system is still in be
 
 ## ESMX Components
 
-ESMX includes a data component, which can be used for testing NUOPC caps. This component is known as [`ESMX_Data`](Comps/ESMX_Data).
+ESMX works with standard NUOPC components. Currently, the ESMX layer itself provides a data component that can be used for diagnostics and testing of user-provided NUOPC components. This data component is known as [`ESMX_Data`](Comps/ESMX_Data).
+
+Generally, a NUOPC component executing under ESMX has access to the current *ESMX Run Configuration* via the `hconfig` object carried by the component instance.
+
+```fortran
+type(ESMF_GridComp)                 :: myComponent
+type(ESMF_HConfig)                  :: hconfig
+...
+call ESMF_GridCompGet(myComponent, hconfig=hconfig, rc=rc)
+```
+
+To access the instance-specific YAML block of the *ESMX Run Configuration*, first query the instance name, then use it to construct the nested `configKey` for lookup inside `hconfig`.
+
+```fortran
+character(ESMF_MAXSTR)              :: compLabel
+character(:),           allocatable :: configKey(:)
+type(ESMF_HConfig)                  :: hconfigNode
+...
+call ESMF_GridCompGet(model, name=compLabel, rc=rc)
+configKey = [ character(len=ESMF_MAXSTR) :: "ESMX", "Components", compLabel ]
+hconfigNode = ESMF_HConfigCreateAt(hconfig, keyStringList=configKey, rc=rc)
+
+```
 
 ## ESMX Software Dependencies
 

--- a/src/addon/ESMX/README.md
+++ b/src/addon/ESMX/README.md
@@ -183,7 +183,7 @@ tests:
     dir: path/to/test/data
 ```
 
-In this example two components are built into `ESMX_EXE_NAME` explicitly. (Read about [dynamically loading of components from shared objects at run-time](#dynamically-loading-components-from-shared-objects-at-run-time) later.) Each component is given a name, here `TaWaS` and `Lumo`, respectively. Components will be referenced by this *component-name* in the run-time configuration (`esmxRun.yaml`) discussed below.
+In this example two components are built into `ESMX_EXE_NAME` explicitly. (Read about [dynamically loading of components from shared objects at run-time](#dynamically-loading-components-from-shared-objects-at-run-time) later.) Each component is given a name, here `TaWaS` and `Lumo`, respectively. Components will be referenced by this *component-name* in the *ESMX Run Configuration* (`esmxRun.yaml`) discussed below.
 
 **CAUTION:** Component names are case-sensitive when used e.g. by default to construct library names, etc. However, they are treated case-insensitive when referenced from within the `esmxRun.yaml` file due to the case-insensitive nature of Fortran when referencing modules via the USE statement.
 
@@ -280,9 +280,9 @@ This section contains a key for for each *test-name*, specifying test specific o
 
 ### ESMX Run Configuration
 
-At startup, the `ESMX_EXE_NAME` executable checks the first command line argument for a filename. If no argument is provided then the filename defaults to `esmxRun.yaml`. This is the ESMX run-time configuration file in [YAML](https://yaml.org/) format, providing settings such as the list of components active at run-time, component attributes, the run sequence, as well as application level options.
+At startup, the `ESMX_EXE_NAME` executable checks the first command line argument for a filename. If no argument is provided then the filename defaults to `esmxRun.yaml`. This is the *ESMX Run Configuration* file in [YAML](https://yaml.org/) format, providing settings such as the list of components active at run-time, component attributes, the run sequence, as well as application level options.
 
-An example `ESMX Run Configuration` file is given here:
+An example *ESMX Run Configuration* file is given here:
 
 
 ```
@@ -309,27 +309,29 @@ ESMX:
         OCN
       @
 
-ATM:
-  model:            Tawas     # model value is case insensitive to match Fortran
-  ompNumThreads:    4
-  attributes:
-    Verbosity:      low
-  petList:          [3, [2-0]]  # petList is list of scalars and lists.
-                                # each list again can be of scalars and lists
-                                # recursively.
-  stdout:
-    filename:       atm.out
+  Components:
 
-OCN:
-  model:            lumo
-  petList:          [0-1, 3]
-  attributes:
-    Verbosity:      low
-  stdout:           {filename: lumo.out}
-  stderr:           {filename: lumo.err}
+    ATM:
+      model:            Tawas     # model value is case insensitive to match Fortran
+      ompNumThreads:    4
+      attributes:
+        Verbosity:      low
+      petList:          [3, [2-0]]  # petList is list of scalars and lists.
+                                    # each list again can be of scalars and lists
+                                    # recursively.
+      stdout:
+        filename:       atm.out
+
+    OCN:
+      model:            lumo
+      petList:          [0-1, 3]
+      attributes:
+        Verbosity:      low
+      stdout:           {filename: lumo.out}
+      stderr:           {filename: lumo.err}
 ```
 
-On the highest level, `ESMX Run Configuration` is expected to define the `ESMX` key, as well as a key for every component that is listed in the `componentList` found under the `Driver` level. The `ESMX` key is associated with a map containing the `App` and `Driver` keys. The `App` key must be present if `ESMX Run Configuration` is read by the `ESMX_EXE_NAME` executable, but is optional (and will be ignored) in case `esmfRun.yaml` is read by the `esmx_driver`.
+On the highest level, *ESMX Run Configuration* is expected to define the `ESMX` key. The `ESMX` key is associated with a map containing the `App`, `Driver`, and `Components` keys. The `App` key must be present if *ESMX Run Configuration* is read by the `ESMX_EXE_NAME` executable, but is optional (and will be ignored) in case `esmfRun.yaml` is read by the `esmx_driver`.
 
 #### ESMX/App Options
 
@@ -369,7 +371,7 @@ This section affects the driver level.
 
 | Option key            | Description / Value options                                                         | Default         |
 | --------------------- | ----------------------------------------------------------------------------------- | --------------- |
-| `componentList`       | list of component labels, each matching a top level key in this file                | *Empty*         |
+| `componentList`       | list of component labels, each matching a key under the ESMX/Components block                | *Empty*         |
 | `runSequence`         | block literal string defining the run sequence                                      | *NUOPC default* |
 | `logSystem`           | system information logging in SetModelServices(): `true` or `false`                 | `false`         |
 | `petList`             | list of PETs on which the driver executes                                           | *None*          |
@@ -379,7 +381,7 @@ This section affects the driver level.
 | `stderr`              | stderr redirection into `filename` provided as subkey                               | *None*          |
 | `attributes`          | map of key value pairs, each defining a driver attribute                            | *None*          |
 
-#### Component Label Options
+#### ESMX/Components Label Options
 
 This section affects the specific component instance.
 
@@ -396,7 +398,7 @@ This section affects the specific component instance.
 
 ### Dynamically loading components from shared objects at run-time
 
-There are two options recognized when specifying the value of the `model` field for a component in the `esmxRun.yaml` file:
+There are two options recognized when specifying the value of the `model` field for a component in the *ESMX Run Configuration* file:
 
 - First, if the value specified is recognized as a *component-name* provided by any of the components built into the `esmx_app` during build-time, as specified by `esmxBuild.yaml`, the respective component is accessed via its Fortran module.
 - Second, if the value does *not* match a build-time dependency, it is assumed to correspond to a shared object file instead. In that case the attempt is made to load the specified shared object file at run-time, and, if successful, is associated with the generic component label. The search order details of the OS dependent dynamic linker apply when looking for the specified shared object file on the system. A convenient way to target a shared object file at a specific location is to use absolute or relative paths, i.e. the value specified in the `model` field contains at least one slash ("/") character. The asterisk character ("*") is supported as a wildcard for the file name suffix of the specified shared object. This allows portability across systems that differ in shared object suffix. The implemented search order is "so", followed by "dylib", and finally "dll", where the first successfully loaded shared object file is used.
@@ -463,7 +465,7 @@ build/externalApp: externalApp.F90 esmxBuild.yaml
 
 The `esmx_driver` target defined by the `add_subdirectory(${ESMF_ESMXDIR}/Driver ./ESMX_Driver)` has a build-time dependency on the ESMX_BUILD_FILE already discussed under the [ESMX Build Configuration section](#esmx-build-configuration). The identical file can be used when working on the `ESMX_Driver` level.
 
-The run-time configuration needed by `ESMX_Driver` can either be supplied by the user application, or alternatively default to `esmxRun.yaml`. The following rules apply:
+The *ESMX Run Configuration* needed by `ESMX_Driver` can either be supplied by the user application, or alternatively default to `esmxRun.yaml`. The following rules apply:
 - `ESMX_Driver`, at the beginning of its `SetModelServices()` method checks whether the parent level has provided an `ESMF_Config` object by setting the `config` member on the `ESMX_Driver` component. If so, the provided `config` object is used. Otherwise `ESMX_Driver` itself creates `config` from file `esmxRun.yaml`.
 - For the case where the `config` object was provided by the parent layer, `ESMX_Driver` does not ingest attributes from `config`. Instead the assumption is made that the parent layer sets the desired attributes on `ESMX_Driver`.
 - For the case where the `config` object was loaded from `esmxRun.yaml` by `ESMX_Driver`, the driver ingests attributes from `config`, potentially overriding parent level settings.


### PR DESCRIPTION
This PR implements the `esmxRun.yaml` restructure proposed under #569. The PR contains a generalization of the `ESMF_HConfigCreateAt()` method to allow direct access to YAML objects inside map nests. 

Resolves #569.