### PR TITLE
Fix failures with AOCC compiler after Dynamic Mask merge

### DIFF
--- a/src/Infrastructure/Array/interface/ESMF_Array.F90
+++ b/src/Infrastructure/Array/interface/ESMF_Array.F90
@@ -753,7 +753,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present(dynamicMask)) then
       ! check for valid input
       ESMF_INIT_CHECK_SHALLOW_SHORT(ESMF_DynamicMaskGetInit, dynamicMask, rc)
-      if (dynamicMask%typeKey=="R8R8R8") then
+      if (dynamicMask%typeKey=="R8R8R8 ") then
         ! insert dynMaskState into RouteHandle for Fortran layer
         dynMaskStateR8R8R8%wrap => dynamicMask%dmsR8R8R8
         call c_ESMC_RouteHandleSetASR8R8R8(routehandle, dynMaskStateR8R8R8, &
@@ -804,7 +804,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
           handleAllElements, localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-      else if (dynamicMask%typeKey=="R4R8R4") then
+      else if (dynamicMask%typeKey=="R4R8R4 ") then
         ! insert dynMaskState into RouteHandle for Fortran layer
         dynMaskStateR4R8R4%wrap => dynamicMask%dmsR4R8R4
         call c_ESMC_RouteHandleSetASR4R8R4(routehandle, dynMaskStateR4R8R4, &
@@ -854,7 +854,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
           handleAllElements, localrc)
         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
           ESMF_CONTEXT, rcToReturn=rc)) return
-      else if (dynamicMask%typeKey=="R4R4R4") then
+      else if (dynamicMask%typeKey=="R4R4R4 ") then
         ! insert dynMaskState into RouteHandle for Fortran layer
         dynMaskStateR4R4R4%wrap => dynamicMask%dmsR4R4R4
         call c_ESMC_RouteHandleSetASR4R4R4(routehandle, dynMaskStateR4R4R4, &

--- a/src/Infrastructure/Field/tests/makefile
+++ b/src/Infrastructure/Field/tests/makefile
@@ -61,9 +61,9 @@ TESTS_RUN     = \
 		RUN_ESMC_FieldGridRegridParUTest \
 		RUN_ESMC_FieldGridGridRegridUTest \
 		RUN_ESMC_FieldGridGridRegridCsrvUTest \
-		RUN_ESMC_FieldSMMFromFileUTest \
 		RUN_ESMC_FieldRegridDynMaskPredefSrcUTest \
 		RUN_ESMC_FieldRegridDynMaskPredefVoteUTest \
+		RUN_ESMC_FieldSMMFromFileUTest \
 		RUN_ESMF_FieldUTest \
 		RUN_ESMF_FieldCreateGetUTest \
 		RUN_ESMF_FieldRegridUTest \
@@ -82,7 +82,6 @@ TESTS_RUN     = \
 		RUN_ESMF_FieldRedistArbUTest \
 		RUN_ESMF_FieldMeshSMMUTest \
 		RUN_ESMF_FieldHaloUTest \
-		RUN_ESMF_FieldSMMFromFileUTest \
 		RUN_ESMF_FieldRegridDynMaskPredefDstUTest \
 		RUN_ESMF_FieldRegridDynMaskPredefSrcUTest \
 		RUN_ESMF_FieldRegridDynMaskPredefVoteUTest \
@@ -100,10 +99,10 @@ TESTS_RUN_UNI = \
 		RUN_ESMC_FieldGridRegridCsrvUTestUNI \
 		RUN_ESMC_FieldGridRegridCsrv2UTestUNI \
 		RUN_ESMC_FieldGridGridRegridUTestUNI \
-		RUN_ESMC_FieldSMMFromFileUTestUNI \
 		RUN_ESMC_FieldGridGridRegridCsrvUTestUNI \
 		RUN_ESMC_FieldRegridDynMaskPredefSrcUTestUNI \
 		RUN_ESMC_FieldRegridDynMaskPredefVoteUTestUNI \
+		RUN_ESMC_FieldSMMFromFileUTestUNI \
 		RUN_ESMF_FieldStressUTestUNI \
 		RUN_ESMF_FieldRegridUTestUNI \
 		RUN_ESMF_FieldRegridCSUTestUNI \
@@ -112,7 +111,6 @@ TESTS_RUN_UNI = \
 		RUN_ESMF_FieldRedistArbUTestUNI \
 		RUN_ESMF_FieldRegridCsrvUTestUNI \
 		RUN_ESMF_FieldRegridCsrv2ndUTestUNI \
-		RUN_ESMF_FieldSMMFromFileUTestUNI \
 		RUN_ESMF_FieldRegridDynMaskPredefDstUTestUNI \
 		RUN_ESMF_FieldRegridDynMaskPredefSrcUTestUNI \
 		RUN_ESMF_FieldRegridDynMaskPredefVoteUTestUNI \

--- a/src/Infrastructure/Route/examples/ESMF_RHandleDynamicMaskingEx.F90
+++ b/src/Infrastructure/Route/examples/ESMF_RHandleDynamicMaskingEx.F90
@@ -359,7 +359,7 @@ program ESMF_RHandleDynamicMaskingEx
 
 !BOE
 ! Now that {\tt routehandle} is available, it can be used to execute the
-! regrid operation over and over during the course of the simualtion run, by
+! regrid operation over and over during the course of the simulation run, by
 ! calling the {\tt ESMF\_FieldRegrid()} method.
 !EOE
 

--- a/src/Infrastructure/Route/interface/ESMF_RHandle.F90
+++ b/src/Infrastructure/Route/interface/ESMF_RHandle.F90
@@ -1522,7 +1522,7 @@ recursive subroutine f_esmf_dynmaskcallbackr8r8r8(routehandle, count, &
     ESMF_CONTEXT, rcToReturn=rc)) return
 
   ! look at typeKey to see what needs to be done
-  if (dynamicMaskState%wrap%typeKey == "R8R8R8") then
+  if (dynamicMaskState%wrap%typeKey == "R8R8R8 ") then
     ! non-vector version
     ! prepare the dynamicMaskList
     if (vectorL==1) then
@@ -1704,7 +1704,7 @@ recursive subroutine f_esmf_dynmaskcallbackr4r8r4(routehandle, count, &
     ESMF_CONTEXT, rcToReturn=rc)) return
 
   ! look at typeKey to see what needs to be done
-  if (dynamicMaskState%wrap%typeKey == "R4R8R4") then
+  if (dynamicMaskState%wrap%typeKey == "R4R8R4 ") then
     ! non-vector version
     ! prepare the dynamicMaskList
     if (vectorL==1) then
@@ -1883,7 +1883,7 @@ recursive subroutine f_esmf_dynmaskcallbackr4r4r4(routehandle, count, &
     ESMF_CONTEXT, rcToReturn=rc)) return
 
   ! look at typeKey to see what needs to be done
-  if (dynamicMaskState%wrap%typeKey == "R4R4R4") then
+  if (dynamicMaskState%wrap%typeKey == "R4R4R4 ") then
     ! non-vector version
     ! prepare the dynamicMaskList
     if (vectorL==1) then


### PR DESCRIPTION
This PR fixes failures that have been showing up in the nightlies with the APCC compiler after #523 has been merged.