### PR TITLE
Isolate YAML symbols from internal yaml-cpp and improve documentation

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -1702,12 +1702,13 @@ endif
 ESMF_YAMLCPP_LC := $(shell echo "$(ESMF_YAMLCPP)" | tr '[:upper:]' '[:lower:]')
 
 ifeq ($(ESMF_YAMLCPP_LC),off)
-$(error ESMF_YAMLCPP=OFF is not longer supported. See ESMF User's Guide for valid options.)
+$(error ESMF_YAMLCPP=OFF is no longer supported. See ESMF User's Guide for valid options.)
 endif
 
 ESMF_YAMLCPP_PRESENT = TRUE
 
 ifeq ($(ESMF_YAMLCPP_LC),internal)
+ESMF_CPPFLAGS        += -DYAML=ESMF_YAML
 ESMF_CXXCOMPILEPATHS += -I$(ESMF_DIR)/src/prologue/yaml-cpp/include
 ESMF_YAMLCPP_INCLUDE =
 ESMF_YAMLCPP_LIBPATH =
@@ -1721,7 +1722,7 @@ endif
 endif
 
 ifeq ($(ESMF_YAMLCPP_PRESENT),TRUE)
-ESMF_CPPFLAGS                += -DESMF_YAMLCPP=1 -DESMF_YAML=1
+ESMF_CPPFLAGS                += -DESMF_YAMLCPP=1
 ifdef ESMF_YAMLCPP_INCLUDE
 ESMF_CXXCOMPILEPATHSTHIRD    += -I$(ESMF_YAMLCPP_INCLUDE)
 ESMF_F90COMPILEPATHSTHIRD    += -I$(ESMF_YAMLCPP_INCLUDE)

--- a/src/doc/ESMF_install.tex
+++ b/src/doc/ESMF_install.tex
@@ -483,15 +483,20 @@ typical case where {\tt ESMF\_XERCES} is set to {\tt "standard"},
 \label{sec:yaml-cpp}
 Support for YAML Ain't Markup Language
 (\htmladdnormallink{YAML\texttrademark}{http://yaml.org})
-may be added to ESMF through the open-source
+in ESMF is provided through the open-source
 \htmladdnormallink{yaml-cpp}{https://github.com/jbeder/yaml-cpp} library,
-a YAML parser and emitter written in C++ that implements
-\htmladdnormallink{YAML Version 1.2 specifications}{http://yaml.org/spec/1.2/spec.html}.
+a YAML parser and emitter written in C++ that implements the
+\htmladdnormallink{YAML Version 1.2 specification}{http://yaml.org/spec/1.2/spec.html}.
 
-ESMF includes the option to build the yaml-cpp from sources kept inside the
-ESMF source tree, or to link against an external build of the yaml-cpp library.
-The following environment variables control the details of how ESMF interacts
-with yaml-cpp:
+ESMF provides the option to build yaml-cpp from sources included within the
+ESMF source tree or to link against an external installation of the library.
+Note that the internally bundled sources are based on yaml-cpp v0.7.0 and
+include a patch that adds support for the YAML merge key ("<<") syntax. This
+extension may not be present when using an externally provided installation of
+yaml-cpp.
+
+The following environment variables control how ESMF accesses the yaml-cpp
+library:
 
 \begin{description}
 


### PR DESCRIPTION
This PR addresses issues raised by @mathomp4 at https://github.com/JCSDA/spack-stack/issues/2027#issuecomment-5045556681

- The `YAML` symbols introduced into the ESMF library when building against the internally bundled yaml-cpp sources are now cleanly isolated under the `ESMF_YAML` namespace. This should prevent symbol conflicts for applications that link against ESMF _and_ yaml-cpp, even when that ESMF library uses the internal yaml-cpp sources.
- The [yaml-cpp section](https://earthsystemmodeling.org/docs/nightly/feature/yamlcpp-work/ESMF_usrdoc/node10.html#SECTION000104700000000000000) in the ESMF User's Guide was improved with respect to the YAML merge key ("<<") extension provided by the internally bundled yaml-cpp implementation, which would likely be missing when building against an external yaml-cpp installation.