### PR TITLE
Implement compatibility check for RouteHandle when executed with DynamicMask option

### DIFF
--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -18,10 +18,10 @@ on:
         required: true
         type: boolean
         default: true
-  push:
-  pull_request:
-    branches:
-      - develop
+#  push:
+#  pull_request:
+#    branches:
+#      - develop
 
 concurrency:
   group: build-esmf-docs-${{ github.ref_name }}

--- a/.github/workflows/build-esmf-docs.yml
+++ b/.github/workflows/build-esmf-docs.yml
@@ -18,10 +18,10 @@ on:
         required: true
         type: boolean
         default: true
-#  push:
-#  pull_request:
-#    branches:
-#      - develop
+  push:
+  pull_request:
+    branches:
+      - develop
 
 concurrency:
   group: build-esmf-docs-${{ github.ref_name }}

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -22,19 +22,6 @@ jobs:
       matrix:
         config:
         - {
-            desc: ubuntu@22.04-gfortran@11-mpiuni-netcdf,
-            osys: ubuntu-22.04,
-            cors: 4,
-            ropt: '',
-            exhs: ON,
-            cmpr: gfortran,
-            cvrs: 11,
-            bopt: 'O',
-            comm: mpiuni,
-            tlib: ON,
-            ncdf: nc-config
-          }
-        - {
             desc: ubuntu@22.04-gfortran@12-mpich-netcdf,
             osys: ubuntu-22.04,
             cors: 4,
@@ -48,28 +35,15 @@ jobs:
             ncdf: nc-config
           }
         - {
-            desc: macos@14-gfortran@13-mpiuni-netcdf,
-            osys: macos-14,
-            cors: 3,
+            desc: ubuntu@22.04-gfortran@12-mpich-netcdf,
+            osys: ubuntu-22.04,
+            cors: 4,
             ropt: '',
             exhs: OFF,
             cmpr: gfortran,
-            cvrs: 13,
-            bopt: 'O',
-            comm: mpiuni,
-            tlib: OFF,
-            ncdf: nc-config
-          }
-        - {
-            desc: macos@14-clang-gfortran@14-openmpi-netcdf,
-            osys: macos-14,
-            cors: 3,
-            ropt: '--oversubscribe',
-            exhs: ON,
-            cmpr: gfortranclang,
-            cvrs: 14,
+            cvrs: 12,
             bopt: 'g',
-            comm: openmpi,
+            comm: mpich,
             tlib: ON,
             ncdf: nc-config
           }

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -22,6 +22,19 @@ jobs:
       matrix:
         config:
         - {
+            desc: ubuntu@22.04-gfortran@11-mpiuni-netcdf-O,
+            osys: ubuntu-22.04,
+            cors: 4,
+            ropt: '',
+            exhs: ON,
+            cmpr: gfortran,
+            cvrs: 11,
+            bopt: 'O',
+            comm: mpiuni,
+            tlib: ON,
+            ncdf: nc-config
+          }
+        - {
             desc: ubuntu@22.04-gfortran@12-mpich-netcdf-O,
             osys: ubuntu-22.04,
             cors: 4,
@@ -31,6 +44,32 @@ jobs:
             cvrs: 12,
             bopt: 'O',
             comm: mpich,
+            tlib: ON,
+            ncdf: nc-config
+          }
+        - {
+            desc: macos@14-gfortran@13-mpiuni-netcdf-O,
+            osys: macos-14,
+            cors: 3,
+            ropt: '',
+            exhs: OFF,
+            cmpr: gfortran,
+            cvrs: 13,
+            bopt: 'O',
+            comm: mpiuni,
+            tlib: OFF,
+            ncdf: nc-config
+          }
+        - {
+            desc: macos@14-clang-gfortran@14-openmpi-netcdf-g,
+            osys: macos-14,
+            cors: 3,
+            ropt: '--oversubscribe',
+            exhs: ON,
+            cmpr: gfortranclang,
+            cvrs: 14,
+            bopt: 'g',
+            comm: openmpi,
             tlib: ON,
             ncdf: nc-config
           }
@@ -181,13 +220,8 @@ jobs:
     - name: ESMF Build
       run: |
         make -j ${{matrix.config.cors}} > ${ARTIFACTS}/build.log 2>&1
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: always() # Or conditionally trigger on failure
-      with:
-        detached: true # Keeps the job running while opening the SSH session
     - name: ESMF All Tests
-      timeout-minutes: 30
+      timeout-minutes: 60
       run: |
         make all_tests > ${ARTIFACTS}/all_tests.log 2>&1
         { grep "SYSTEM TESTS SUMMARY" -A1 ${ARTIFACTS}/all_tests.log > ${ARTIFACTS}/summary.log || true; }
@@ -220,7 +254,7 @@ jobs:
           exit 1
         fi
     - name: Archive Results
-      if: always()
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v6
       with:
         name: logs-${{matrix.config.desc}}

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -181,6 +181,11 @@ jobs:
     - name: ESMF Build
       run: |
         make -j ${{matrix.config.cors}} > ${ARTIFACTS}/build.log 2>&1
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: always() # Or conditionally trigger on failure
+      with:
+        detached: true # Keeps the job running while opening the SSH session
     - name: ESMF All Tests
       timeout-minutes: 30
       run: |

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         config:
         - {
-            desc: ubuntu@22.04-gfortran@12-mpich-netcdf,
+            desc: ubuntu@22.04-gfortran@12-mpich-netcdf-O,
             osys: ubuntu-22.04,
             cors: 4,
             ropt: '',
@@ -35,7 +35,7 @@ jobs:
             ncdf: nc-config
           }
         - {
-            desc: ubuntu@22.04-gfortran@12-mpich-netcdf,
+            desc: ubuntu@22.04-gfortran@12-mpich-netcdf-g,
             osys: ubuntu-22.04,
             cors: 4,
             ropt: '',

--- a/.github/workflows/esmf-all-tests.yml
+++ b/.github/workflows/esmf-all-tests.yml
@@ -34,19 +34,6 @@ jobs:
             tlib: ON,
             ncdf: nc-config
           }
-        - {
-            desc: ubuntu@22.04-gfortran@12-mpich-netcdf-g,
-            osys: ubuntu-22.04,
-            cors: 4,
-            ropt: '',
-            exhs: OFF,
-            cmpr: gfortran,
-            cvrs: 12,
-            bopt: 'g',
-            comm: mpich,
-            tlib: ON,
-            ncdf: nc-config
-          }
     steps:
     - name: Set up system
       run: |
@@ -195,7 +182,7 @@ jobs:
       run: |
         make -j ${{matrix.config.cors}} > ${ARTIFACTS}/build.log 2>&1
     - name: ESMF All Tests
-      timeout-minutes: 60
+      timeout-minutes: 30
       run: |
         make all_tests > ${ARTIFACTS}/all_tests.log 2>&1
         { grep "SYSTEM TESTS SUMMARY" -A1 ${ARTIFACTS}/all_tests.log > ${ARTIFACTS}/summary.log || true; }
@@ -228,7 +215,7 @@ jobs:
           exit 1
         fi
     - name: Archive Results
-      if: ${{ failure() }}
+      if: always()
       uses: actions/upload-artifact@v6
       with:
         name: logs-${{matrix.config.desc}}

--- a/src/Infrastructure/Array/src/ESMCI_Array.C
+++ b/src/Infrastructure/Array/src/ESMCI_Array.C
@@ -11313,6 +11313,11 @@ template<typename SIT, typename DIT> int sparseMatMulStoreEncodeXXE(
     }
 #endif
 
+    // store srcTermProcessingOpt setting in routehandle for reference
+    localrc = (*routehandle)->setSrcTermProcessing(srcTermProcessingOpt);
+    if (ESMC_LogDefault.MsgFoundError(localrc, ESMCI_ERR_PASSTHRU,
+      ESMC_CONTEXT, &rc)) return rc;
+
 #ifdef ASMM_STORE_TIMING_on
   VMK::wtime(t12);   //gjt - profile
 #endif

--- a/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
+++ b/src/Infrastructure/DELayout/src/ESMCI_DELayout.C
@@ -3769,6 +3769,14 @@ int XXE::exec(
   VM::logMemInfo(std::string("XXE::exec():1.0"));
 #endif
 
+  // check for dynamicMask compatibility
+  if (rh && rh->validAsPtr() && rh->getSrcTermProcessing()!=0){
+    ESMC_LogDefault.MsgFoundError(ESMC_RC_ARG_BAD,
+      "Dynamic Masking requires RouteHandle with srcTermProcessing=0",
+      ESMC_CONTEXT, &rc);
+    return rc;
+  }
+
   // set index range
   int indexRangeStart = 0;        // default
   if (indexStart > 0) indexRangeStart = indexStart;

--- a/src/Infrastructure/Route/include/ESMCI_RHandle.h
+++ b/src/Infrastructure/Route/include/ESMCI_RHandle.h
@@ -76,6 +76,7 @@ namespace ESMCI {
     void *srcMaskValue;
     void *dstMaskValue;
     bool handleAllElements;
+    int srcTermProcessing;
    public:
     RouteHandle():ESMC_Base(-1){    // use Base constructor w/o BaseID increment
       // initialize the name for this RouteHandle object in the Base class
@@ -83,6 +84,7 @@ namespace ESMCI {
       srcMaskValue=NULL;
       dstMaskValue=NULL;
       handleAllElements=false;
+      srcTermProcessing=0;
     }
     ~RouteHandle(){destruct();}
     static RouteHandle *create(int *rc);
@@ -143,6 +145,10 @@ namespace ESMCI {
       handleAllElements = handleAllElements_;
       return ESMF_SUCCESS;
     }
+    int setSrcTermProcessing(int srcTermProcessing_){
+      srcTermProcessing = srcTermProcessing_;
+      return ESMF_SUCCESS;
+    }
     template<typename T> bool getSrcMaskValue(T* &value){
       value=(T*)srcMaskValue;
       return (srcMaskValue != NULL);
@@ -154,7 +160,10 @@ namespace ESMCI {
     bool getHandleAllElements(){
       return handleAllElements;
     }
-        
+    int getSrcTermProcessing(){
+      return srcTermProcessing;
+    }
+
     // fingerprinting of src/dst Arrays
     int fingerprint(Array *srcArrayArg, Array *dstArrayArg){
       srcArray = srcArrayArg;

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -687,7 +687,7 @@ program ESMF_RouteHandleAdvancedUTest
   !NEX_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=1"
   write(failMsg, *) "ESMF_FieldRegrid unexpected success"
-  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
+  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB1, &
     routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
@@ -714,7 +714,7 @@ program ESMF_RouteHandleAdvancedUTest
   !NEX_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=0"
   write(failMsg, *) "ESMF_FieldRegrid failed"
-  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
+  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB1, &
     routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
@@ -723,7 +723,7 @@ program ESMF_RouteHandleAdvancedUTest
   !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - ESMF_TERMORDER_FREE"
   write(failMsg, *) "ESMF_FieldRegrid unexpected success"
-  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
+  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB1, &
     routehandle=rh1, termorderflag=ESMF_TERMORDER_FREE, &
     dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -691,9 +691,9 @@ program ESMF_RouteHandleAdvancedUTest
     routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-#if 0
+
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Test RouteHandleDestroy()"
   write(failMsg, *) "RouteHandleDestroy failed"
   call ESMF_RouteHandleDestroy(rh1, noGarbage=.true., rc=rc)
@@ -701,7 +701,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Create RouteHandle for dynamic masking - srcTermProcessing=0"
   write(failMsg, *) "RouteHandleCreate failed"
   srcTermProcessing=0 ! required for dynamic masking
@@ -709,7 +709,7 @@ program ESMF_RouteHandleAdvancedUTest
     srcTermProcessing=srcTermProcessing, routehandle=rh1, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-
+#if 0
   !-----------------------------------------------------------------------------
   !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=0"

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -663,9 +663,9 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   ! DynamicMask testing
-#if 0
+
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Test ESMF_DynamicMaskSetR8R8R8()"
   write(failMsg, *) "Did not return ESMF_SUCCESS"
   call ESMF_DynamicMaskSetR8R8R8(dynamicMask, &
@@ -674,7 +674,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Create RouteHandle for dynamic masking - srcTermProcessing=1"
   write(failMsg, *) "RouteHandleCreate failed"
   srcTermProcessing=1 ! this will trigger error when trying to apply
@@ -682,7 +682,7 @@ program ESMF_RouteHandleAdvancedUTest
     srcTermProcessing=srcTermProcessing, routehandle=rh1, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-
+#if 0
   !-----------------------------------------------------------------------------
   !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=1"
@@ -728,15 +728,15 @@ program ESMF_RouteHandleAdvancedUTest
     dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-
+#endif
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Test RouteHandleDestroy()"
   write(failMsg, *) "RouteHandleDestroy failed"
   call ESMF_RouteHandleDestroy(rh1, noGarbage=.true., rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-#endif
+
   ! Clean-up
 
   call ESMF_GridCompFinalize(compA, exportState=stateAB1, userRc=urc, rc=rc)

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -233,18 +233,31 @@ end module compBmod
 
 !-------------------------------------------------------------------------------
 
-#ifndef ESMF_NO_DYNMASKOVERLOAD
-
 module dynMaskmod
   use ESMF
   implicit none
   private
+  public dynMaskR8R8R8
+#ifndef ESMF_NO_DYNMASKOVERLOAD
   public dynMaskR4R4R4
   public dynMaskR4R4R4V
   public dynMaskR4R8R4V
-  
+#endif
+
  contains
- 
+
+  subroutine dynMaskR8R8R8(dynamicMaskList, dynamicSrcMaskValue, &
+    dynamicDstMaskValue, rc)
+    type(ESMF_DynamicMaskElementR8R8R8), pointer        :: dynamicMaskList(:)
+    real(ESMF_KIND_R8),            intent(in), optional :: dynamicSrcMaskValue
+    real(ESMF_KIND_R8),            intent(in), optional :: dynamicDstMaskValue
+    integer,                       intent(out)          :: rc
+    ! dummy routine for unit test that does nothing
+    ! return successfully
+    rc = ESMF_SUCCESS
+  end subroutine
+
+#ifndef ESMF_NO_DYNMASKOVERLOAD
   subroutine dynMaskR4R4R4(dynamicMaskList, dynamicSrcMaskValue, &
     dynamicDstMaskValue, rc)
     type(ESMF_DynamicMaskElementR4R4R4), pointer        :: dynamicMaskList(:)
@@ -266,7 +279,7 @@ module dynMaskmod
     ! return successfully
     rc = ESMF_SUCCESS
   end subroutine
- 
+
   subroutine dynMaskR4R8R4V(dynamicMaskList, dynamicSrcMaskValue, &
     dynamicDstMaskValue, rc)
     type(ESMF_DynamicMaskElementR4R8R4V), pointer       :: dynamicMaskList(:)
@@ -277,10 +290,9 @@ module dynMaskmod
     ! return successfully
     rc = ESMF_SUCCESS
   end subroutine
- 
-end module dynMaskmod
-
 #endif
+
+end module dynMaskmod
 
 !------------------------------------------------------------------------------
 !------------------------------------------------------------------------------
@@ -310,9 +322,7 @@ program ESMF_RouteHandleAdvancedUTest
 
   use compAmod, only: ssA => SetServices
   use compBmod, only: ssB => SetServices
-#ifndef ESMF_NO_DYNMASKOVERLOAD  
   use dynMaskmod
-#endif
 
   implicit none
 
@@ -338,6 +348,7 @@ program ESMF_RouteHandleAdvancedUTest
   type(ESMF_RouteHandle)  :: rh1, rh2
   logical                 :: isCreated
   type(ESMF_DynamicMask)  :: dynamicMask
+  integer                 :: srcTermProcessing
 
   ! individual test failure message
   character(ESMF_MAXSTR) :: failMsg
@@ -651,6 +662,83 @@ program ESMF_RouteHandleAdvancedUTest
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
 
+  ! DynamicMask testing
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Test ESMF_DynamicMaskSetR8R8R8()"
+  write(failMsg, *) "Did not return ESMF_SUCCESS"
+  call ESMF_DynamicMaskSetR8R8R8(dynamicMask, &
+    dynamicMaskRoutine=dynMaskR8R8R8, handleAllElements=.true., rc=rc)
+  call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Create RouteHandle for dynamic masking - srcTermProcessing=1"
+  write(failMsg, *) "RouteHandleCreate failed"
+  srcTermProcessing=1 ! this will trigger error when trying to apply
+  call ESMF_FieldRegridStore(srcField=fieldA, dstField=fieldB1, &
+    srcTermProcessing=srcTermProcessing, routehandle=rh1, rc=rc)
+  call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=1"
+  write(failMsg, *) "ESMF_FieldRegrid unexpected success"
+  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
+    routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
+  call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Test RouteHandleDestroy()"
+  write(failMsg, *) "RouteHandleDestroy failed"
+  call ESMF_RouteHandleDestroy(rh1, noGarbage=.true., rc=rc)
+  call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Create RouteHandle for dynamic masking - srcTermProcessing=0"
+  write(failMsg, *) "RouteHandleCreate failed"
+  srcTermProcessing=0 ! required for dynamic masking
+  call ESMF_FieldRegridStore(srcField=fieldA, dstField=fieldB1, &
+    srcTermProcessing=srcTermProcessing, routehandle=rh1, rc=rc)
+  call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=0"
+  write(failMsg, *) "ESMF_FieldRegrid failed"
+  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
+    routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
+  call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Apply the Routehandle with dynamic masking - ESMF_TERMORDER_FREE"
+  write(failMsg, *) "ESMF_FieldRegrid unexpected success"
+  call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
+    routehandle=rh1, termorderflag=ESMF_TERMORDER_FREE, &
+    dynamicMask=dynamicMask, rc=rc)
+  call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  !-----------------------------------------------------------------------------
+  !NEX_UTest_Multi_Proc_Only
+  write(name, *) "Test RouteHandleDestroy()"
+  write(failMsg, *) "RouteHandleDestroy failed"
+  call ESMF_RouteHandleDestroy(rh1, noGarbage=.true., rc=rc)
+  call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
+  !-----------------------------------------------------------------------------
+
+  ! Clean-up
+
   call ESMF_GridCompFinalize(compA, exportState=stateAB1, userRc=urc, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, &
@@ -707,7 +795,7 @@ program ESMF_RouteHandleAdvancedUTest
 
 #ifndef ESMF_NO_DYNMASKOVERLOAD
 
- !-----------------------------------------------------------------------------
+  !-----------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
   write(name, *) "Test ESMF_DynamicMaskSetR4R4R4()"
   write(failMsg, *) "Did not return ESMF_SUCCESS"
@@ -716,7 +804,7 @@ program ESMF_RouteHandleAdvancedUTest
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
 
- !-----------------------------------------------------------------------------
+  !-----------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
   write(name, *) "Test ESMF_DynamicMaskSetR4R4R4V()"
   write(failMsg, *) "Did not return ESMF_SUCCESS"
@@ -725,7 +813,7 @@ program ESMF_RouteHandleAdvancedUTest
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
 
- !-----------------------------------------------------------------------------
+  !-----------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
   write(name, *) "Test ESMF_DynamicMaskSetR4R8R4V()"
   write(failMsg, *) "Did not return ESMF_SUCCESS"
@@ -733,7 +821,7 @@ program ESMF_RouteHandleAdvancedUTest
     dynamicMaskRoutine=dynMaskR4R8R4V, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-  
+
 #else
 
   write(name, *) "Dummy test to satisfy scripts for ESMF_NO_DYNMASKOVERLOAD"

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -663,9 +663,9 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   ! DynamicMask testing
-
+#if 0
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Test ESMF_DynamicMaskSetR8R8R8()"
   write(failMsg, *) "Did not return ESMF_SUCCESS"
   call ESMF_DynamicMaskSetR8R8R8(dynamicMask, &
@@ -674,7 +674,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Create RouteHandle for dynamic masking - srcTermProcessing=1"
   write(failMsg, *) "RouteHandleCreate failed"
   srcTermProcessing=1 ! this will trigger error when trying to apply
@@ -684,7 +684,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=1"
   write(failMsg, *) "ESMF_FieldRegrid unexpected success"
   call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
@@ -693,7 +693,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Test RouteHandleDestroy()"
   write(failMsg, *) "RouteHandleDestroy failed"
   call ESMF_RouteHandleDestroy(rh1, noGarbage=.true., rc=rc)
@@ -701,7 +701,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Create RouteHandle for dynamic masking - srcTermProcessing=0"
   write(failMsg, *) "RouteHandleCreate failed"
   srcTermProcessing=0 ! required for dynamic masking
@@ -711,7 +711,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=0"
   write(failMsg, *) "ESMF_FieldRegrid failed"
   call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
@@ -720,7 +720,7 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - ESMF_TERMORDER_FREE"
   write(failMsg, *) "ESMF_FieldRegrid unexpected success"
   call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
@@ -730,13 +730,13 @@ program ESMF_RouteHandleAdvancedUTest
   !-----------------------------------------------------------------------------
 
   !-----------------------------------------------------------------------------
-  !NEX_UTest_Multi_Proc_Only
+  !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Test RouteHandleDestroy()"
   write(failMsg, *) "RouteHandleDestroy failed"
   call ESMF_RouteHandleDestroy(rh1, noGarbage=.true., rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-
+#endif
   ! Clean-up
 
   call ESMF_GridCompFinalize(compA, exportState=stateAB1, userRc=urc, rc=rc)

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -709,16 +709,16 @@ program ESMF_RouteHandleAdvancedUTest
     srcTermProcessing=srcTermProcessing, routehandle=rh1, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-#if 0
+
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=0"
   write(failMsg, *) "ESMF_FieldRegrid failed"
   call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
     routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-
+#if 0
   !-----------------------------------------------------------------------------
   !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - ESMF_TERMORDER_FREE"

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -682,16 +682,16 @@ program ESMF_RouteHandleAdvancedUTest
     srcTermProcessing=srcTermProcessing, routehandle=rh1, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-#if 0
+
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - srcTermProcessing=1"
   write(failMsg, *) "ESMF_FieldRegrid unexpected success"
   call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB2, &
     routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-
+#if 0
   !-----------------------------------------------------------------------------
   !NEX_disabled_UTest_Multi_Proc_Only
   write(name, *) "Test RouteHandleDestroy()"

--- a/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
+++ b/src/Infrastructure/Route/tests/ESMF_RouteHandleAdvancedUTest.F90
@@ -718,9 +718,9 @@ program ESMF_RouteHandleAdvancedUTest
     routehandle=rh1, dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc == ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-#if 0
+
   !-----------------------------------------------------------------------------
-  !NEX_disabled_UTest_Multi_Proc_Only
+  !NEX_UTest_Multi_Proc_Only
   write(name, *) "Apply the Routehandle with dynamic masking - ESMF_TERMORDER_FREE"
   write(failMsg, *) "ESMF_FieldRegrid unexpected success"
   call ESMF_FieldRegrid(srcField=fieldA, dstField=fieldB1, &
@@ -728,7 +728,7 @@ program ESMF_RouteHandleAdvancedUTest
     dynamicMask=dynamicMask, rc=rc)
   call ESMF_Test((rc /= ESMF_SUCCESS), name, failMsg, result, ESMF_SRCLINE)
   !-----------------------------------------------------------------------------
-#endif
+
   !-----------------------------------------------------------------------------
   !NEX_UTest_Multi_Proc_Only
   write(name, *) "Test RouteHandleDestroy()"


### PR DESCRIPTION
This PR resolves #366. It implements a check during RouteHandle (RH) execution that will ERROR out when executing with active DynamicMask option, but RH was created with `srcTermProcessing!=0`. Add unit testing to ensure correct behavior.